### PR TITLE
[codex] Add pelican SVG runs for GPT and Gemini

### DIFF
--- a/outputs/gemini-3-1-pro/pelican-cycling.svg
+++ b/outputs/gemini-3-1-pro/pelican-cycling.svg
@@ -1,0 +1,349 @@
+<svg viewBox="0 0 1000 700" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <!-- 环境光影渐变 -->
+        <linearGradient id="skyGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#4a90e2" />
+            <stop offset="40%" stop-color="#87ceeb" />
+            <stop offset="80%" stop-color="#ffdfa0" />
+            <stop offset="100%" stop-color="#ffb347" />
+        </linearGradient>
+        
+        <radialGradient id="sunGrad" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stop-color="#ffffff" />
+            <stop offset="20%" stop-color="#ffeeaa" />
+            <stop offset="100%" stop-color="#ffb347" stop-opacity="0" />
+        </radialGradient>
+
+        <linearGradient id="seaGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#005c8a" />
+            <stop offset="40%" stop-color="#0083b0" />
+            <stop offset="100%" stop-color="#00b4db" />
+        </linearGradient>
+
+        <linearGradient id="sandGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#e6d3a8" />
+            <stop offset="100%" stop-color="#c2a77a" />
+        </linearGradient>
+
+        <!-- 自行车材质渐变 -->
+        <linearGradient id="frameGrad" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#00e5ff" />
+            <stop offset="50%" stop-color="#00b4db" />
+            <stop offset="100%" stop-color="#0083b0" />
+        </linearGradient>
+
+        <linearGradient id="chromeGrad" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#ffffff" />
+            <stop offset="50%" stop-color="#cccccc" />
+            <stop offset="100%" stop-color="#999999" />
+        </linearGradient>
+
+        <linearGradient id="tireGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#444444" />
+            <stop offset="100%" stop-color="#111111" />
+        </linearGradient>
+
+        <!-- 鹈鹕材质渐变 -->
+        <radialGradient id="bodyGrad" cx="50%" cy="50%" r="50%" fx="70%" fy="30%">
+            <stop offset="0%" stop-color="#ffffff" />
+            <stop offset="70%" stop-color="#e6ecef" />
+            <stop offset="100%" stop-color="#a0b4c0" />
+        </radialGradient>
+
+        <linearGradient id="beakTopGrad" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stop-color="#ffe066" />
+            <stop offset="60%" stop-color="#ffb300" />
+            <stop offset="100%" stop-color="#f57c00" />
+        </linearGradient>
+
+        <linearGradient id="beakPouchGrad" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#ffcc80" />
+            <stop offset="40%" stop-color="#ff8a65" />
+            <stop offset="80%" stop-color="#e64a19" />
+            <stop offset="100%" stop-color="#bf360c" />
+        </linearGradient>
+
+        <!-- 滤镜 -->
+        <filter id="blur-shadow" x="-20%" y="-20%" width="140%" height="140%">
+            <feGaussianBlur stdDeviation="8" />
+        </filter>
+        
+        <filter id="blur-cloud" x="-20%" y="-20%" width="140%" height="140%">
+            <feGaussianBlur stdDeviation="6" />
+        </filter>
+
+        <!-- 复用组件：车轮 -->
+        <g id="wheel">
+            <!-- 外胎 -->
+            <circle cx="0" cy="0" r="90" fill="none" stroke="url(#tireGrad)" stroke-width="14" />
+            <!-- 白边复古轮胎圈 -->
+            <circle cx="0" cy="0" r="82" fill="none" stroke="#f4f4f4" stroke-width="5" />
+            <!-- 金属轮毂 -->
+            <circle cx="0" cy="0" r="77" fill="none" stroke="url(#chromeGrad)" stroke-width="6" />
+            <!-- 交叉辐条 -->
+            <g stroke="#cfcfcf" stroke-width="1.5">
+                <line x1="-75" y1="0" x2="75" y2="0" />
+                <line x1="0" y1="-75" x2="0" y2="75" />
+                <line x1="-53" y1="-53" x2="53" y2="53" />
+                <line x1="-53" y1="53" x2="53" y2="-53" />
+                <line x1="-69" y1="-29" x2="69" y2="29" />
+                <line x1="-69" y1="29" x2="69" y2="-29" />
+                <line x1="-29" y1="-69" x2="29" y2="69" />
+                <line x1="-29" y1="69" x2="29" y2="-69" />
+            </g>
+            <!-- 轴心 -->
+            <circle cx="0" cy="0" r="8" fill="url(#chromeGrad)" stroke="#666" stroke-width="2"/>
+        </g>
+    </defs>
+
+    <!-- 背景：天空与太阳 -->
+    <rect x="0" y="0" width="1000" height="400" fill="url(#skyGrad)" />
+    <!-- 太阳光晕 -->
+    <circle cx="800" cy="220" r="150" fill="url(#sunGrad)" />
+    <circle cx="800" cy="220" r="40" fill="#ffffff" filter="url(#blur-cloud)" />
+
+    <!-- 远处的飞鸟 -->
+    <g fill="#ffffff" opacity="0.6">
+        <path d="M 150,150 Q 160,140 170,150 Q 180,140 190,150 Q 180,155 170,145 Q 160,155 150,150 Z" />
+        <path d="M 220,120 Q 225,115 230,120 Q 235,115 240,120 Q 235,123 230,118 Q 225,123 220,120 Z" />
+    </g>
+
+    <!-- 云彩 -->
+    <g fill="#ffffff" opacity="0.85" filter="url(#blur-cloud)">
+        <circle cx="200" cy="180" r="30" />
+        <circle cx="240" cy="160" r="45" />
+        <circle cx="290" cy="180" r="35" />
+        <rect x="190" y="170" width="110" height="40" rx="20" />
+        
+        <circle cx="850" cy="120" r="25" />
+        <circle cx="890" cy="110" r="35" />
+        <circle cx="930" cy="130" r="20" />
+    </g>
+
+    <!-- 背景：海面 -->
+    <rect x="0" y="400" width="1000" height="120" fill="url(#seaGrad)" />
+    <!-- 水波纹与太阳倒影 -->
+    <g stroke="#ffffff" stroke-width="2" fill="none" opacity="0.4" stroke-linecap="round">
+        <path d="M 150,430 Q 180,430 210,430" />
+        <path d="M 350,460 Q 380,460 410,460" />
+        <path d="M 100,480 Q 140,480 180,480" />
+        <!-- 倒影区域 -->
+        <g stroke="#ffcc80" stroke-width="3" opacity="0.8">
+            <path d="M 750,415 L 850,415" />
+            <path d="M 770,435 L 830,435" />
+            <path d="M 740,455 L 860,455" />
+            <path d="M 780,475 L 820,475" />
+            <path d="M 760,495 L 840,495" />
+        </g>
+        <path d="M 680,440 Q 700,440 720,440" />
+        <path d="M 880,460 Q 900,460 920,460" />
+    </g>
+
+    <!-- 背景：沙滩 -->
+    <path d="M 0,520 Q 250,510 500,520 T 1000,520 L 1000,700 L 0,700 Z" fill="url(#sandGrad)" />
+    <path d="M 0,560 Q 300,530 600,580 T 1000,550 L 1000,700 L 0,700 Z" fill="#b99e71" opacity="0.3" />
+
+    <!-- 投影 -->
+    <path d="M 180,630 L 700,610 L 780,630 L 250,650 Z" fill="rgba(0,0,0,0.25)" filter="url(#blur-shadow)" />
+    <ellipse cx="280" cy="625" rx="50" ry="10" fill="rgba(0,0,0,0.3)" filter="url(#blur-shadow)" />
+    <ellipse cx="720" cy="625" rx="50" ry="10" fill="rgba(0,0,0,0.3)" filter="url(#blur-shadow)" />
+
+    <!-- 左侧（背景层）踏板与鹈鹕左腿 -->
+    <g id="left-leg-and-pedal">
+        <!-- 左侧曲柄 -->
+        <line x1="500" y1="540" x2="475" y2="515" stroke="#888888" stroke-width="7" stroke-linecap="round" />
+        <!-- 左腿大腿 -->
+        <path d="M 370,330 C 380,360 400,390 420,390 C 410,360 390,340 370,330 Z" fill="#a0b4c0" />
+        <!-- 左腿小腿 -->
+        <line x1="415" y1="385" x2="475" y2="515" stroke="#cc7700" stroke-width="8" stroke-linecap="round" />
+        <!-- 左侧脚蹼 -->
+        <path d="M 475,515 L 495,515 L 505,530 L 485,525 Z" fill="#cc7700" />
+        <!-- 左踏板 -->
+        <rect x="463" y="511" width="24" height="8" rx="2" fill="#555555" />
+    </g>
+
+    <!-- 挡泥板（后层） -->
+    <path d="M 190,550 A 100 100 0 0 1 350,450" fill="none" stroke="url(#frameGrad)" stroke-width="12" stroke-linecap="round" />
+
+    <!-- 车轮 -->
+    <use href="#wheel" x="280" y="520" />
+    <use href="#wheel" x="720" y="520" />
+
+    <!-- 自行车车架 -->
+    <g id="bicycle-frame">
+        <!-- 后下叉 (Chainstay) -->
+        <line x1="280" y1="520" x2="500" y2="540" stroke="url(#frameGrad)" stroke-width="12" stroke-linecap="round" />
+        <!-- 后上叉 (Seatstay) -->
+        <line x1="280" y1="520" x2="420" y2="360" stroke="url(#frameGrad)" stroke-width="10" stroke-linecap="round" />
+        <!-- 下管 (Down tube) -->
+        <line x1="500" y1="540" x2="680" y2="400" stroke="url(#frameGrad)" stroke-width="15" stroke-linecap="round" />
+        <!-- 上管 (Top tube) -->
+        <line x1="420" y1="360" x2="660" y2="340" stroke="url(#frameGrad)" stroke-width="14" stroke-linecap="round" />
+        <!-- 立管 (Seat tube) -->
+        <line x1="500" y1="540" x2="420" y2="360" stroke="url(#frameGrad)" stroke-width="14" stroke-linecap="round" />
+        <!-- 头管 (Head tube) -->
+        <line x1="660" y1="340" x2="680" y2="400" stroke="url(#frameGrad)" stroke-width="18" stroke-linecap="round" />
+        <!-- 前叉 (Fork) -->
+        <line x1="680" y1="400" x2="720" y2="520" stroke="url(#chromeGrad)" stroke-width="12" stroke-linecap="round" />
+        <!-- 挡泥板（前层） -->
+        <path d="M 630,550 A 100 100 0 0 1 790,450" fill="none" stroke="url(#frameGrad)" stroke-width="12" stroke-linecap="round" />
+    </g>
+
+    <!-- 座管与座椅 -->
+    <line x1="420" y1="360" x2="410" y2="320" stroke="url(#chromeGrad)" stroke-width="8" />
+    <path d="M 380,320 C 370,310 440,310 450,330 L 380,330 Z" fill="#2a2a2a" />
+    <!-- 座椅弹簧细节 -->
+    <path d="M 395,330 L 390,345 M 435,330 L 430,345" stroke="#999" stroke-width="3" />
+
+    <!-- 传动系统：牙盘与链条 -->
+    <g id="drivetrain">
+        <!-- 链条 -->
+        <path d="M 280,510 L 500,518 M 280,530 L 500,562" stroke="#444444" stroke-width="4" stroke-dasharray="5 3" />
+        <circle cx="280" cy="520" r="10" fill="#999" stroke="#555" stroke-width="2" />
+        <!-- 牙盘 -->
+        <circle cx="500" cy="540" r="24" fill="none" stroke="#555" stroke-width="4" stroke-dasharray="4 2" />
+        <circle cx="500" cy="540" r="18" fill="url(#chromeGrad)" />
+        <line x1="482" y1="540" x2="518" y2="540" stroke="#777" stroke-width="4" />
+        <line x1="500" y1="522" x2="500" y2="558" stroke="#777" stroke-width="4" />
+    </g>
+
+    <!-- 右侧曲柄与踏板 (前景) -->
+    <g id="right-crank">
+        <line x1="500" y1="540" x2="525" y2="565" stroke="url(#chromeGrad)" stroke-width="7" stroke-linecap="round" />
+        <rect x="513" y="561" width="24" height="8" rx="2" fill="#222222" />
+    </g>
+
+    <!-- 鹈鹕主体 (尾巴、身体、脖子、头部) -->
+    <g id="pelican">
+        <!-- 尾羽 -->
+        <path d="M 260,330 L 150,360 L 140,340 L 240,310 Z" fill="#333333" />
+        <path d="M 250,350 L 140,380 L 130,360 L 220,330 Z" fill="#1a1a1a" />
+        
+        <!-- 身体 -->
+        <path d="M 380,360 
+                 C 280,380 200,340 180,280 
+                 C 160,220 280,200 350,230 
+                 C 410,250 460,290 450,340 
+                 C 445,355 420,360 380,360 Z" 
+              fill="url(#bodyGrad)" />
+              
+        <!-- 脖子 -->
+        <path d="M 350,240 
+                 C 340,160 430,150 460,110 
+                 C 470,90 500,80 520,90 
+                 C 530,110 500,130 480,130 
+                 C 440,160 410,210 400,260 Z" 
+              fill="url(#bodyGrad)" />
+              
+        <!-- 喉囊 (下颌) -->
+        <!-- 增加半透明度和阴影表现饱满感 -->
+        <path d="M 505,105 C 570,180 720,210 800,130 C 680,120 580,115 505,105 Z" fill="url(#beakPouchGrad)" />
+        <path d="M 505,105 C 550,150 630,170 730,125" fill="none" stroke="#d84315" stroke-width="2" opacity="0.4" />
+        
+        <!-- 上喙 (上颌) -->
+        <path d="M 515,85 Q 680,80 800,120 Q 815,125 808,135 Q 803,135 800,130 Q 680,110 505,105 Z" fill="url(#beakTopGrad)" />
+        
+        <!-- 眼睛与眼斑 -->
+        <path d="M 495,90 C 495,80 515,80 515,90 C 515,100 495,100 495,90 Z" fill="#ffe082" stroke="#ffb300" stroke-width="1.5" />
+        <circle cx="505" cy="90" r="5" fill="#111111" />
+        <circle cx="507" cy="88" r="1.5" fill="#ffffff" />
+    </g>
+
+    <!-- 配饰：车篓与捕到的鱼 -->
+    <g id="basket-and-fish">
+        <!-- 车把立管 -->
+        <line x1="660" y1="340" x2="650" y2="290" stroke="url(#chromeGrad)" stroke-width="10" />
+        
+        <!-- 车篓底色与轮廓 -->
+        <path d="M 670,290 L 730,290 L 715,360 L 665,360 Z" fill="#d4a373" stroke="#8b5a2b" stroke-width="3" stroke-linejoin="round" />
+        
+        <!-- 鱼 -->
+        <g id="fish">
+            <path d="M 685,300 L 665,320 L 685,325 Z" fill="#90a4ae" />
+            <path d="M 685,300 C 680,270 690,250 710,240 C 725,230 745,240 745,240 C 745,240 735,260 715,270 C 700,280 685,300 685,300 Z" fill="url(#chromeGrad)" stroke="#78909c" stroke-width="1" />
+            <circle cx="730" cy="245" r="2.5" fill="#111" />
+            <circle cx="731" cy="244" r="0.8" fill="#fff" />
+            <path d="M 718,245 Q 713,255 718,265" fill="none" stroke="#546e7a" stroke-width="1.5" />
+        </g>
+        
+        <!-- 车篓藤条纹理 -->
+        <line x1="675" y1="305" x2="725" y2="305" stroke="#b5835a" stroke-width="4" />
+        <line x1="673" y1="322" x2="721" y2="322" stroke="#b5835a" stroke-width="4" />
+        <line x1="670" y1="340" x2="717" y2="340" stroke="#b5835a" stroke-width="4" />
+        <line x1="685" y1="290" x2="680" y2="360" stroke="#b5835a" stroke-width="4" />
+        <line x1="700" y1="290" x2="695" y2="360" stroke="#b5835a" stroke-width="4" />
+        <line x1="715" y1="290" x2="710" y2="360" stroke="#b5835a" stroke-width="4" />
+    </g>
+
+    <!-- 车把与握把 -->
+    <path d="M 600,270 C 630,260 660,260 680,290" fill="none" stroke="url(#chromeGrad)" stroke-width="10" stroke-linecap="round" />
+    <line x1="585" y1="275" x2="615" y2="265" stroke="#8b4513" stroke-width="16" stroke-linecap="round" />
+
+    <!-- 鹈鹕生动的配饰：红底白点波浪头巾 -->
+    <g id="bandana">
+        <path d="M 400,260 C 410,275 435,275 440,250 L 445,265 C 420,285 395,280 400,260 Z" fill="#d32f2f" />
+        <!-- 飘扬的头巾尾巴 -->
+        <path d="M 408,265 Q 360,280 320,265 Q 360,295 415,275 Z" fill="#b71c1c" />
+        <path d="M 418,268 Q 370,305 340,315 Q 380,325 425,278 Z" fill="#d32f2f" />
+        <!-- 波点 -->
+        <circle cx="410" cy="263" r="2" fill="#ffffff" />
+        <circle cx="425" cy="265" r="2" fill="#ffffff" />
+        <circle cx="435" cy="255" r="2" fill="#ffffff" />
+        <circle cx="390" cy="275" r="1.5" fill="#ffffff" />
+        <circle cx="360" cy="273" r="1.5" fill="#ffffff" />
+        <circle cx="380" cy="295" r="1.5" fill="#ffffff" />
+        <circle cx="350" cy="305" r="1.5" fill="#ffffff" />
+    </g>
+
+    <!-- 鹈鹕右腿 (前景层) -->
+    <g id="right-leg">
+        <path d="M 390,340 C 410,380 440,430 470,440 C 460,400 420,360 390,340 Z" fill="url(#bodyGrad)" />
+        <line x1="465" y1="435" x2="525" y2="565" stroke="#ff9900" stroke-width="9" stroke-linecap="round" />
+        <path d="M 525,565 L 560,575 L 575,595 L 540,585 Z" fill="#ffaa00" />
+    </g>
+
+    <!-- 鹈鹕右翼 (握住车把的翅膀，最前层) -->
+    <g id="pelican-wing">
+        <!-- 基础翅膀形态 -->
+        <path d="M 350,240 C 440,250 560,260 600,270 C 590,290 500,310 400,320 C 300,330 200,320 220,290 Z" fill="url(#bodyGrad)" />
+        
+        <!-- 初级飞羽 (深色) -->
+        <path d="M 220,290 C 180,290 120,300 90,320 C 120,330 180,320 220,310 Z" fill="#222222" />
+        <path d="M 230,300 C 180,310 110,330 80,350 C 120,355 180,340 230,320 Z" fill="#3a3a3a" />
+        <path d="M 250,310 C 200,320 130,350 100,380 C 140,380 200,360 250,330 Z" fill="#4d4d4d" />
+        
+        <!-- 次级飞羽 -->
+        <path d="M 300,310 C 260,330 200,360 180,380 C 220,370 270,340 320,320 Z" fill="#888888" />
+        <path d="M 350,315 C 310,340 250,370 230,390 C 270,380 320,350 370,325 Z" fill="#aaaaaa" />
+        
+        <!-- 肩羽覆羽 (亮白) -->
+        <path d="M 400,260 C 450,270 520,270 580,280 C 560,290 480,300 400,290 C 350,280 320,270 350,260 Z" fill="#ffffff" />
+        
+        <!-- 翅膀轮廓与羽毛纹理 -->
+        <path d="M 350,240 C 440,250 560,260 600,270" fill="none" stroke="#e0e0e0" stroke-width="2" />
+        <path d="M 420,285 Q 470,285 520,290" fill="none" stroke="#cccccc" stroke-width="2" />
+        <path d="M 380,300 Q 430,300 480,305" fill="none" stroke="#bbbbbb" stroke-width="2" />
+    </g>
+
+    <!-- 动感特效：后轮扬起的沙粒与速度线 -->
+    <g id="action-effects">
+        <!-- 速度线 -->
+        <line x1="120" y1="520" x2="220" y2="520" stroke="#ffffff" stroke-width="3" opacity="0.5" stroke-dasharray="15 8" />
+        <line x1="80" y1="560" x2="200" y2="560" stroke="#b99e71" stroke-width="4" opacity="0.6" stroke-dasharray="25 15" />
+        
+        <!-- 扬起的沙子 -->
+        <g fill="#c2a77a">
+            <circle cx="180" cy="580" r="4" />
+            <circle cx="160" cy="595" r="5" />
+            <circle cx="140" cy="575" r="2.5" />
+            <circle cx="195" cy="605" r="3" />
+            <circle cx="150" cy="615" r="4.5" />
+            <circle cx="130" cy="590" r="2" />
+            <circle cx="170" cy="610" r="3.5" />
+        </g>
+    </g>
+
+    <!-- 整体氛围光 (屏幕混合叠加，增加温馨感) -->
+    <polygon points="800,220 -200,800 200,800 800,220" fill="url(#sunGrad)" opacity="0.25" style="mix-blend-mode: screen;" />
+
+</svg>

--- a/outputs/gemini-3-5-flash/pelican-cycling.svg
+++ b/outputs/gemini-3-5-flash/pelican-cycling.svg
@@ -1,0 +1,342 @@
+<svg viewBox="0 0 800 600" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <!-- 天空渐变 -->
+    <linearGradient id="skyGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#1A3060" />
+      <stop offset="40%" stop-color="#C25A7C" />
+      <stop offset="70%" stop-color="#EC7D52" />
+      <stop offset="100%" stop-color="#FCD0A1" />
+    </linearGradient>
+
+    <!-- 太阳径向渐变 -->
+    <radialGradient id="sunGrad" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#FFFDF0" stop-opacity="1" />
+      <stop offset="40%" stop-color="#FFE090" stop-opacity="0.8" />
+      <stop offset="100%" stop-color="#FCD0A1" stop-opacity="0" />
+    </radialGradient>
+
+    <!-- 海水渐变 -->
+    <linearGradient id="seaGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#22607A" />
+      <stop offset="100%" stop-color="#0F2042" />
+    </linearGradient>
+
+    <!-- 沙滩渐变 -->
+    <linearGradient id="sandGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#EED59B" />
+      <stop offset="100%" stop-color="#C5A363" />
+    </linearGradient>
+
+    <!-- 云朵渐变 -->
+    <linearGradient id="cloudGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.3" />
+      <stop offset="100%" stop-color="#FCD0A1" stop-opacity="0" />
+    </linearGradient>
+
+    <!-- 鹈鹕羽毛阴影渐变 -->
+    <linearGradient id="pelicanShadow" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#FFFFFF" />
+      <stop offset="85%" stop-color="#F1F5F9" />
+      <stop offset="100%" stop-color="#CBD5E1" />
+    </linearGradient>
+
+    <!-- 鹈鹕大嘴渐变 -->
+    <linearGradient id="beakGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#FBBF24" />
+      <stop offset="70%" stop-color="#F59E0B" />
+      <stop offset="100%" stop-color="#D97706" />
+    </linearGradient>
+
+    <!-- 鹈鹕喉囊渐变 -->
+    <linearGradient id="pouchGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#FDA4AF" />
+      <stop offset="50%" stop-color="#F87171" />
+      <stop offset="100%" stop-color="#FB923C" />
+    </linearGradient>
+
+    <!-- 自行车车轮组件 -->
+    <g id="wheel">
+      <!-- 轮胎 -->
+      <circle cx="0" cy="0" r="55" fill="none" stroke="#2D3748" stroke-width="12" />
+      <!-- 车胎内圈胎纹 -->
+      <circle cx="0" cy="0" r="49" fill="none" stroke="#1A202C" stroke-width="1.5" />
+      <!-- 轮毂 -->
+      <circle cx="0" cy="0" r="47" fill="none" stroke="#E2E8F0" stroke-width="2" />
+      <!-- 辐条 -->
+      <path d="M-47 0 L47 0 M0 -47 L0 47 M-33 -33 L33 33 M-33 33 L33 -33 M-43 -18 L43 18 M-43 18 L43 -18 M-18 -43 L18 43 M-18 43 L18 -43" stroke="#94A3B8" stroke-width="1" opacity="0.7" />
+      <!-- 轴心 -->
+      <circle cx="0" cy="0" r="9" fill="#4A5568" />
+      <circle cx="0" cy="0" r="5" fill="#718096" />
+    </g>
+  </defs>
+
+  <!-- BACKGROUND: 天空 -->
+  <rect width="800" height="420" fill="url(#skyGrad)" />
+
+  <!-- 太阳 -->
+  <circle cx="380" cy="270" r="100" fill="url(#sunGrad)" />
+
+  <!-- 背景远山/海岛 -->
+  <path d="M-50 350 Q 80 320 200 340 T 450 350 T 700 345 T 850 350 L 850 370 L -50 370 Z" fill="#4A4161" opacity="0.4" />
+
+  <!-- 远处的云 -->
+  <path d="M 120 180 Q 150 160 180 180 T 240 180 L 240 200 L 120 200 Z" fill="url(#cloudGrad)" />
+  <path d="M 550 140 Q 580 120 610 140 T 670 140 L 670 160 L 550 160 Z" fill="url(#cloudGrad)" />
+
+  <!-- 海燕/海鸥（远景） -->
+  <path d="M 150 90 Q 155 83 160 90 Q 165 83 170 90" fill="none" stroke="#475569" stroke-width="2" stroke-linecap="round" />
+  <path d="M 185 105 Q 189 100 193 105 Q 197 100 201 105" fill="none" stroke="#475569" stroke-width="1.5" stroke-linecap="round" />
+  <path d="M 480 110 Q 488 100 496 110 Q 504 100 512 110" fill="none" stroke="#475569" stroke-width="2" stroke-linecap="round" />
+
+  <!-- MIDDLEGROUND: 大海 -->
+  <path d="M -50 350 Q 200 330 450 355 T 850 350 L 850 450 L -50 450 Z" fill="url(#seaGrad)" />
+
+  <!-- 太阳在海面的金色波光 -->
+  <g opacity="0.6">
+    <ellipse cx="380" cy="360" rx="90" ry="2" fill="#FFE090" />
+    <ellipse cx="375" cy="370" rx="130" ry="3" fill="#FFE090" />
+    <ellipse cx="385" cy="385" rx="100" ry="2.5" fill="#FFE090" />
+    <ellipse cx="380" cy="400" rx="70" ry="2" fill="#FFE090" />
+    <ellipse cx="380" cy="415" rx="40" ry="1.5" fill="#FFE090" />
+  </g>
+
+  <!-- 岸边的浪花细线 -->
+  <path d="M 50 425 Q 200 410 400 425 T 750 420" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" opacity="0.5" />
+  <path d="M 100 435 Q 300 420 500 435 T 850 430" fill="none" stroke="#FFFFFF" stroke-width="1.5" stroke-linecap="round" opacity="0.4" />
+
+  <!-- FOREGROUND: 沙滩路段 -->
+  <path d="M -50 425 Q 350 400 850 440 L 850 650 L -50 650 Z" fill="url(#sandGrad)" />
+  <!-- 潮湿沙滩反光带 -->
+  <path d="M -50 425 Q 350 400 850 440 L 850 460 L -50 445 Z" fill="#E2C98F" opacity="0.6" />
+
+  <!-- 背景海滩植物（左侧） -->
+  <g fill="#2D3748" opacity="0.85">
+    <path d="M 10 440 Q 5 380 -10 350 Q 15 390 25 440" />
+    <path d="M 25 440 Q 30 360 50 330 Q 45 380 35 440" />
+    <path d="M 35 440 Q 55 370 85 350 Q 65 390 45 440" />
+  </g>
+
+  <!-- 自行车投影（使画面写实的关键细节） -->
+  <ellipse cx="280" cy="565" rx="65" ry="12" fill="#78350F" opacity="0.35" />
+  <ellipse cx="520" cy="565" rx="65" ry="12" fill="#78350F" opacity="0.35" />
+  <ellipse cx="400" cy="565" rx="80" ry="15" fill="#78350F" opacity="0.25" />
+
+  <!-- 自行车组件：后半部分 (置于躯干后方) -->
+  <!-- 后轮 -->
+  <use href="#wheel" x="280" y="510" />
+  <!-- 后挡泥板（复古奶油黄） -->
+  <path d="M 215 510 A 65 65 0 0 1 338 468" fill="none" stroke="#FEF08A" stroke-width="8" stroke-linecap="round" />
+  <path d="M 215 510 A 65 65 0 0 1 338 468" fill="none" stroke="#E2E8F0" stroke-width="2" stroke-linecap="round" opacity="0.5" />
+  <!-- 后泥板支架 -->
+  <line x1="280" y1="510" x2="225" y2="490" stroke="#94A3B8" stroke-width="2" />
+  <line x1="280" y1="510" x2="255" y2="460" stroke="#94A3B8" stroke-width="2" />
+
+  <!-- 自行车传动系统 -->
+  <!-- 链条暗部与亮部 -->
+  <path d="M 380 495 L 280 502 M 380 525 L 280 518" fill="none" stroke="#334155" stroke-width="3" />
+  <path d="M 380 495 L 280 502 M 380 525 L 280 518" fill="none" stroke="#94A3B8" stroke-width="1" />
+  <!-- 牙盘 -->
+  <circle cx="380" cy="510" r="19" fill="#E2E8F0" stroke="#475569" stroke-width="2" />
+  <circle cx="380" cy="510" r="14" fill="#334155" />
+  <!-- 背景脚踏板与腿 (处于车身另一侧) -->
+  <line x1="345" y1="440" x2="360" y2="540" stroke="#C2410C" stroke-width="8" stroke-linecap="round" opacity="0.8" />
+  <path d="M 360 540 Q 380 545 385 550 Q 365 555 350 545 Z" fill="#9A3412" opacity="0.8" />
+  <line x1="380" y1="510" x2="360" y2="540" stroke="#64748B" stroke-width="5" stroke-linecap="round" opacity="0.8" />
+  <line x1="350" y1="540" x2="370" y2="540" stroke="#1E293B" stroke-width="5" stroke-linecap="round" opacity="0.8" />
+
+  <!-- 自行车车架 (主结构) -->
+  <!-- 湖蓝色复古车架 -->
+  <line x1="380" y1="510" x2="345" y2="422" stroke="#06B6D4" stroke-width="8" stroke-linecap="round" /> <!-- 立管 -->
+  <line x1="280" y1="510" x2="380" y2="510" stroke="#06B6D4" stroke-width="8" stroke-linecap="round" /> <!-- 平叉 -->
+  <line x1="280" y1="510" x2="345" y2="422" stroke="#06B6D4" stroke-width="5" stroke-linecap="round" /> <!-- 后斜撑 -->
+  <line x1="380" y1="510" x2="480" y2="390" stroke="#06B6D4" stroke-width="9" stroke-linecap="round" /> <!-- 下管 -->
+  <path d="M 345 435 Q 410 420 480 390" fill="none" stroke="#06B6D4" stroke-width="8" stroke-linecap="round" /> <!-- 弯曲上管 -->
+  
+  <!-- 复古皮革车座 -->
+  <path d="M 322 415 Q 350 405 368 418 Q 360 426 345 423 L 322 422 Z" fill="#78350F" />
+  <path d="M 322 415 Q 350 405 360 415" fill="none" stroke="#B45309" stroke-width="2" />
+  <rect x="340" y="422" width="6" height="10" fill="#94A3B8" />
+
+  <!-- 自行车前半部分 -->
+  <!-- 前轮 -->
+  <use href="#wheel" x="520" y="510" />
+  <!-- 前挡泥板 -->
+  <path d="M 480 465 A 65 65 0 0 1 580 515" fill="none" stroke="#FEF08A" stroke-width="8" stroke-linecap="round" />
+  <path d="M 480 465 A 65 65 0 0 1 580 515" fill="none" stroke="#E2E8F0" stroke-width="2" stroke-linecap="round" opacity="0.5" />
+  <!-- 前叉 -->
+  <line x1="480" y1="390" x2="520" y2="510" stroke="#06B6D4" stroke-width="7" stroke-linecap="round" />
+  <line x1="480" y1="390" x2="475" y2="345" stroke="#94A3B8" stroke-width="6" stroke-linecap="round" /> <!-- 车把立管 -->
+
+  <!-- 复古燕把 -->
+  <path d="M 475 345 Q 455 338 430 360" fill="none" stroke="#94A3B8" stroke-width="5" stroke-linecap="round" />
+  <path d="M 475 345 Q 490 340 500 350" fill="none" stroke="#94A3B8" stroke-width="4" stroke-linecap="round" opacity="0.7" /> <!-- 右车把微露 -->
+  <line x1="435" y1="356" x2="425" y2="363" stroke="#1E293B" stroke-width="7" stroke-linecap="round" /> <!-- 黑色把套 -->
+
+  <!-- 车筐 (藤编效果) -->
+  <g>
+    <!-- 挂接架 -->
+    <line x1="475" y1="355" x2="490" y2="365" stroke="#475569" stroke-width="3" />
+    <line x1="480" y1="390" x2="495" y2="395" stroke="#475569" stroke-width="3" />
+    <!-- 车筐主体 -->
+    <rect x="490" y="360" width="48" height="38" rx="6" fill="#D97706" stroke="#92400E" stroke-width="2" />
+    <!-- 藤编网格纹理 -->
+    <line x1="490" y1="370" x2="538" y2="370" stroke="#78350F" stroke-width="1.5" />
+    <line x1="490" y1="380" x2="538" y2="380" stroke="#78350F" stroke-width="1.5" />
+    <line x1="490" y1="390" x2="538" y2="390" stroke="#78350F" stroke-width="1.5" />
+    <line x1="500" y1="360" x2="500" y2="398" stroke="#78350F" stroke-width="1.5" />
+    <line x1="514" y1="360" x2="514" y2="398" stroke="#78350F" stroke-width="1.5" />
+    <line x1="528" y1="360" x2="528" y2="398" stroke="#78350F" stroke-width="1.5" />
+    <!-- 车筐里盛开的鲜花与绿叶 -->
+    <path d="M 522 355 Q 535 345 528 360 Z" fill="#22C55E" />
+    <circle cx="522" cy="358" r="7" fill="#EF4444" />
+    <circle cx="522" cy="358" r="2.5" fill="#FCD34D" />
+    <path d="M 498 358 Q 485 350 495 360 Z" fill="#10B981" />
+    <circle cx="502" cy="358" r="6" fill="#F43F5E" />
+    <circle cx="502" cy="358" r="2" fill="#FBBF24" />
+  </g>
+
+
+  <!-- SUBJECT: 鹈鹕 -->
+  
+  <!-- 远侧翅膀 (微露) -->
+  <path d="M 330 350 C 335 325 360 330 375 342 C 370 355 350 360 330 350 Z" fill="#CBD5E1" opacity="0.7" />
+
+  <!-- 尾羽 -->
+  <g>
+    <path d="M 275 395 C 250 390 240 405 230 400 C 248 415 268 410 278 402 Z" fill="#CBD5E1" />
+    <path d="M 280 390 C 255 380 245 395 235 390 C 252 405 272 400 282 395 Z" fill="#E2E8F0" />
+  </g>
+
+  <!-- 身体躯干 (丰满厚重) -->
+  <path d="M 345 425 C 290 425 278 395 270 395 C 290 375 315 358 355 358 C 390 358 402 390 385 415 C 375 425 360 425 345 425 Z" fill="url(#pelicanShadow)" stroke="#E2E8F0" stroke-width="1" />
+
+  <!-- S型修长的脖子 -->
+  <path d="M 345 360 C 330 305 352 255 378 248 C 388 243 392 228 388 212 C 398 212 408 232 398 252 C 382 272 368 308 375 360 Z" fill="url(#pelicanShadow)" />
+
+  <!-- 随风飘扬的红色围巾 (动感核心) -->
+  <g>
+    <!-- 飘带 1 -->
+    <path d="M 368 275 C 320 270 290 240 245 260 C 285 280 318 290 368 277 Z" fill="#DC2626" />
+    <!-- 飘带 2 -->
+    <path d="M 368 275 C 310 280 280 270 235 290 C 275 305 308 300 368 277 Z" fill="#991B1B" />
+    <!-- 围巾结 -->
+    <ellipse cx="372" cy="275" rx="14" ry="8" transform="rotate(-15 372 275)" fill="#EF4444" />
+    <ellipse cx="372" cy="275" rx="10" ry="5" transform="rotate(-15 372 275)" fill="#F87171" opacity="0.6" />
+  </g>
+
+  <!-- 头部 -->
+  <path d="M 370 215 C 365 190 380 180 405 185 C 418 190 422 205 410 220 C 400 230 380 230 370 215 Z" fill="url(#pelicanShadow)" />
+  <!-- 后脑勺的呆毛/羽冠 -->
+  <path d="M 370 200 Q 352 188 358 182 Q 358 195 370 205" fill="#CBD5E1" />
+  <path d="M 373 192 Q 355 180 360 175 Q 361 188 372 196" fill="#E2E8F0" />
+
+  <!-- 喉囊 (大而富有质感) -->
+  <g>
+    <path d="M 410 218 C 435 240 420 295 382 295 C 368 295 368 265 375 245 Z" fill="url(#pouchGrad)" />
+    <!-- 喉囊纹理褶皱 -->
+    <path d="M 400 240 Q 390 265 377 270" fill="none" stroke="#EF4444" stroke-width="1.5" opacity="0.4" />
+    <path d="M 408 235 Q 398 265 382 278" fill="none" stroke="#EF4444" stroke-width="1.5" opacity="0.4" />
+    <path d="M 414 230 Q 406 260 388 285" fill="none" stroke="#EF4444" stroke-width="1.5" opacity="0.4" />
+  </g>
+
+  <!-- 巨大的眼睑与灵动的眼睛 -->
+  <g>
+    <path d="M 383 198 Q 395 188 406 203" fill="none" stroke="#E2E8F0" stroke-width="3.5" stroke-linecap="round" />
+    <circle cx="395" cy="202" r="8" fill="#FBBF24" /> <!-- 鲜艳的黄眼圈 -->
+    <circle cx="395" cy="202" r="4.5" fill="#1E293B" />
+    <circle cx="393.5" cy="200.5" r="1.5" fill="#FFFFFF" /> <!-- 高光 -->
+  </g>
+
+  <!-- 标致性的大长嘴 -->
+  <g>
+    <!-- 上喙 -->
+    <path d="M 405 195 Q 480 205 540 225 Q 545 228 542 235 Q 530 235 515 230 L 410 218 Z" fill="url(#beakGrad)" />
+    <!-- 尖端标志性的红色鹰钩 -->
+    <path d="M 535 223 Q 544 226 542 235 Q 534 235 528 228 Z" fill="#EF4444" />
+    <!-- 上喙反光线 -->
+    <path d="M 412 198 Q 480 208 532 226" fill="none" stroke="#FFF" stroke-width="2.5" opacity="0.6" stroke-linecap="round" />
+    <!-- 下喙 -->
+    <path d="M 410 218 L 515 230 Q 520 232 515 235 L 410 226 Z" fill="#F59E0B" />
+  </g>
+
+  <!-- 近侧大腿 -->
+  <path d="M 345 425 Q 365 430 365 450 Q 345 455 340 425 Z" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="1" />
+  <!-- 橙色的小腿 -->
+  <line x1="355" y1="445" x2="400" y2="480" stroke="#FB923C" stroke-width="8" stroke-linecap="round" />
+  <!-- 踩在踏板上的橙红色鸭蹼脚 -->
+  <g>
+    <path d="M 400 480 L 428 475 L 432 485 L 402 490 Z" fill="#EA580C" />
+    <!-- 蹼爪骨骼线 -->
+    <line x1="400" y1="480" x2="428" y2="475" stroke="#F97316" stroke-width="2.5" />
+    <line x1="400" y1="480" x2="432" y2="485" stroke="#F97316" stroke-width="2.5" />
+    <line x1="400" y1="480" x2="415" y2="492" stroke="#F97316" stroke-width="2.5" />
+    <!-- 黑色利爪微显 -->
+    <circle cx="428" cy="475" r="1.5" fill="#1E293B" />
+    <circle cx="432" cy="485" r="1.5" fill="#1E293B" />
+  </g>
+
+  <!-- 近侧脚踏板 (盖在脚掌上) -->
+  <line x1="380" y1="510" x2="400" y2="480" stroke="#CBD5E1" stroke-width="6" stroke-linecap="round" /> <!-- 曲柄 -->
+  <line x1="390" y1="480" x2="415" y2="480" stroke="#475569" stroke-width="5" stroke-linecap="round" /> <!-- 踏板 -->
+
+  <!-- 近侧翅膀 (富有层次感，紧握车把) -->
+  <g>
+    <!-- 翅膀根部 -->
+    <path d="M 340 360 C 350 330 385 330 408 350 C 388 368 360 372 340 360 Z" fill="#FFFFFF" stroke="#F1F5F9" stroke-width="1" />
+    <!-- 中层羽毛 (浅灰色过渡) -->
+    <path d="M 350 365 C 370 345 398 345 418 365 C 398 382 370 382 350 365 Z" fill="#E2E8F0" />
+    <!-- 飞羽/初级飞羽 (呈握持姿态，深色，符合野生鹈鹕特征) -->
+    <!-- 羽毛手指 1 (握在把手上) -->
+    <path d="M 370 370 Q 410 365 435 365 Q 430 376 398 382 Z" fill="#475569" />
+    <!-- 羽毛手指 2 -->
+    <path d="M 380 375 Q 415 370 432 373 Q 425 384 392 387 Z" fill="#1E293B" />
+    <!-- 羽毛手指 3 -->
+    <path d="M 390 380 Q 415 378 428 381 Q 420 392 388 392 Z" fill="#0F172A" />
+  </g>
+
+
+  <!-- FOREGROUND: 近景环境（增强纵深感与真实感） -->
+  
+  <!-- 右侧巨大的椰子树剪影 (框架构图) -->
+  <g>
+    <!-- 树干 -->
+    <path d="M 800 650 Q 750 350 740 180 Q 748 178 755 180 Q 765 350 815 650 Z" fill="#1E293B" />
+    <!-- 树干环形树纹 -->
+    <g stroke="#0F172A" stroke-width="2" opacity="0.4">
+      <path d="M 790 580 Q 770 575 752 578" />
+      <path d="M 780 520 Q 762 515 746 518" />
+      <path d="M 770 460 Q 754 455 741 458" />
+      <path d="M 761 400 Q 746 395 736 398" />
+      <path d="M 753 340 Q 740 335 732 338" />
+      <path d="M 748 280 Q 736 275 730 278" />
+      <path d="M 744 220 Q 736 215 732 218" />
+    </g>
+    <!-- 繁茂的椰树叶 -->
+    <!-- 叶 1 (左下垂) -->
+    <path d="M 745 180 Q 630 165 545 220 Q 640 195 745 180" fill="#1E293B" />
+    <!-- 叶 2 (左中) -->
+    <path d="M 745 180 Q 650 100 575 135 Q 660 140 745 180" fill="#1E1B4B" />
+    <!-- 叶 3 (向上) -->
+    <path d="M 745 180 Q 710 70 665 60 Q 710 105 745 180" fill="#1E293B" />
+    <!-- 叶 4 (右伸) -->
+    <path d="M 745 180 Q 790 70 835 80 Q 780 115 745 180" fill="#1E1B4B" />
+    <!-- 叶 5 (右下垂) -->
+    <path d="M 745 180 Q 840 140 875 185 Q 810 165 745 180" fill="#1E293B" />
+  </g>
+
+  <!-- 左前角沙滩小草（前景遮挡） -->
+  <g fill="#1E293B">
+    <path d="M -10 600 Q 15 540 -5 500 Q 25 550 35 600 Z" />
+    <path d="M 15 600 Q 40 520 60 470 Q 55 540 45 600 Z" opacity="0.9" />
+    <path d="M 35 600 Q 65 530 95 500 Q 75 550 55 600 Z" opacity="0.8" />
+  </g>
+
+  <!-- 车轮扬起的一丝沙尘 (点缀动感) -->
+  <g fill="#C5A363" opacity="0.6">
+    <circle cx="210" cy="560" r="3" />
+    <circle cx="225" cy="552" r="2" />
+    <circle cx="200" cy="565" r="1.5" />
+    <circle cx="455" cy="562" r="2.5" />
+    <circle cx="445" cy="558" r="1.5" />
+  </g>
+</svg>

--- a/outputs/gpt-5-5-xhigh/pelican-cycling.svg
+++ b/outputs/gpt-5-5-xhigh/pelican-cycling.svg
@@ -1,0 +1,240 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800" role="img" aria-labelledby="title desc">
+  <title id="title">海边骑自行车的鹈鹕</title>
+  <desc id="desc">一只逼真的褐鹈鹕在金色海岸边骑着复古自行车，海浪、湿沙和飞溅的水珠营造出鲜活的速度感。</desc>
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#5eb5dc"/>
+      <stop offset=".48" stop-color="#b9ddeb"/>
+      <stop offset=".77" stop-color="#f1d5aa"/>
+      <stop offset="1" stop-color="#ebb879"/>
+    </linearGradient>
+    <radialGradient id="sunGlow" cx=".73" cy=".21" r=".37">
+      <stop offset="0" stop-color="#fff9cf" stop-opacity=".95"/>
+      <stop offset=".28" stop-color="#ffe8a4" stop-opacity=".42"/>
+      <stop offset="1" stop-color="#ffd38b" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="sea" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#498fa8"/>
+      <stop offset=".48" stop-color="#2d7189"/>
+      <stop offset="1" stop-color="#174b60"/>
+    </linearGradient>
+    <linearGradient id="sand" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#d2a670"/>
+      <stop offset=".45" stop-color="#b78251"/>
+      <stop offset="1" stop-color="#795138"/>
+    </linearGradient>
+    <linearGradient id="wetSand" x1="0" y1="0" x2="1" y2=".7">
+      <stop offset="0" stop-color="#816452"/>
+      <stop offset=".5" stop-color="#9f7552"/>
+      <stop offset="1" stop-color="#4a4650"/>
+    </linearGradient>
+    <linearGradient id="frameMetal" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#27545c"/>
+      <stop offset=".48" stop-color="#6ca4a4"/>
+      <stop offset=".58" stop-color="#173a42"/>
+      <stop offset="1" stop-color="#8db9b1"/>
+    </linearGradient>
+    <linearGradient id="pelicanBody" x1=".2" y1=".05" x2=".75" y2=".95">
+      <stop offset="0" stop-color="#f2ead7"/>
+      <stop offset=".34" stop-color="#c7b89f"/>
+      <stop offset=".72" stop-color="#766d62"/>
+      <stop offset="1" stop-color="#403e3b"/>
+    </linearGradient>
+    <linearGradient id="wing" x1=".1" y1=".2" x2=".9" y2=".9">
+      <stop offset="0" stop-color="#eee4cf"/>
+      <stop offset=".38" stop-color="#a79c8c"/>
+      <stop offset=".72" stop-color="#5a5651"/>
+      <stop offset="1" stop-color="#292d2f"/>
+    </linearGradient>
+    <linearGradient id="neck" x1="0" y1="0" x2=".8" y2="1">
+      <stop offset="0" stop-color="#f7eee0"/>
+      <stop offset=".48" stop-color="#d2b99d"/>
+      <stop offset="1" stop-color="#806c5d"/>
+    </linearGradient>
+    <linearGradient id="bill" x1="0" y1=".1" x2="1" y2=".8">
+      <stop offset="0" stop-color="#f6c883"/>
+      <stop offset=".52" stop-color="#d88b4b"/>
+      <stop offset="1" stop-color="#8f4b31"/>
+    </linearGradient>
+    <linearGradient id="pouch" x1=".25" y1="0" x2=".7" y2="1">
+      <stop offset="0" stop-color="#e79b65"/>
+      <stop offset=".62" stop-color="#bd684c"/>
+      <stop offset="1" stop-color="#7b4139"/>
+    </linearGradient>
+    <filter id="soft" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="10"/>
+    </filter>
+    <filter id="tinyBlur" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="2.3"/>
+    </filter>
+    <filter id="drop" x="-30%" y="-30%" width="170%" height="180%">
+      <feDropShadow dx="2" dy="8" stdDeviation="7" flood-color="#18252a" flood-opacity=".38"/>
+    </filter>
+    <filter id="bikeShadow" x="-30%" y="-70%" width="170%" height="260%">
+      <feGaussianBlur stdDeviation="7"/>
+    </filter>
+    <clipPath id="rearWheelClip"><circle cx="397" cy="628" r="111"/></clipPath>
+    <clipPath id="frontWheelClip"><circle cx="785" cy="628" r="111"/></clipPath>
+    <pattern id="sandGrain" width="80" height="40" patternUnits="userSpaceOnUse">
+      <circle cx="8" cy="8" r="1" fill="#f3c991" opacity=".22"/>
+      <circle cx="34" cy="28" r=".8" fill="#392d2b" opacity=".18"/>
+      <circle cx="67" cy="13" r="1.3" fill="#e2b780" opacity=".17"/>
+      <path d="M17 36l12-2M49 5l8 1" stroke="#f3d0a2" stroke-width=".7" opacity=".16"/>
+    </pattern>
+  </defs>
+
+  <!-- Atmosphere -->
+  <rect width="1200" height="800" fill="url(#sky)"/>
+  <rect width="1200" height="540" fill="url(#sunGlow)"/>
+  <circle cx="881" cy="158" r="47" fill="#fff5bf" opacity=".75" filter="url(#soft)"/>
+  <circle cx="881" cy="158" r="25" fill="#fffbdc" opacity=".92"/>
+
+  <g fill="#fff" opacity=".48" filter="url(#soft)">
+    <path d="M-45 165c67-55 129-30 160-3 29-44 107-43 129 12 53-21 101 7 110 46H-45z"/>
+    <path d="M755 95c49-34 95-17 114 8 35-37 99-22 103 24 41-12 76 9 81 39H740z"/>
+  </g>
+  <g fill="none" stroke="#416d7b" stroke-width="3" stroke-linecap="round" opacity=".48">
+    <path d="M173 230q12-10 24 0q12-10 24 0"/>
+    <path d="M1031 260q10-8 20 0q10-8 20 0"/>
+    <path d="M952 211q7-6 14 0q7-6 14 0"/>
+  </g>
+
+  <!-- Ocean -->
+  <path d="M0 340C181 327 333 346 501 335c174-12 311-2 455 3 100 4 181-3 244-8v262H0z" fill="url(#sea)"/>
+  <path d="M0 358c196-10 291 16 466 2 196-16 312 1 468 5 104 3 193-9 266-13" fill="none" stroke="#d4edf1" stroke-width="4" opacity=".72"/>
+  <g fill="none" stroke-linecap="round">
+    <path d="M32 398c89-16 161 16 255-2s167 9 256-5" stroke="#a7d6df" stroke-width="7" opacity=".48"/>
+    <path d="M665 410c91-13 167 15 261-2 88-16 174 8 258-7" stroke="#d0e9e7" stroke-width="6" opacity=".58"/>
+    <path d="M70 454c129-27 215 19 360-4 130-21 230 16 360-1" stroke="#f3f0df" stroke-width="11" opacity=".72"/>
+    <path d="M20 480c132-15 220 21 344 7 112-13 221 15 316 3" stroke="#eaf1e9" stroke-width="9" opacity=".54"/>
+  </g>
+
+  <!-- Beach -->
+  <path d="M0 470c189-6 360 40 531 42 208 3 377-44 669-28v316H0z" fill="url(#sand)"/>
+  <path d="M0 529c221-8 361 63 578 38 222-25 391-51 622-27v260H0z" fill="url(#wetSand)"/>
+  <rect y="505" width="1200" height="295" fill="url(#sandGrain)" opacity=".8"/>
+  <path d="M0 498c121-20 193 27 297 19 89-7 141 31 233 23 120-10 198-56 326-39 120 16 218-18 344-5" fill="none" stroke="#f7f1dc" stroke-width="18" opacity=".86"/>
+  <path d="M0 509c126-19 198 27 300 19 93-7 149 32 239 23 127-13 196-50 318-38 125 13 221-16 343-4" fill="none" stroke="#d3ece6" stroke-width="8" opacity=".75"/>
+  <g fill="#fffdf3" opacity=".7">
+    <circle cx="104" cy="506" r="5"/><circle cx="141" cy="516" r="3"/><circle cx="223" cy="514" r="7"/>
+    <circle cx="274" cy="528" r="4"/><circle cx="918" cy="506" r="6"/><circle cx="983" cy="503" r="3"/>
+    <circle cx="1091" cy="509" r="8"/><circle cx="1130" cy="503" r="4"/>
+  </g>
+
+  <!-- Reflections and speed streaks -->
+  <g stroke-linecap="round" opacity=".22" filter="url(#tinyBlur)">
+    <path d="M195 710h260M116 736h212M854 701h248M910 747h197" stroke="#f3d49d" stroke-width="12"/>
+    <path d="M250 680h145M805 681h177M54 663h184" stroke="#c9e1da" stroke-width="7"/>
+  </g>
+  <ellipse cx="596" cy="739" rx="323" ry="28" fill="#1d2b31" opacity=".35" filter="url(#bikeShadow)"/>
+
+  <!-- Bicycle wheels -->
+  <g filter="url(#drop)">
+    <g>
+      <circle cx="397" cy="628" r="114" fill="none" stroke="#151d20" stroke-width="13"/>
+      <circle cx="397" cy="628" r="106" fill="none" stroke="#b7c6c3" stroke-width="3"/>
+      <circle cx="397" cy="628" r="9" fill="#c9d5cf" stroke="#26363a" stroke-width="4"/>
+      <g stroke="#d1ddd8" stroke-width="1.25" opacity=".8" clip-path="url(#rearWheelClip)">
+        <path d="M397 628L397 514M397 628L452 528M397 628L492 564M397 628L507 599M397 628L510 649M397 628L487 690M397 628L456 725M397 628L405 741M397 628L349 732M397 628L305 696M397 628L287 650M397 628L292 585M397 628L327 538"/>
+      </g>
+    </g>
+    <g>
+      <circle cx="785" cy="628" r="114" fill="none" stroke="#151d20" stroke-width="13"/>
+      <circle cx="785" cy="628" r="106" fill="none" stroke="#b7c6c3" stroke-width="3"/>
+      <circle cx="785" cy="628" r="9" fill="#c9d5cf" stroke="#26363a" stroke-width="4"/>
+      <g stroke="#d1ddd8" stroke-width="1.25" opacity=".8" clip-path="url(#frontWheelClip)">
+        <path d="M785 628L785 514M785 628L840 528M785 628L880 564M785 628L895 599M785 628L898 649M785 628L875 690M785 628L844 725M785 628L793 741M785 628L737 732M785 628L693 696M785 628L675 650M785 628L680 585M785 628L715 538"/>
+      </g>
+    </g>
+  </g>
+
+  <!-- Bicycle frame -->
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M397 628L513 620L602 475L696 620L513 620L466 495L602 475" stroke="#12262c" stroke-width="20" opacity=".45"/>
+    <path d="M397 628L513 620L602 475L696 620L513 620L466 495L602 475" stroke="url(#frameMetal)" stroke-width="13"/>
+    <path d="M696 620L753 465L785 628" stroke="#1e3d44" stroke-width="12"/>
+    <path d="M735 467q28-9 57 4" stroke="#1b3035" stroke-width="10"/>
+    <path d="M442 489h49" stroke="#28211d" stroke-width="12"/>
+    <path d="M449 481h45q7 0 7 7v3h-59z" fill="#674636" stroke="#30231f" stroke-width="3"/>
+    <circle cx="513" cy="620" r="29" stroke="#28363a" stroke-width="5"/>
+    <circle cx="513" cy="620" r="19" stroke="#d7c28b" stroke-width="4"/>
+    <path d="M513 620l43 17" stroke="#242b2d" stroke-width="6"/>
+    <path d="M556 637h24" stroke="#1f2527" stroke-width="7"/>
+    <path d="M513 620l-39-22" stroke="#242b2d" stroke-width="6"/>
+    <path d="M454 594h25" stroke="#1f2527" stroke-width="7"/>
+    <path d="M506 607C480 592 438 591 397 622" stroke="#c5a45d" stroke-width="4"/>
+  </g>
+
+  <!-- Pelican body -->
+  <g filter="url(#drop)">
+    <path d="M459 448c11-80 88-135 175-113 74 19 98 92 61 151-36 57-117 75-186 38-40-22-57-47-50-76z" fill="url(#pelicanBody)"/>
+    <path d="M490 443c41-79 142-93 191-35 20 24 20 57-2 83-55 27-119 15-177-24z" fill="#d8cdb9" opacity=".48"/>
+    <!-- Rear plumage -->
+    <path d="M479 403c-41-12-83-3-121 22 34 5 55 17 73 31-32-2-59 7-82 26 47-1 82 11 117 35 14-31 20-72 13-114z" fill="#6b6861"/>
+    <path d="M451 418c-30-1-55 6-77 20 31 5 51 14 74 30" fill="none" stroke="#d2c5ae" stroke-width="5" opacity=".55"/>
+    <path d="M452 454c-31 5-53 14-72 29 31-1 56 7 79 24" fill="none" stroke="#a79b89" stroke-width="5" opacity=".5"/>
+
+    <!-- Far balancing wing -->
+    <path d="M568 379c51-78 119-119 188-133-49 39-60 65-76 93 35-28 72-42 109-49-33 28-61 57-83 93-37 60-80 83-119 66z" fill="#625e58"/>
+    <path d="M597 400c47-58 91-98 142-126M620 419c49-44 88-71 136-93" fill="none" stroke="#c3b6a1" stroke-width="5" opacity=".48"/>
+
+    <!-- Main wing gripping handlebar -->
+    <path d="M581 393c48-7 88 19 107 57 14 29 29 37 59 33 23-4 43 7 48 24-38 12-75 10-107-7-32-17-62-34-96-44-26-8-36-59-11-63z" fill="url(#wing)"/>
+    <path d="M604 411c42 14 62 46 89 63 25 16 52 22 83 20M591 431c35 13 59 39 90 59" fill="none" stroke="#e4d5bc" stroke-width="5" opacity=".58"/>
+    <path d="M745 482c9-4 19-4 29 2M755 491c11-4 22-2 31 3M767 501c9-2 18 0 25 5" fill="none" stroke="#3a3937" stroke-width="5"/>
+
+    <!-- Neck -->
+    <path d="M545 394c-25-37-28-94-2-137 22-36 67-50 105-34 30 12 48 40 40 67-9 30-46 39-67 19-19-18-11-40-24-52-9-8-21 1-23 15-6 42 26 82 55 105z" fill="url(#neck)"/>
+    <path d="M570 365c-5-35-1-66 13-86 5-7 12-9 16-3 7 11 3 25 13 38 10 13 28 19 47 14" fill="none" stroke="#8d745f" stroke-width="6" opacity=".55"/>
+    <path d="M558 282c9-44 31-67 68-69 32-2 59 14 71 40-44-15-87-5-139 29z" fill="#f2eadc"/>
+
+    <!-- Head -->
+    <path d="M604 229c9-31 45-47 78-34 25 10 38 32 31 55-8 24-38 36-68 25-30-10-48-25-41-46z" fill="#f5eee1"/>
+    <path d="M674 199c19 5 34 17 39 33-19-8-35-7-49 2-17 11-34 8-51-6 16-23 38-34 61-29z" fill="#d8c6af"/>
+    <ellipse cx="687" cy="225" rx="10" ry="11" fill="#20292b"/>
+    <circle cx="690" cy="222" r="3.2" fill="#f7d65e"/>
+    <circle cx="692" cy="219" r="1.8" fill="#fff"/>
+
+    <!-- Beak and pouch -->
+    <path d="M706 234c66-7 139 5 207 29-77 2-147 1-211-1-11-1-14-24 4-28z" fill="url(#bill)"/>
+    <path d="M712 255c56 3 116 5 180 7-47 21-108 39-167 24-17-4-24-17-13-31z" fill="url(#pouch)"/>
+    <path d="M716 241c57 1 120 8 184 20" fill="none" stroke="#793f2f" stroke-width="3" opacity=".65"/>
+    <path d="M735 268c42 12 91 7 138-1" fill="none" stroke="#f0ae76" stroke-width="4" opacity=".4"/>
+    <path d="M913 263l-20-2 15 9z" fill="#593832"/>
+  </g>
+
+  <!-- Legs and feet -->
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M554 505c-5 42-10 78-41 108" stroke="#815540" stroke-width="15"/>
+    <path d="M513 613c14 5 26 13 38 24" stroke="#b47b55" stroke-width="10"/>
+    <path d="M513 613c-7 10-15 18-25 24M517 614c2 12 2 23 0 35" stroke="#b47b55" stroke-width="7"/>
+    <path d="M635 506c-2 37 8 74 43 108" stroke="#77503f" stroke-width="15"/>
+    <path d="M678 614c19 0 36 4 51 12" stroke="#b47b55" stroke-width="10"/>
+    <path d="M678 614c7 10 12 20 14 31M680 614c-3 12-4 23-2 34" stroke="#b47b55" stroke-width="7"/>
+  </g>
+
+  <!-- Feather details -->
+  <g fill="none" stroke-linecap="round" opacity=".48">
+    <path d="M488 475c49 18 102 23 154 10M501 494c40 15 87 19 130 10M504 439c42 25 91 30 139 19" stroke="#efe3ce" stroke-width="5"/>
+    <path d="M525 519c31 8 61 10 91 4M472 459c12-29 31-51 56-67" stroke="#4c4a47" stroke-width="4"/>
+    <path d="M550 345c15 5 30 4 45-4M548 327c16 5 28 4 39-2" stroke="#f7eddd" stroke-width="4"/>
+  </g>
+
+  <!-- Water spray around wheels -->
+  <g fill="#e8f5f2" opacity=".86">
+    <circle cx="313" cy="676" r="6"/><circle cx="292" cy="661" r="3.5"/><circle cx="274" cy="638" r="5"/>
+    <circle cx="253" cy="620" r="2.8"/><circle cx="323" cy="701" r="3"/><circle cx="350" cy="718" r="4"/>
+    <circle cx="872" cy="688" r="5"/><circle cx="897" cy="671" r="3"/><circle cx="914" cy="643" r="5"/>
+    <circle cx="926" cy="615" r="2.5"/><circle cx="853" cy="713" r="3.5"/><circle cx="831" cy="729" r="4"/>
+  </g>
+  <g fill="none" stroke="#f6fbf5" stroke-linecap="round" opacity=".72">
+    <path d="M338 694c-42-13-69-31-88-57M851 701c43-11 72-34 88-69" stroke-width="5"/>
+    <path d="M356 714c-32-3-56-12-76-28M834 719c35-4 63-16 82-35" stroke-width="3"/>
+  </g>
+
+  <!-- Foreground texture -->
+  <path d="M0 760c160-20 316 3 474-7 188-12 374-4 726-15v62H0z" fill="#342f31" opacity=".28"/>
+  <g stroke="#e8c88f" stroke-linecap="round" opacity=".38">
+    <path d="M44 704h64M152 754h91M941 772h109M1051 716h83M43 785h165M694 768h106" stroke-width="4"/>
+  </g>
+</svg>

--- a/site/src/data/cases.ts
+++ b/site/src/data/cases.ts
@@ -138,6 +138,9 @@ export const RUNS: Record<string, Record<string, RunDef>> = {
         en: 'Generated in one shot in the Claude web app on Fable 5 Max (max thinking effort).',
       },
     },
+    'gpt-5-5-xhigh': {},
+    'gemini-3-1-pro': {},
+    'gemini-3-5-flash': {},
   },
 }
 


### PR DESCRIPTION
## What changed

- Add `pelican-cycling.svg` outputs for GPT-5.5 xhigh, Gemini 3.1 Pro, and Gemini 3.5 Flash.
- Register the three model runs in `site/src/data/cases.ts` so they appear in the SVG benchmark viewer.

## Why

These three completed model artifacts were missing from the Pelican by the Sea comparison.

## Validation

- Confirmed all three files are valid SVG/XML.
- Confirmed the artifacts match the supplied source files.
- Confirmed the PR is based on `nagi-studio/nagi-bench:main` and changes only the three SVG files plus three run registrations.