### PR TITLE
feat: add Qwen3.7-Max via QoderWork results

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -58,7 +58,7 @@ One-shot LLM eval cases by NAGI STUDIO: same prompt, different model x harness x
 | MiniMax M2.7 | MiniMax | MiniMax Code Web · Thinking | 01 |
 | GLM-5 Turbo | Zhipu AI | ZCode · Thinking | 03 |
 | GLM-5.2 | Zhipu AI | ZCode · Max | 03 |
-| Qwen3.7-Max | Alibaba | Qoder · Default | 02 |
+| Qwen3.7-Max | Alibaba | Qoder · Default<br>QoderWork · Default | 04 |
 
 Pending: GLM-5.1 (PRs welcome)
 <!-- registry:end -->

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ NAGI STUDIO 的 LLM 测评案例集：同一段提示词，不同「模型 × Ha
 | MiniMax M2.7 | MiniMax | MiniMax Code Web · Thinking | 01 |
 | GLM-5 Turbo | Zhipu AI | ZCode · Thinking | 03 |
 | GLM-5.2 | Zhipu AI | ZCode · Max | 03 |
-| Qwen3.7-Max | Alibaba | Qoder · Default | 02 |
+| Qwen3.7-Max | Alibaba | Qoder · Default<br>QoderWork · Default | 04 |
 
 待测：GLM-5.1（欢迎 PR 补充）
 <!-- registry:end -->

--- a/models/qwen3-7-max-qoderwork.json
+++ b/models/qwen3-7-max-qoderwork.json
@@ -1,0 +1,24 @@
+{
+  "label": "Qwen3.7-Max",
+  "vendor": "Alibaba",
+  "harness": "QoderWork",
+  "effort": "Default",
+  "artifactDir": "qwen3-7-max/qoderwork-default",
+  "order": 131,
+  "runs": {
+    "mythos-craft": {
+      "note": {
+        "zh": "在 QoderWork 中由 Qwen3.7-Max 一次生成，未经修改的原始输出。基于 Three.js r128 的体素世界：含 Perlin 噪声地形（5 级 FBM）、区块加载系统、第一人称 WASD+鼠标控制、6 种可选方块（草地/泥土/石头/沙子/木头/黑曜石）、左键破坏/右键放置、5 类神话建筑（巫师塔/古神殿/巨树/龙巢/符文阵）、动态天空/云层/海面波浪。",
+        "en": "Generated in one shot by Qwen3.7-Max inside QoderWork; unmodified original output. A Three.js r128 voxel world featuring: Perlin noise terrain (5-octave FBM), chunk-based loading, first-person WASD + mouse look controls, 6 placeable block types (grass/dirt/stone/sand/wood/obsidian), left-click break/right-click place, 5 mythic structure types (Wizard Tower, Ancient Temple, Giant Tree, Dragon Nest, Runic Circle), dynamic sky/clouds/ocean waves."
+      },
+      "contributor": "FFFxueGawaine"
+    },
+    "pelican-cycling": {
+      "note": {
+        "zh": "在 QoderWork 中由 Qwen3.7-Max 一次生成，未经修改的原始 SVG。海边骑行场景：渐变天空与太阳、层叠远山、海面波光与帆船、沙滩贝壳与海星螃蟹、棕榈树；鹈鹕拥有渐变身体/翅膀羽毛细节/标志性大嘴与喉囊/头部冠羽/蹼足踩踏板；红色自行车含辐条轮毂/车架/链条/踏板；运动线条与扬尘表现动感。",
+        "en": "Generated in one shot by Qwen3.7-Max inside QoderWork; unmodified original SVG. A seaside cycling scene with: gradient sky and sun, layered distant mountains, shimmering sea with sailboat, sandy beach with shells/starfish/crab, palm tree; the pelican features gradient body, wing feather details, iconic beak and throat pouch, head crest, webbed feet on pedals; red bicycle with spoked wheels, frame, chain, and pedals; motion lines and dust particles convey movement."
+      },
+      "contributor": "FFFxueGawaine"
+    }
+  }
+}

--- a/outputs/qwen3-7-max/qoderwork-default/mythos-craft.html
+++ b/outputs/qwen3-7-max/qoderwork-default/mythos-craft.html
@@ -1,0 +1,524 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>Mythos Craft</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{overflow:hidden;background:#000;font-family:'Segoe UI',sans-serif}
+canvas{display:block}
+#blocker{position:fixed;inset:0;background:rgba(0,0,0,.75);display:flex;align-items:center;justify-content:center;z-index:10;flex-direction:column}
+#blocker h1{color:#e0d6c2;font-size:3em;text-shadow:0 0 20px rgba(255,200,100,.5);margin-bottom:.3em;font-weight:300;letter-spacing:.15em}
+#blocker p{color:#aaa;font-size:1.1em;margin:.2em 0}
+#blocker .key{display:inline-block;background:#333;border:1px solid #555;border-radius:4px;padding:2px 8px;color:#e0d6c2;font-family:monospace}
+#blocker button{margin-top:1.5em;padding:.7em 2.5em;font-size:1.1em;background:linear-gradient(135deg,#5a4a3a,#8a7a5a);color:#fff;border:1px solid #aa9a7a;border-radius:8px;cursor:pointer;letter-spacing:.1em}
+#blocker button:hover{background:linear-gradient(135deg,#7a6a4a,#aa9a6a)}
+#crosshair{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);pointer-events:none;z-index:5}
+#crosshair::before,#crosshair::after{content:'';position:absolute;background:rgba(255,255,255,.7)}
+#crosshair::before{width:20px;height:2px;left:-10px;top:-1px}
+#crosshair::after{width:2px;height:20px;left:-1px;top:-10px}
+#hud{position:fixed;bottom:20px;left:50%;transform:translateX(-50%);display:flex;gap:4px;z-index:5}
+.slot{width:50px;height:50px;border:2px solid rgba(255,255,255,.3);background:rgba(0,0,0,.5);display:flex;align-items:center;justify-content:center;border-radius:4px}
+.slot.active{border-color:#fff;background:rgba(255,255,255,.15)}
+.slot canvas{width:36px;height:36px;image-rendering:pixelated}
+#info{position:fixed;top:10px;left:10px;color:#fff;font-size:13px;z-index:5;text-shadow:1px 1px 2px #000;line-height:1.6}
+</style>
+</head>
+<body>
+<div id="blocker">
+<h1>MYTHOS CRAFT</h1>
+<p><span class="key">W</span><span class="key">A</span><span class="key">S</span><span class="key">D</span> Move &nbsp; <span class="key">Space</span> Jump &nbsp; Mouse Look</p>
+<p>Left Click: Break Block &nbsp; Right Click: Place Block</p>
+<p><span class="key">1</span>-<span class="key">6</span> Select Block Type</p>
+<button id="startBtn">Enter World</button>
+</div>
+<div id="crosshair" style="display:none"></div>
+<div id="hud" style="display:none"></div>
+<div id="info" style="display:none"></div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+<script>
+// ═══════════════════════════════════════════
+//  MYTHOS CRAFT — Single-file Voxel World
+// ═══════════════════════════════════════════
+
+// ── Perlin Noise (classic 3D) ──
+const Noise=(()=>{const p=[];const perm=new Uint8Array(512);
+const grad3=[[1,1,0],[-1,1,0],[1,-1,0],[-1,-1,0],[1,0,1],[-1,0,1],[1,0,-1],[-1,0,-1],[0,1,1],[0,-1,1],[0,1,-1],[0,-1,-1]];
+function seed(s){const r=()=>(s=(s*16807+0)%2147483647,(s-1)/2147483646);for(let i=0;i<256;i++)p[i]=i;
+for(let i=255;i>0;i--){const j=Math.floor(r()*(i+1));[p[i],p[j]]=[p[j],p[i]]}for(let i=0;i<512;i++)perm[i]=p[i&255]}
+seed(42);
+function dot3(g,x,y,z){return g[0]*x+g[1]*y+g[2]*z}
+function fade(t){return t*t*t*(t*(t*6-15)+10)}
+function lerp(a,b,t){return a+t*(b-a)}
+function noise3(x,y,z){const X=Math.floor(x)&255,Y=Math.floor(y)&255,Z=Math.floor(z)&255;
+x-=Math.floor(x);y-=Math.floor(y);z-=Math.floor(z);
+const u=fade(x),v=fade(y),w=fade(z);
+const A=perm[X]+Y,AA=perm[A]+Z,AB=perm[A+1]+Z,B=perm[X+1]+Y,BA=perm[B]+Z,BB=perm[B+1]+Z;
+return lerp(lerp(lerp(dot3(grad3[perm[AA]%12],x,y,z),dot3(grad3[perm[BA]%12],x-1,y,z),u),
+lerp(dot3(grad3[perm[AB]%12],x,y-1,z),dot3(grad3[perm[BB]%12],x-1,y-1,z),u),v),
+lerp(lerp(dot3(grad3[perm[AA+1]%12],x,y,z-1),dot3(grad3[perm[BA+1]%12],x-1,y,z-1),u),
+lerp(dot3(grad3[perm[AB+1]%12],x,y-1,z-1),dot3(grad3[perm[BB+1]%12],x-1,y-1,z-1),u),v),w)}
+function fbm(x,y,z,oct=4){let v=0,a=1,f=1,t=0;for(let i=0;i<oct;i++){v+=a*noise3(x*f,y*f,z*f);t+=a;a*=.5;f*=2}return v/t}
+return{noise3,fbm,seed}})();
+
+// ── Block Types ──
+const BLOCK={AIR:0,GRASS:1,DIRT:2,STONE:3,SAND:4,WOOD:5,LEAVES:6,WATER:7,SNOW:8,GOLD:9,CRYSTAL:10,OBSIDIAN:11,MOSSY_STONE:12,SANDSTONE:13};
+const BLOCK_NAMES=['Air','Grass','Dirt','Stone','Sand','Wood','Leaves','Water','Snow','Gold','Crystal','Obsidian','Mossy Stone','Sandstone'];
+const BLOCK_COLORS={
+[BLOCK.GRASS]:[0x5a8f29,0x8B6914,0x8B6914],
+[BLOCK.DIRT]:[0x8B6914,0x8B6914,0x8B6914],
+[BLOCK.STONE]:[0x808080,0x808080,0x808080],
+[BLOCK.SAND]:[0xd4b96c,0xd4b96c,0xd4b96c],
+[BLOCK.WOOD]:[0x8B5A2B,0x6B3A1B,0x8B5A2B],
+[BLOCK.LEAVES]:[0x2d7a2d,0x2d7a2d,0x2d7a2d],
+[BLOCK.WATER]:[0x3388cc,0x3388cc,0x3388cc],
+[BLOCK.SNOW]:[0xf0f0f0,0xe0e0e0,0xf0f0f0],
+[BLOCK.GOLD]:[0xffd700,0xffd700,0xffd700],
+[BLOCK.CRYSTAL]:[0x88ccff,0x88ccff,0xaaeeff],
+[BLOCK.OBSIDIAN]:[0x1a0a2e,0x1a0a2e,0x1a0a2e],
+[BLOCK.MOSSY_STONE]:[0x556B2F,0x808080,0x808080],
+[BLOCK.SANDSTONE]:[0xc4a95a,0xb49a4a,0xc4a95a]
+};
+
+// ── Texture Generator ──
+function makeTex(fn,sz=16){
+const c=document.createElement('canvas');c.width=c.height=sz;
+const ctx=c.getContext('2d');fn(ctx,sz);
+const tex=new THREE.CanvasTexture(c);tex.magFilter=THREE.NearestFilter;tex.minFilter=THREE.NearestFilter;return tex}
+
+function noiseFill(ctx,sz,baseCol,variance){
+const id=ctx.createImageData(sz,sz);
+const r0=(baseCol>>16)&255,g0=(baseCol>>8)&255,b0=baseCol&255;
+for(let i=0;i<sz*sz;i++){const v=(Math.random()-.5)*variance;
+id.data[i*4]=Math.max(0,Math.min(255,r0+v));id.data[i*4+1]=Math.max(0,Math.min(255,g0+v));
+id.data[i*4+2]=Math.max(0,Math.min(255,b0+v));id.data[i*4+3]=255}ctx.putImageData(id,0,0)}
+
+const textures={};
+function initTextures(){
+textures[BLOCK.GRASS]={
+top:makeTex((c,s)=>{noiseFill(c,s,0x5a8f29,30);for(let i=0;i<20;i++){c.fillStyle=`rgba(80,160,40,${Math.random()*.3})`;c.fillRect(Math.random()*s|0,Math.random()*s|0,1,1)}}),
+side:makeTex((c,s)=>{noiseFill(c,s,0x8B6914,20);c.fillStyle='#5a8f29';c.fillRect(0,0,s,3);noiseFill(c,s,0x7a5910,15)}),
+bottom:makeTex((c,s)=>noiseFill(c,s,0x8B6914,20))};
+textures[BLOCK.DIRT]={all:makeTex((c,s)=>noiseFill(c,s,0x8B6914,25))};
+textures[BLOCK.STONE]={all:makeTex((c,s)=>{noiseFill(c,s,0x808080,30);c.strokeStyle='rgba(0,0,0,0.15)';c.lineWidth=1;c.beginPath();c.moveTo(0,s/2);c.lineTo(s,s/2);c.moveTo(s/3,0);c.lineTo(s/3,s);c.stroke()})};
+textures[BLOCK.SAND]={all:makeTex((c,s)=>noiseFill(c,s,0xd4b96c,15))};
+textures[BLOCK.WOOD]={
+top:makeTex((c,s)=>{noiseFill(c,s,0x6B3A1B,15);c.strokeStyle='rgba(100,60,20,0.4)';c.beginPath();c.arc(s/2,s/2,4,0,Math.PI*2);c.stroke()}),
+side:makeTex((c,s)=>{noiseFill(c,s,0x8B5A2B,15);for(let y=0;y<s;y+=3){c.fillStyle=`rgba(60,30,10,${.1+Math.random()*.1})`;c.fillRect(0,y,s,1)}})};
+textures[BLOCK.LEAVES]={all:makeTex((c,s)=>{noiseFill(c,s,0x2d7a2d,35);for(let i=0;i<30;i++){c.fillStyle=`rgba(${20+Math.random()*40|0},${100+Math.random()*60|0},${20+Math.random()*30|0},.5)`;c.fillRect(Math.random()*s|0,Math.random()*s|0,2,2)}})};
+textures[BLOCK.SNOW]={all:makeTex((c,s)=>noiseFill(c,s,0xf0f0f0,8))};
+textures[BLOCK.GOLD]={all:makeTex((c,s)=>{noiseFill(c,s,0xffd700,20);c.fillStyle='rgba(255,240,150,.3)';c.fillRect(3,3,4,4);c.fillRect(9,8,5,3)})};
+textures[BLOCK.CRYSTAL]={all:makeTex((c,s)=>{noiseFill(c,s,0x88ccff,20);c.fillStyle='rgba(200,230,255,.4)';c.beginPath();c.moveTo(s/2,0);c.lineTo(s,s/2);c.lineTo(s/2,s);c.lineTo(0,s/2);c.fill()})};
+textures[BLOCK.OBSIDIAN]={all:makeTex((c,s)=>{noiseFill(c,s,0x1a0a2e,15);c.fillStyle='rgba(80,40,120,.2)';c.fillRect(2,5,6,3);c.fillRect(8,10,5,4)})};
+textures[BLOCK.MOSSY_STONE]={all:makeTex((c,s)=>{noiseFill(c,s,0x808080,25);c.fillStyle='rgba(60,120,30,.35)';for(let i=0;i<8;i++)c.fillRect(Math.random()*s|0,Math.random()*s|0,3,2)})};
+textures[BLOCK.SANDSTONE]={all:makeTex((c,s)=>{noiseFill(c,s,0xc4a95a,18);c.strokeStyle='rgba(0,0,0,.1)';c.beginPath();c.moveTo(0,s/3);c.lineTo(s,s/3);c.moveTo(0,s*2/3);c.lineTo(s,s*2/3);c.stroke()})};
+}
+
+function getBlockMaterials(bt){
+const t=textures[bt];if(!t)return null;
+if(t.all){const m=new THREE.MeshLambertMaterial({map:t.all});return[m,m,m,m,m,m]}
+const mats=[];
+const sideM=t.side?new THREE.MeshLambertMaterial({map:t.side}):new THREE.MeshLambertMaterial({map:t.top});
+mats.push(sideM,sideM, // +x -x
+new THREE.MeshLambertMaterial({map:t.top}),new THREE.MeshLambertMaterial({map:t.bottom||t.top}),
+sideM,sideM); // +z -z
+return mats}
+
+// ── World Config ──
+const CHUNK_SIZE=16,WORLD_HEIGHT=64,SEA_LEVEL=20,RENDER_DIST=4;
+const world=new Map();
+function key(x,y,z){return `${x},${y},${z}`}
+function getBlock(x,y,z){return world.get(key(x,y,z))||BLOCK.AIR}
+function setBlock(x,y,z,b){if(b===BLOCK.AIR)world.delete(key(x,y,z));else world.set(key(x,y,z),b)}
+
+// ── Terrain Generation ──
+function getHeight(wx,wz){
+const s1=.008,s2=.025,s3=.06;
+let h=Noise.fbm(wx*s1,0,wz*s1,5)*30;
+h+=Noise.fbm(wx*s2,10,wz*s2,3)*12;
+h+=Noise.fbm(wx*s3,20,wz*s3,2)*5;
+return Math.floor(h+28)}
+
+function generateChunkTerrain(cx,cz){
+for(let x=0;x<CHUNK_SIZE;x++)for(let z=0;z<CHUNK_SIZE;z++){
+const wx=cx*CHUNK_SIZE+x,wz=cz*CHUNK_SIZE+z;
+const h=getHeight(wx,wz);
+for(let y=0;y<=Math.min(h,WORLD_HEIGHT-1);y++){
+let bt;
+if(y===h){bt=h>38?BLOCK.SNOW:h>SEA_LEVEL?BLOCK.GRASS:BLOCK.SAND}
+else if(y>h-4)bt=h>SEA_LEVEL?BLOCK.DIRT:BLOCK.SAND;
+else bt=BLOCK.STONE;
+setBlock(wx,y,wz,bt)}
+// Water
+for(let y=h+1;y<=SEA_LEVEL;y++){setBlock(wx,y,wz,BLOCK.WATER)}
+// Trees
+if(h>SEA_LEVEL+1&&h<36&&Math.random()<.012){placeTree(wx,h,wz)}
+}}
+
+function placeTree(x,y,z){
+const th=4+Math.floor(Math.random()*3);
+for(let i=1;i<=th;i++)setBlock(x,y+i,z,BLOCK.WOOD);
+for(let dx=-2;dx<=2;dx++)for(let dz=-2;dz<=2;dz++)for(let dy=0;dy<=2;dy++){
+if(Math.abs(dx)+Math.abs(dz)+dy>4)continue;
+if(dx===0&&dz===0&&dy<2)continue;
+if(getBlock(x+dx,y+th+dy,z+dz)===BLOCK.AIR)setBlock(x+dx,y+th+dy,z+dz,BLOCK.LEAVES)}
+}
+
+// ── Mythic Structures ──
+function placeWizardTower(bx,by,bz){
+const h=18+Math.floor(Math.random()*8);
+for(let y=0;y<h;y++){const r=y<h-3?2:1;
+for(let dx=-r;dx<=r;dx++)for(let dz=-r;dz<=r;dz++){
+if(dx*dx+dz*dz<=r*r+1)setBlock(bx+dx,by+y,bz+dz,BLOCK.MOSSY_STONE)}}
+// Roof cone
+for(let y=0;y<5;y++){const r=3-y;
+for(let dx=-r;dx<=r;dx++)for(let dz=-r;dz<=r;dz++){
+if(dx*dx+dz*dz<=r*r)setBlock(bx+dx,by+h+y,bz+dz,BLOCK.OBSIDIAN)}}
+// Gold tip
+setBlock(bx,by+h+5,bz,BLOCK.GOLD);setBlock(bx,by+h+6,bz,BLOCK.GOLD);
+// Windows (crystal)
+for(let y=4;y<h;y+=4){setBlock(bx+2,by+y,bz,BLOCK.CRYSTAL);setBlock(bx-2,by+y,bz,BLOCK.CRYSTAL);
+setBlock(bx,by+y,bz+2,BLOCK.CRYSTAL);setBlock(bx,by+y,bz-2,BLOCK.CRYSTAL)}
+// Floating orbs
+for(let i=0;i<4;i++){const a=i*Math.PI/2;
+setBlock(bx+Math.round(Math.cos(a)*4),by+h+2,bz+Math.round(Math.sin(a)*4),BLOCK.CRYSTAL)}
+}
+
+function placeAncientTemple(bx,by,bz){
+const w=7,d=5,h=8;
+// Platform
+for(let dx=-w;dx<=w;dx++)for(let dz=-d;dz<=d;dz++){setBlock(bx+dx,by,bz+dz,BLOCK.SANDSTONE);setBlock(bx+dx,by-1,bz+dz,BLOCK.SANDSTONE)}
+// Columns
+const colPos=[[-w+1,-d+1],[w-1,-d+1],[-w+1,d-1],[w-1,d-1],[-w+1,0],[w-1,0],[0,-d+1],[0,d-1]];
+colPos.forEach(([cx,cz])=>{for(let y=1;y<=h;y++)setBlock(bx+cx,by+y,bz+cz,BLOCK.SANDSTONE);
+setBlock(bx+cx,by+h+1,bz+cz,BLOCK.GOLD)});
+// Roof
+for(let dx=-w;dx<=w;dx++)for(let dz=-d;dz<=d;dz++)setBlock(bx+dx,by+h+1,bz+dz,BLOCK.SANDSTONE);
+// Inner sanctum
+for(let dx=-2;dx<=2;dx++)for(let dz=-2;dz<=2;dz++){
+if(Math.abs(dx)===2||Math.abs(dz)===2){for(let y=1;y<=4;y++)setBlock(bx+dx,by+y,bz+dz,BLOCK.OBSIDIAN)}
+else setBlock(bx+dx,by+1,bz+dz,BLOCK.GOLD)}
+setBlock(bx,by+2,bz,BLOCK.CRYSTAL);setBlock(bx,by+3,bz,BLOCK.CRYSTAL);
+}
+
+function placeGiantTree(bx,by,bz){
+// Massive trunk
+for(let y=0;y<20;y++){const r=y<15?2:1;
+for(let dx=-r;dx<=r;dx++)for(let dz=-r;dz<=r;dz++)setBlock(bx+dx,by+y,bz+dz,BLOCK.WOOD)}
+// Giant canopy
+for(let dx=-8;dx<=8;dx++)for(let dz=-8;dz<=8;dz++)for(let dy=0;dy<=6;dy++){
+const dist=Math.sqrt(dx*dx+dz*dz+dy*dy*2);
+if(dist<7&&Math.random()>.15)setBlock(bx+dx,by+18+dy,bz+dz,BLOCK.LEAVES)}
+// Glowing fruits
+for(let i=0;i<12;i++){const a=Math.random()*Math.PI*2,r2=3+Math.random()*4;
+const fx=bx+Math.round(Math.cos(a)*r2),fz=bz+Math.round(Math.sin(a)*r2),fy=by+18+Math.floor(Math.random()*5);
+if(getBlock(fx,fy,fz)===BLOCK.LEAVES)setBlock(fx,fy,fz,BLOCK.GOLD)}
+}
+
+function placeDragonNest(bx,by,bz){
+// Obsidian ring
+for(let a=0;a<Math.PI*2;a+=.3){const r=5;
+for(let dy=-1;dy<=1;dy++)setBlock(bx+Math.round(Math.cos(a)*r),by+dy,bz+Math.round(Math.sin(a)*r),BLOCK.OBSIDIAN)}
+// Lava center (gold blocks as lava)
+for(let dx=-3;dx<=3;dx++)for(let dz=-3;dz<=3;dz++){if(dx*dx+dz*dz<=10)setBlock(bx+dx,by-1,bz+dz,BLOCK.GOLD)}
+// Crystal spikes
+for(let i=0;i<6;i++){const a=i*Math.PI/3,r=4;
+const sx=bx+Math.round(Math.cos(a)*r),sz=bz+Math.round(Math.sin(a)*r);
+for(let y=0;y<3+Math.floor(Math.random()*3);y++)setBlock(sx,by+y,sz,BLOCK.CRYSTAL)}
+// Dragon eggs
+setBlock(bx,by,bz,BLOCK.OBSIDIAN);setBlock(bx,by+1,bz,BLOCK.OBSIDIAN);setBlock(bx,by+2,bz,BLOCK.CRYSTAL);
+}
+
+function placeRunicCircle(bx,by,bz){
+const r=8;
+for(let a=0;a<Math.PI*2;a+=.15){
+const x=bx+Math.round(Math.cos(a)*r),z=bz+Math.round(Math.sin(a)*r);
+setBlock(x,by,z,BLOCK.OBSIDIAN);setBlock(x,by+1,z,BLOCK.CRYSTAL)}
+// Inner runes
+for(let a=0;a<Math.PI*2;a+=.5){const r2=4;
+const x=bx+Math.round(Math.cos(a)*r2),z=bz+Math.round(Math.sin(a)*r2);
+setBlock(x,by,z,BLOCK.GOLD)}
+// Pillars at cardinal points
+for(let i=0;i<4;i++){const a=i*Math.PI/2;
+const px=bx+Math.round(Math.cos(a)*r),pz=bz+Math.round(Math.sin(a)*r);
+for(let y=0;y<6;y++)setBlock(px,by+y,pz,BLOCK.MOSSY_STONE);
+setBlock(px,by+6,pz,BLOCK.CRYSTAL)}
+}
+
+function placeMythicStructures(cx,cz){
+const rng=Noise.noise3(cx*.1,100,cz*.1);
+if(rng>.3){const wx=cx*CHUNK_SIZE+8,wz=cz*CHUNK_SIZE+8,h=getHeight(wx,wz);
+if(h>SEA_LEVEL+2){
+const r=Noise.noise3(cx*.3,200,cz*.3);
+if(r>0.4)placeWizardTower(wx,h+1,wz);
+else if(r>0.1)placeAncientTemple(wx,h+1,wz);
+else if(r>-0.1)placeGiantTree(wx,h+1,wz);
+else if(r>-0.3)placeDragonNest(wx,h+1,wz);
+else placeRunicCircle(wx,h+1,wz);
+}}}
+
+// ── Chunk Meshing ──
+const chunkMeshes=new Map();
+const geo=new THREE.BoxGeometry(1,1,1);
+
+function chunkKey(cx,cz){return `${cx},${cz}`}
+
+function isTransparent(x,y,z){const b=getBlock(x,y,z);return b===BLOCK.AIR||b===BLOCK.WATER||b===BLOCK.LEAVES}
+
+function buildChunkMesh(cx,cz,scene){
+const old=chunkMeshes.get(chunkKey(cx,cz));
+if(old){old.forEach(m=>{scene.remove(m);m.geometry.dispose()});chunkMeshes.delete(chunkKey(cx,cz))}
+
+const meshesByType=new Map();
+const ox=cx*CHUNK_SIZE,oz=cz*CHUNK_SIZE;
+
+for(let x=0;x<CHUNK_SIZE;x++)for(let z=0;z<CHUNK_SIZE;z++)for(let y=0;y<WORLD_HEIGHT;y++){
+const wx=ox+x,wz=oz+z;const bt=getBlock(wx,y,wz);if(bt===BLOCK.AIR)continue;
+// Face culling
+const faces=[];
+if(isTransparent(wx+1,y,wz))faces.push(0);if(isTransparent(wx-1,y,wz))faces.push(1);
+if(isTransparent(wx,y+1,wz))faces.push(2);if(isTransparent(wx,y-1,wz))faces.push(3);
+if(isTransparent(wx,y,wz+1))faces.push(4);if(isTransparent(wx,y,wz-1))faces.push(5);
+if(faces.length===0)continue;
+if(!meshesByType.has(bt))meshesByType.set(bt,[]);
+meshesByType.get(bt).push({x:wx,y,z:wz,faces})}
+
+const meshes=[];
+meshesByType.forEach((blocks,bt)=>{
+const mats=getBlockMaterials(bt);if(!mats)return;
+const isWater=bt===BLOCK.WATER;
+if(isWater)mats.forEach(m=>{m.transparent=true;m.opacity=.6});
+const isLeaf=bt===BLOCK.LEAVES;
+if(isLeaf)mats.forEach(m=>{m.transparent=true;m.opacity=.9;m.side=THREE.DoubleSide});
+
+// Use instanced mesh for performance
+const count=blocks.length;
+const instMesh=new THREE.InstancedMesh(geo,mats.length===1?mats[0]:mats,count);
+const dummy=new THREE.Object3D();
+let idx=0;
+blocks.forEach(b=>{dummy.position.set(b.x,b.y,b.z);dummy.updateMatrix();instMesh.setMatrixAt(idx++,dummy.matrix)});
+instMesh.instanceMatrix.needsUpdate=true;
+instMesh.castShadow=!isWater;instMesh.receiveShadow=true;
+if(isWater)instMesh.renderOrder=1;
+scene.add(instMesh);meshes.push(instMesh)});
+chunkMeshes.set(chunkKey(cx,cz),meshes)}
+
+// ── Scene Setup ──
+const renderer=new THREE.WebGLRenderer({antialias:true});
+renderer.setSize(window.innerWidth,window.innerHeight);
+renderer.setPixelRatio(Math.min(window.devicePixelRatio,2));
+renderer.shadowMap.enabled=true;
+renderer.shadowMap.type=THREE.PCFSoftShadowMap;
+document.body.appendChild(renderer.domElement);
+
+const scene=new THREE.Scene();
+scene.background=new THREE.Color(0x87CEEB);
+scene.fog=new THREE.Fog(0x87CEEB,RENDER_DIST*CHUNK_SIZE*.5,RENDER_DIST*CHUNK_SIZE*.9);
+
+const camera=new THREE.PerspectiveCamera(75,window.innerWidth/window.innerHeight,.1,1000);
+camera.position.set(8,45,8);
+
+// Lighting
+const ambientLight=new THREE.AmbientLight(0x666688,.6);scene.add(ambientLight);
+const sunLight=new THREE.DirectionalLight(0xffeedd,1.0);
+sunLight.position.set(50,80,30);sunLight.castShadow=true;
+sunLight.shadow.mapSize.set(2048,2048);
+sunLight.shadow.camera.left=-60;sunLight.shadow.camera.right=60;
+sunLight.shadow.camera.top=60;sunLight.shadow.camera.bottom=-60;
+sunLight.shadow.camera.far=200;
+scene.add(sunLight);
+const hemiLight=new THREE.HemisphereLight(0x87CEEB,0x8B6914,.3);scene.add(hemiLight);
+
+// ── Player Controller ──
+const player={pos:new THREE.Vector3(8,45,8),vel:new THREE.Vector3(),onGround:false,yaw:0,pitch:0,height:1.7,speed:6,jumpForce:8};
+const keys={};let isLocked=false;
+
+document.addEventListener('keydown',e=>{keys[e.code]=true;
+if(e.code>='Digit1'&&e.code<='Digit9'){selectedSlot=parseInt(e.code[5])-1;updateHUD()}});
+document.addEventListener('keyup',e=>keys[e.code]=false);
+
+document.addEventListener('pointerlockchange',()=>{isLocked=!!document.pointerLockElement;
+document.getElementById('blocker').style.display=isLocked?'none':'flex';
+document.getElementById('crosshair').style.display=isLocked?'block':'none';
+document.getElementById('hud').style.display=isLocked?'flex':'none';
+document.getElementById('info').style.display=isLocked?'block':'none'});
+
+document.addEventListener('mousemove',e=>{if(!isLocked)return;
+player.yaw-=e.movementX*.002;player.pitch-=e.movementY*.002;
+player.pitch=Math.max(-Math.PI/2+.01,Math.min(Math.PI/2-.01,player.pitch))});
+
+// ── Block Interaction ──
+let selectedSlot=0;
+const hotbar=[BLOCK.GRASS,BLOCK.DIRT,BLOCK.STONE,BLOCK.SAND,BLOCK.WOOD,BLOCK.OBSIDIAN];
+const raycaster=new THREE.Raycaster();
+raycaster.far=8;
+
+function raycast(){
+raycaster.set(camera.position,new THREE.Vector3(0,0,-1).applyQuaternion(camera.quaternion));
+const hits=[];const step=.05;
+for(let t=0;t<8;t+=step){
+const p=raycaster.ray.origin.clone().add(raycaster.ray.direction.clone().multiplyScalar(t));
+const bx=Math.round(p.x),by=Math.round(p.y),bz=Math.round(p.z);
+const b=getBlock(bx,by,bz);
+if(b!==BLOCK.AIR&&b!==BLOCK.WATER){
+// Find previous position for placement
+const pp=raycaster.ray.origin.clone().add(raycaster.ray.direction.clone().multiplyScalar(t-step));
+return{hit:{x:bx,y:by,z:bz,block:b},place:{x:Math.round(pp.x),y:Math.round(pp.y),z:Math.round(pp.z)}}}
+}return null}
+
+document.addEventListener('mousedown',e=>{if(!isLocked)return;
+const r=raycast();if(!r)return;
+if(e.button===0){// Break
+setBlock(r.hit.x,r.hit.y,r.hit.z,BLOCK.AIR);rebuildNearby(r.hit.x,r.hit.z)}
+else if(e.button===2){// Place
+const b=hotbar[selectedSlot]||BLOCK.STONE;
+if(getBlock(r.place.x,r.place.y,r.place.z)===BLOCK.AIR||getBlock(r.place.x,r.place.y,r.place.z)===BLOCK.WATER){
+setBlock(r.place.x,r.place.y,r.place.z,b);rebuildNearby(r.place.x,r.place.z)}}});
+document.addEventListener('contextmenu',e=>e.preventDefault());
+
+function rebuildNearby(wx,wz){
+const cx=Math.floor(wx/CHUNK_SIZE),cz=Math.floor(wz/CHUNK_SIZE);
+buildChunkMesh(cx,cz,scene);
+const lx=wx-cx*CHUNK_SIZE,lz=wz-cz*CHUNK_SIZE;
+if(lx===0)buildChunkMesh(cx-1,cz,scene);
+if(lx===CHUNK_SIZE-1)buildChunkMesh(cx+1,cz,scene);
+if(lz===0)buildChunkMesh(cx,cz-1,scene);
+if(lz===CHUNK_SIZE-1)buildChunkMesh(cx,cz+1,scene)}
+
+// ── HUD ──
+function initHUD(){
+const hud=document.getElementById('hud');hud.innerHTML='';
+hotbar.forEach((bt,i)=>{
+const slot=document.createElement('div');slot.className='slot'+(i===selectedSlot?' active':'');
+const c=document.createElement('canvas');c.width=c.height=16;const ctx=c.getContext('2d');
+const col=BLOCK_COLORS[bt];if(col){const cc=Array.isArray(col)?col[0]:col;
+ctx.fillStyle='#'+cc.toString(16).padStart(6,'0');ctx.fillRect(0,0,16,16);
+ctx.strokeStyle='rgba(0,0,0,.3)';ctx.strokeRect(0,0,16,16)}
+slot.appendChild(c);slot.title=BLOCK_NAMES[bt];hud.appendChild(slot)})}
+
+function updateHUD(){
+const slots=document.querySelectorAll('.slot');
+slots.forEach((s,i)=>s.className='slot'+(i===selectedSlot?' active':''))}
+
+// ── Physics & Update ──
+const gravity=20;
+function collidesAt(x,y,z){
+const hw=.3;
+for(let dx=-1;dx<=1;dx++)for(let dy=0;dy<=2;dy++)for(let dz=-1;dz<=1;dz++){
+const bx=Math.round(x+dx*hw),by=Math.round(y+dy*.85),bz=Math.round(z+dz*hw);
+const b=getBlock(bx,by,bz);if(b!==BLOCK.AIR&&b!==BLOCK.WATER)return true}return false}
+
+function updatePlayer(dt){
+if(!isLocked)return;
+dt=Math.min(dt,.05);
+const fwd=new THREE.Vector3(-Math.sin(player.yaw),0,-Math.cos(player.yaw));
+const right=new THREE.Vector3(Math.cos(player.yaw),0,-Math.sin(player.yaw));
+const move=new THREE.Vector3();
+if(keys['KeyW'])move.add(fwd);if(keys['KeyS'])move.sub(fwd);
+if(keys['KeyA'])move.sub(right);if(keys['KeyD'])move.add(right);
+if(move.length()>.01)move.normalize();
+player.vel.x=move.x*player.speed;player.vel.z=move.z*player.speed;
+player.vel.y-=gravity*dt;
+if(keys['Space']&&player.onGround){player.vel.y=player.jumpForce;player.onGround=false}
+
+// Move with collision
+const nx=player.pos.x+player.vel.x*dt;
+if(!collidesAt(nx,player.pos.y,player.pos.z))player.pos.x=nx;else player.vel.x=0;
+const nz=player.pos.z+player.vel.z*dt;
+if(!collidesAt(player.pos.x,player.pos.y,nz))player.pos.z=nz;else player.vel.z=0;
+const ny=player.pos.y+player.vel.y*dt;
+if(!collidesAt(player.pos.x,ny,player.pos.z))player.pos.y=ny;
+else{if(player.vel.y<0)player.onGround=true;player.vel.y=0}
+if(player.pos.y<-10){player.pos.set(8,45,8);player.vel.set(0,0,0)}
+
+camera.position.set(player.pos.x,player.pos.y+player.height,player.pos.z);
+camera.rotation.order='YXZ';camera.rotation.y=player.yaw;camera.rotation.x=player.pitch;
+
+// Update sun shadow camera to follow player
+sunLight.position.set(player.pos.x+50,80,player.pos.z+30);
+sunLight.target.position.copy(player.pos);scene.add(sunLight.target)}
+
+// ── World Management ──
+const loadedChunks=new Set();
+function updateChunks(){
+const pcx=Math.floor(player.pos.x/CHUNK_SIZE),pcz=Math.floor(player.pos.z/CHUNK_SIZE);
+const needed=new Set();
+for(let dx=-RENDER_DIST;dx<=RENDER_DIST;dx++)for(let dz=-RENDER_DIST;dz<=RENDER_DIST;dz++){
+if(dx*dx+dz*dz>RENDER_DIST*RENDER_DIST)continue;
+const cx=pcx+dx,cz=pcz+dz;const ck=chunkKey(cx,cz);needed.add(ck);
+if(!loadedChunks.has(ck)){
+generateChunkTerrain(cx,cz);placeMythicStructures(cx,cz);
+buildChunkMesh(cx,cz,scene);loadedChunks.add(ck)}}
+// Unload distant chunks
+loadedChunks.forEach(ck=>{if(!needed.has(ck)){
+const[cx,cz]=ck.split(',').map(Number);
+const old=chunkMeshes.get(ck);
+if(old){old.forEach(m=>{scene.remove(m);m.geometry.dispose()});chunkMeshes.delete(ck)}
+loadedChunks.delete(ck)}})}
+
+// ── Skybox extras ──
+// Sun sphere
+const sunGeo=new THREE.SphereGeometry(3,16,16);
+const sunMat=new THREE.MeshBasicMaterial({color:0xffee88});
+const sunMesh=new THREE.Mesh(sunGeo,sunMat);scene.add(sunMesh);
+
+// Clouds
+const cloudGroup=new THREE.Group();
+for(let i=0;i<25;i++){
+const cGeo=new THREE.BoxGeometry(8+Math.random()*12,1.5,6+Math.random()*8);
+const cMat=new THREE.MeshLambertMaterial({color:0xffffff,transparent:true,opacity:.8});
+const cloud=new THREE.Mesh(cGeo,cMat);
+cloud.position.set((Math.random()-.5)*300,50+Math.random()*10,(Math.random()-.5)*300);
+cloudGroup.add(cloud)}
+scene.add(cloudGroup);
+
+// ── Info Display ──
+const infoEl=document.getElementById('info');
+let frameCount=0,lastFpsTime=performance.now(),fps=0;
+
+// ── Game Loop ──
+let lastTime=performance.now();
+let chunkUpdateTimer=0;
+
+function animate(){
+requestAnimationFrame(animate);
+const now=performance.now(),dt=(now-lastTime)/1000;lastTime=now;
+
+frameCount++;if(now-lastFpsTime>500){fps=Math.round(frameCount/((now-lastFpsTime)/1000));frameCount=0;lastFpsTime=now}
+
+updatePlayer(dt);
+
+chunkUpdateTimer+=dt;
+if(chunkUpdateTimer>.5){chunkUpdateTimer=0;updateChunks()}
+
+// Move clouds
+cloudGroup.children.forEach(c=>{c.position.x+=dt*.5;if(c.position.x>150)c.position.x=-150});
+
+// Sun position
+sunMesh.position.set(player.pos.x+80,65,player.pos.z+50);
+
+// Info
+if(infoEl)infoEl.innerHTML=`FPS: ${fps}<br>Pos: ${player.pos.x.toFixed(1)}, ${player.pos.y.toFixed(1)}, ${player.pos.z.toFixed(1)}<br>Block: ${BLOCK_NAMES[hotbar[selectedSlot]]||'?'}`;
+
+renderer.render(scene,camera)}
+
+// ── Init ──
+document.getElementById('startBtn').addEventListener('click',()=>renderer.domElement.requestPointerLock());
+window.addEventListener('resize',()=>{camera.aspect=window.innerWidth/window.innerHeight;camera.updateProjectionMatrix();renderer.setSize(window.innerWidth,window.innerHeight)});
+
+initTextures();initHUD();
+
+// Generate initial chunks
+for(let dx=-2;dx<=2;dx++)for(let dz=-2;dz<=2;dz++){
+const ck=chunkKey(dx,dz);generateChunkTerrain(dx,dz);placeMythicStructures(dx,dz);
+buildChunkMesh(dx,dz,scene);loadedChunks.add(ck)}
+
+// Place player on terrain
+const spawnH=getHeight(8,8);player.pos.set(8,spawnH+3,8);
+
+animate();
+</script>
+</body>
+</html>

--- a/outputs/qwen3-7-max/qoderwork-default/pelican-cycling.svg
+++ b/outputs/qwen3-7-max/qoderwork-default/pelican-cycling.svg
@@ -1,0 +1,456 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" width="800" height="600">
+  <defs>
+    <!-- Sky gradient -->
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1a3a6a"/>
+      <stop offset="35%" stop-color="#4a8abf"/>
+      <stop offset="65%" stop-color="#87CEEB"/>
+      <stop offset="100%" stop-color="#b8dff0"/>
+    </linearGradient>
+    <!-- Sea gradient -->
+    <linearGradient id="sea" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2a6a9a"/>
+      <stop offset="40%" stop-color="#3a88b8"/>
+      <stop offset="100%" stop-color="#5ab0d8"/>
+    </linearGradient>
+    <!-- Sand gradient -->
+    <linearGradient id="sand" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#e8d5a0"/>
+      <stop offset="100%" stop-color="#d4b96c"/>
+    </linearGradient>
+    <!-- Sun glow -->
+    <radialGradient id="sunGlow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#fff8e0" stop-opacity="1"/>
+      <stop offset="40%" stop-color="#ffe880" stop-opacity=".8"/>
+      <stop offset="100%" stop-color="#ffcc00" stop-opacity="0"/>
+    </radialGradient>
+    <!-- Pelican body gradient -->
+    <linearGradient id="pelicanBody" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f5f0e8"/>
+      <stop offset="50%" stop-color="#e8e0d0"/>
+      <stop offset="100%" stop-color="#d0c8b8"/>
+    </linearGradient>
+    <!-- Beak gradient -->
+    <linearGradient id="beakGrad" x1="0" y1="0" x2="1" y2="0.3">
+      <stop offset="0%" stop-color="#f0a830"/>
+      <stop offset="60%" stop-color="#e89020"/>
+      <stop offset="100%" stop-color="#d07818"/>
+    </linearGradient>
+    <!-- Pouch gradient -->
+    <linearGradient id="pouchGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f0a830"/>
+      <stop offset="100%" stop-color="#e07828"/>
+    </linearGradient>
+    <!-- Bicycle frame gradient -->
+    <linearGradient id="bikeFrame" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#cc2222"/>
+      <stop offset="50%" stop-color="#aa1818"/>
+      <stop offset="100%" stop-color="#881010"/>
+    </linearGradient>
+    <!-- Tire gradient -->
+    <radialGradient id="tire" cx="50%" cy="50%" r="50%">
+      <stop offset="70%" stop-color="#222"/>
+      <stop offset="85%" stop-color="#333"/>
+      <stop offset="100%" stop-color="#1a1a1a"/>
+    </radialGradient>
+    <!-- Water reflection -->
+    <linearGradient id="waterReflect" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fff" stop-opacity=".15"/>
+      <stop offset="100%" stop-color="#fff" stop-opacity="0"/>
+    </linearGradient>
+    <!-- Wing feather gradient -->
+    <linearGradient id="wingFeather" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c8c0b0"/>
+      <stop offset="100%" stop-color="#a09888"/>
+    </linearGradient>
+    <!-- Cloud filter -->
+    <filter id="cloudBlur">
+      <feGaussianBlur stdDeviation="3"/>
+    </filter>
+    <filter id="softShadow">
+      <feDropShadow dx="2" dy="3" stdDeviation="3" flood-color="#00000040"/>
+    </filter>
+  </defs>
+
+  <!-- ═══ SKY ═══ -->
+  <rect width="800" height="600" fill="url(#sky)"/>
+
+  <!-- Sun -->
+  <circle cx="650" cy="120" r="80" fill="url(#sunGlow)"/>
+  <circle cx="650" cy="120" r="32" fill="#fff8e0"/>
+  <circle cx="650" cy="120" r="28" fill="#fffae8"/>
+
+  <!-- Sun rays -->
+  <g opacity=".2" stroke="#ffdd66" stroke-width="1.5" fill="none">
+    <line x1="650" y1="60" x2="650" y2="30"/>
+    <line x1="690" y1="80" x2="715" y2="60"/>
+    <line x1="710" y1="120" x2="740" y2="120"/>
+    <line x1="690" y1="160" x2="715" y2="180"/>
+    <line x1="650" y1="180" x2="650" y2="210"/>
+    <line x1="610" y1="160" x2="585" y2="180"/>
+    <line x1="590" y1="120" x2="560" y2="120"/>
+    <line x1="610" y1="80" x2="585" y2="60"/>
+  </g>
+
+  <!-- Clouds -->
+  <g filter="url(#cloudBlur)" opacity=".85">
+    <ellipse cx="150" cy="90" rx="70" ry="22" fill="#fff"/>
+    <ellipse cx="180" cy="80" rx="50" ry="18" fill="#fff"/>
+    <ellipse cx="120" cy="85" rx="40" ry="15" fill="#f8f8f8"/>
+    <ellipse cx="450" cy="70" rx="80" ry="20" fill="#fff"/>
+    <ellipse cx="480" cy="60" rx="55" ry="16" fill="#fff"/>
+    <ellipse cx="420" cy="65" rx="45" ry="14" fill="#f0f0f0"/>
+    <ellipse cx="300" cy="130" rx="45" ry="12" fill="#fff" opacity=".6"/>
+    <ellipse cx="720" cy="55" rx="50" ry="15" fill="#fff" opacity=".7"/>
+  </g>
+
+  <!-- Distant mountains -->
+  <g opacity=".4">
+    <path d="M0 350 L80 280 L150 310 L220 260 L300 290 L380 250 L450 280 L520 240 L580 270 L650 230 L720 260 L800 240 L800 380 L0 380Z" fill="#4a6a8a"/>
+    <path d="M0 360 L60 320 L130 340 L200 300 L280 330 L360 290 L440 320 L500 290 L570 310 L640 280 L710 300 L800 270 L800 380 L0 380Z" fill="#5a7a9a"/>
+  </g>
+
+  <!-- ═══ SEA ═══ -->
+  <rect x="0" y="370" width="800" height="120" fill="url(#sea)"/>
+
+  <!-- Waves -->
+  <g fill="none" stroke="#fff" stroke-width="1" opacity=".3">
+    <path d="M0 385 Q50 380 100 385 Q150 390 200 385 Q250 380 300 385 Q350 390 400 385 Q450 380 500 385 Q550 390 600 385 Q650 380 700 385 Q750 390 800 385"/>
+    <path d="M0 400 Q40 395 80 400 Q120 405 160 400 Q200 395 240 400 Q280 405 320 400 Q360 395 400 400 Q440 405 480 400 Q520 395 560 400 Q600 405 640 400 Q680 395 720 400 Q760 405 800 400"/>
+    <path d="M0 420 Q60 415 120 420 Q180 425 240 420 Q300 415 360 420 Q420 425 480 420 Q540 415 600 420 Q660 425 720 420 Q780 415 800 420"/>
+    <path d="M0 445 Q70 440 140 445 Q210 450 280 445 Q350 440 420 445 Q490 450 560 445 Q630 440 700 445 Q770 450 800 445"/>
+  </g>
+
+  <!-- Water shimmer -->
+  <g opacity=".15">
+    <ellipse cx="500" cy="400" rx="60" ry="3" fill="#fff"/>
+    <ellipse cx="600" cy="420" rx="40" ry="2" fill="#fff"/>
+    <ellipse cx="350" cy="430" rx="50" ry="2.5" fill="#fff"/>
+    <ellipse cx="650" cy="390" rx="30" ry="2" fill="#fff"/>
+  </g>
+
+  <!-- Sun reflection on water -->
+  <g opacity=".2">
+    <ellipse cx="650" cy="390" rx="25" ry="4" fill="#ffe880"/>
+    <ellipse cx="650" cy="410" rx="18" ry="3" fill="#ffe880"/>
+    <ellipse cx="650" cy="430" rx="12" ry="2.5" fill="#ffe880"/>
+    <ellipse cx="650" cy="450" rx="8" ry="2" fill="#ffe880"/>
+  </g>
+
+  <!-- Seagulls -->
+  <g fill="none" stroke="#fff" stroke-width="1.5" stroke-linecap="round">
+    <path d="M180 180 Q188 172 196 178 M196 178 Q204 172 212 180"/>
+    <path d="M250 150 Q256 144 262 148 M262 148 Q268 144 274 150"/>
+    <path d="M550 160 Q557 153 564 157 M564 157 Q571 153 578 160"/>
+    <path d="M120 200 Q125 195 130 198 M130 198 Q135 195 140 200" stroke-width="1"/>
+    <path d="M680 175 Q685 170 690 173 M690 173 Q695 170 700 175" stroke-width="1"/>
+  </g>
+
+  <!-- ═══ BEACH/SHORE ═══ -->
+  <path d="M0 470 Q100 460 200 465 Q400 458 600 462 Q700 460 800 465 L800 600 L0 600Z" fill="url(#sand)"/>
+
+  <!-- Shore foam -->
+  <path d="M0 470 Q100 460 200 465 Q400 458 600 462 Q700 460 800 465" fill="none" stroke="#fff" stroke-width="2.5" opacity=".5"/>
+  <path d="M0 475 Q80 468 180 472 Q380 465 580 469 Q700 467 800 472" fill="none" stroke="#fff" stroke-width="1.5" opacity=".3"/>
+
+  <!-- Sand texture dots -->
+  <g fill="#c8a858" opacity=".3">
+    <circle cx="100" cy="510" r="1.2"/><circle cx="150" cy="530" r="1"/><circle cx="200" cy="500" r="1.5"/>
+    <circle cx="250" cy="540" r="1"/><circle cx="350" cy="520" r="1.3"/><circle cx="450" cy="505" r="1.2"/>
+    <circle cx="550" cy="535" r="1"/><circle cx="600" cy="515" r="1.5"/><circle cx="680" cy="525" r="1.2"/>
+    <circle cx="720" cy="500" r="1"/><circle cx="50" cy="540" r="1.2"/><circle cx="400" cy="550" r="1"/>
+    <circle cx="300" cy="570" r="1.3"/><circle cx="500" cy="560" r="1.2"/><circle cx="650" cy="555" r="1"/>
+  </g>
+
+  <!-- Small shells/pebbles on beach -->
+  <g opacity=".4">
+    <ellipse cx="120" cy="515" rx="4" ry="2.5" fill="#d8c8a0" transform="rotate(-15,120,515)"/>
+    <ellipse cx="480" cy="525" rx="3" ry="2" fill="#c8b890" transform="rotate(20,480,525)"/>
+    <ellipse cx="650" cy="510" rx="3.5" ry="2" fill="#d0c098" transform="rotate(-10,650,510)"/>
+    <circle cx="300" cy="530" r="2" fill="#b8a878"/>
+  </g>
+
+  <!-- ═══ BICYCLE ═══ -->
+  <g filter="url(#softShadow)">
+    <!-- Shadow on ground -->
+    <ellipse cx="380" cy="530" rx="90" ry="8" fill="#00000020"/>
+
+    <!-- Rear wheel -->
+    <g>
+      <circle cx="310" cy="490" r="42" fill="none" stroke="#222" stroke-width="5"/>
+      <circle cx="310" cy="490" r="39" fill="none" stroke="#333" stroke-width="1"/>
+      <circle cx="310" cy="490" r="36" fill="none" stroke="#2a2a2a" stroke-width=".5"/>
+      <!-- Spokes -->
+      <g stroke="#aaa" stroke-width=".7" opacity=".8">
+        <line x1="310" y1="452" x2="310" y2="480"/>
+        <line x1="310" y1="500" x2="310" y2="528"/>
+        <line x1="272" y1="490" x2="300" y2="490"/>
+        <line x1="320" y1="490" x2="348" y2="490"/>
+        <line x1="280" y1="460" x2="302" y2="482"/>
+        <line x1="318" y1="498" x2="340" y2="520"/>
+        <line x1="340" y1="460" x2="318" y2="482"/>
+        <line x1="302" y1="498" x2="280" y2="520"/>
+        <line x1="286" y1="472" x2="304" y2="484"/>
+        <line x1="316" y1="496" x2="334" y2="508"/>
+        <line x1="334" y1="472" x2="316" y2="484"/>
+        <line x1="304" y1="496" x2="286" y2="508"/>
+      </g>
+      <!-- Hub -->
+      <circle cx="310" cy="490" r="5" fill="#666"/>
+      <circle cx="310" cy="490" r="3" fill="#888"/>
+    </g>
+
+    <!-- Front wheel -->
+    <g>
+      <circle cx="460" cy="490" r="42" fill="none" stroke="#222" stroke-width="5"/>
+      <circle cx="460" cy="490" r="39" fill="none" stroke="#333" stroke-width="1"/>
+      <circle cx="460" cy="490" r="36" fill="none" stroke="#2a2a2a" stroke-width=".5"/>
+      <!-- Spokes -->
+      <g stroke="#aaa" stroke-width=".7" opacity=".8">
+        <line x1="460" y1="452" x2="460" y2="480"/>
+        <line x1="460" y1="500" x2="460" y2="528"/>
+        <line x1="422" y1="490" x2="450" y2="490"/>
+        <line x1="470" y1="490" x2="498" y2="490"/>
+        <line x1="430" y1="460" x2="452" y2="482"/>
+        <line x1="468" y1="498" x2="490" y2="520"/>
+        <line x1="490" y1="460" x2="468" y2="482"/>
+        <line x1="452" y1="498" x2="430" y2="520"/>
+        <line x1="436" y1="472" x2="454" y2="484"/>
+        <line x1="466" y1="496" x2="484" y2="508"/>
+        <line x1="484" y1="472" x2="466" y2="484"/>
+        <line x1="454" y1="496" x2="436" y2="508"/>
+      </g>
+      <!-- Hub -->
+      <circle cx="460" cy="490" r="5" fill="#666"/>
+      <circle cx="460" cy="490" r="3" fill="#888"/>
+    </g>
+
+    <!-- Frame -->
+    <g stroke="url(#bikeFrame)" stroke-width="4.5" stroke-linecap="round" fill="none">
+      <!-- Chain stay (rear hub to bottom bracket) -->
+      <line x1="310" y1="490" x2="380" y2="475"/>
+      <!-- Seat stay (rear hub to seat tube top) -->
+      <line x1="310" y1="490" x2="370" y2="420"/>
+      <!-- Seat tube -->
+      <line x1="370" y1="420" x2="380" y2="475"/>
+      <!-- Down tube (bottom bracket to head tube bottom) -->
+      <line x1="380" y1="475" x2="440" y2="430"/>
+      <!-- Top tube -->
+      <line x1="370" y1="420" x2="440" y2="425"/>
+      <!-- Head tube -->
+      <line x1="440" y1="425" x2="440" y2="435"/>
+    </g>
+
+    <!-- Fork -->
+    <g stroke="#aa1818" stroke-width="3.5" stroke-linecap="round" fill="none">
+      <line x1="440" y1="430" x2="460" y2="490"/>
+      <line x1="442" y1="432" x2="462" y2="490"/>
+    </g>
+
+    <!-- Handlebar stem -->
+    <line x1="440" y1="425" x2="445" y2="405" stroke="#555" stroke-width="3" stroke-linecap="round"/>
+
+    <!-- Handlebars -->
+    <g stroke="#444" stroke-width="3" stroke-linecap="round" fill="none">
+      <path d="M430 400 Q437 395 445 400 Q453 395 460 400"/>
+      <!-- Grips -->
+      <line x1="427" y1="400" x2="433" y2="400" stroke="#222" stroke-width="5"/>
+      <line x1="457" y1="400" x2="463" y2="400" stroke="#222" stroke-width="5"/>
+    </g>
+
+    <!-- Seat post -->
+    <line x1="370" y1="420" x2="365" y2="405" stroke="#555" stroke-width="3" stroke-linecap="round"/>
+
+    <!-- Seat/Saddle -->
+    <ellipse cx="365" cy="402" rx="18" ry="5" fill="#2a2a2a"/>
+    <ellipse cx="362" cy="401" rx="12" ry="3.5" fill="#3a3a3a"/>
+    <path d="M350 402 Q365 396 380 402" fill="#2a2a2a" stroke="#222" stroke-width=".5"/>
+
+    <!-- Bottom bracket / Crank -->
+    <circle cx="380" cy="475" r="6" fill="#555"/>
+    <circle cx="380" cy="475" r="4" fill="#777"/>
+
+    <!-- Chain ring -->
+    <circle cx="380" cy="475" r="12" fill="none" stroke="#666" stroke-width="1.5"/>
+
+    <!-- Pedal cranks -->
+    <line x1="380" y1="475" x2="368" y2="490" stroke="#555" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="380" y1="475" x2="392" y2="460" stroke="#555" stroke-width="2.5" stroke-linecap="round"/>
+
+    <!-- Pedals -->
+    <rect x="362" y="488" width="12" height="4" rx="1" fill="#333"/>
+    <rect x="386" y="457" width="12" height="4" rx="1" fill="#333"/>
+
+    <!-- Chain -->
+    <path d="M392 475 Q400 483 392 490 L320 490 Q312 483 320 476" fill="none" stroke="#555" stroke-width="1.2" stroke-dasharray="2,1.5"/>
+  </g>
+
+  <!-- ═══ PELICAN ═══ -->
+  <g filter="url(#softShadow)">
+    <!-- Tail feathers -->
+    <g>
+      <path d="M305 410 Q280 395 270 405 Q285 400 300 415" fill="#c8c0b0" stroke="#a8a090" stroke-width=".5"/>
+      <path d="M308 405 Q275 388 268 398 Q282 393 303 410" fill="#d0c8b8" stroke="#a8a090" stroke-width=".5"/>
+      <path d="M310 415 Q285 402 278 412 Q290 407 308 420" fill="#bab2a2" stroke="#a8a090" stroke-width=".5"/>
+    </g>
+
+    <!-- Body -->
+    <ellipse cx="370" cy="395" rx="65" ry="35" fill="url(#pelicanBody)" stroke="#c0b8a8" stroke-width=".5"/>
+
+    <!-- Body feather details -->
+    <g stroke="#c0b8a8" stroke-width=".4" fill="none" opacity=".5">
+      <path d="M325 385 Q340 382 355 385"/>
+      <path d="M330 390 Q345 387 360 390"/>
+      <path d="M335 395 Q350 392 365 395"/>
+      <path d="M340 400 Q355 397 370 400"/>
+      <path d="M345 405 Q360 402 375 405"/>
+    </g>
+
+    <!-- Wing (folded, resting on body) -->
+    <path d="M330 380 Q360 360 410 375 Q400 385 370 390 Q345 392 330 385Z" fill="url(#wingFeather)" stroke="#a8a090" stroke-width=".7"/>
+    <!-- Wing feather details -->
+    <g stroke="#a09080" stroke-width=".5" fill="none" opacity=".6">
+      <path d="M340 382 Q365 372 395 378"/>
+      <path d="M338 386 Q360 378 390 382"/>
+      <path d="M335 380 L345 375"/>
+      <path d="M350 378 L360 373"/>
+      <path d="M365 377 L375 374"/>
+      <path d="M380 378 L390 376"/>
+    </g>
+
+    <!-- Neck -->
+    <path d="M410 385 Q425 370 435 340 Q440 320 438 300 Q435 285 430 275" fill="url(#pelicanBody)" stroke="#c0b8a8" stroke-width="1"/>
+    <path d="M420 390 Q435 375 445 345 Q448 325 445 305 Q442 290 437 278" fill="url(#pelicanBody)" stroke="#c0b8a8" stroke-width=".5"/>
+
+    <!-- Neck feather texture -->
+    <g stroke="#d0c8b8" stroke-width=".4" fill="none" opacity=".4">
+      <path d="M418 380 Q428 370 435 355"/>
+      <path d="M422 370 Q432 360 438 345"/>
+      <path d="M428 355 Q435 345 440 335"/>
+      <path d="M432 340 Q438 330 442 320"/>
+    </g>
+
+    <!-- Head -->
+    <ellipse cx="432" cy="268" rx="20" ry="16" fill="#f5f0e8" stroke="#c0b8a8" stroke-width=".5"/>
+
+    <!-- Eye -->
+    <circle cx="440" cy="263" r="5" fill="#fff" stroke="#888" stroke-width=".5"/>
+    <circle cx="441" cy="262" r="3" fill="#1a1a2a"/>
+    <circle cx="442" cy="261" r="1.2" fill="#fff"/>
+    <!-- Eye ring -->
+    <circle cx="440" cy="263" r="6.5" fill="none" stroke="#6888a8" stroke-width="1" opacity=".5"/>
+
+    <!-- Head crest/tuft -->
+    <g stroke="#c8c0b0" stroke-width="1.2" fill="none" opacity=".7">
+      <path d="M420 258 Q415 248 418 240"/>
+      <path d="M423 256 Q419 245 423 237"/>
+      <path d="M417 260 Q411 252 414 244"/>
+    </g>
+
+    <!-- Upper beak (long, characteristic pelican beak) -->
+    <path d="M448 265 Q480 258 510 262 Q520 264 525 268 Q520 270 510 270 Q480 272 452 272Z" fill="url(#beakGrad)" stroke="#c08020" stroke-width=".8"/>
+    <!-- Beak ridge line -->
+    <line x1="450" y1="267" x2="520" y2="266" stroke="#d09030" stroke-width=".6" opacity=".5"/>
+    <!-- Beak tip hook -->
+    <path d="M522 266 Q527 264 525 268 Q524 270 520 270" fill="#d07818" stroke="#b06810" stroke-width=".5"/>
+
+    <!-- Lower beak -->
+    <path d="M448 272 Q480 275 510 272 Q508 275 500 278 Q480 282 455 278Z" fill="#e89828" stroke="#c08020" stroke-width=".5"/>
+
+    <!-- Pouch (the distinctive pelican throat pouch) -->
+    <path d="M440 275 Q455 280 475 282 Q490 283 500 280 Q495 295 475 302 Q455 308 440 300 Q430 292 432 282Z" fill="url(#pouchGrad)" stroke="#d08020" stroke-width=".7" opacity=".85"/>
+    <!-- Pouch texture lines -->
+    <g stroke="#c87820" stroke-width=".4" fill="none" opacity=".4">
+      <path d="M445 282 Q460 288 480 286"/>
+      <path d="M442 290 Q458 296 478 293"/>
+      <path d="M445 298 Q460 302 475 299"/>
+    </g>
+
+    <!-- Legs -->
+    <!-- Left leg (on pedal) -->
+    <path d="M355 425 Q350 450 355 470 Q358 480 365 488" stroke="#e8a040" stroke-width="3" fill="none" stroke-linecap="round"/>
+    <!-- Right leg (on other pedal) -->
+    <path d="M375 420 Q385 440 390 455 Q393 460 392 460" stroke="#e8a040" stroke-width="3" fill="none" stroke-linecap="round"/>
+
+    <!-- Feet/webbed toes on pedals -->
+    <!-- Left foot -->
+    <g fill="#e8a040" stroke="#c88030" stroke-width=".5">
+      <path d="M360 487 L355 493 L362 492 L368 494 L372 490 L365 488Z"/>
+    </g>
+    <!-- Right foot -->
+    <g fill="#e8a040" stroke="#c88030" stroke-width=".5">
+      <path d="M388 458 L384 464 L390 463 L396 465 L400 461 L394 459Z"/>
+    </g>
+
+    <!-- Wing holding handlebar (front wing tip) -->
+    <path d="M410 380 Q430 385 440 395 Q445 398 448 400" fill="none" stroke="#c0b8a8" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M448 398 L445 402 L450 401 L454 403 L452 399Z" fill="#c8c0b0" stroke="#a8a090" stroke-width=".5"/>
+  </g>
+
+  <!-- ═══ MOTION LINES ═══ -->
+  <g stroke="#888" stroke-width="1" opacity=".3" stroke-linecap="round">
+    <line x1="240" y1="475" x2="215" y2="475"/>
+    <line x1="240" y1="485" x2="210" y2="485"/>
+    <line x1="240" y1="495" x2="218" y2="495"/>
+    <line x1="240" y1="505" x2="220" y2="505"/>
+    <line x1="240" y1="465" x2="222" y2="465"/>
+  </g>
+
+  <!-- Dust/sand particles from wheels -->
+  <g fill="#d4b96c" opacity=".3">
+    <circle cx="260" cy="520" r="2"/>
+    <circle cx="250" cy="515" r="1.5"/>
+    <circle cx="255" cy="525" r="1.8"/>
+    <circle cx="245" cy="510" r="1.2"/>
+    <circle cx="265" cy="528" r="1"/>
+    <circle cx="248" cy="522" r="1.3"/>
+  </g>
+
+  <!-- ═══ FOREGROUND DETAILS ═══ -->
+  <!-- Starfish -->
+  <g transform="translate(100,555) scale(.7)" fill="#d08858" stroke="#b07040" stroke-width=".5">
+    <path d="M0 -12 L3 -4 L12 -4 L5 2 L7 10 L0 5 L-7 10 L-5 2 L-12 -4 L-3 -4Z"/>
+  </g>
+
+  <!-- Small crab -->
+  <g transform="translate(620,545)" opacity=".7">
+    <ellipse rx="6" ry="4" fill="#c85838"/>
+    <circle cx="-3" cy="-3" r="1.5" fill="#222"/>
+    <circle cx="3" cy="-3" r="1.5" fill="#222"/>
+    <line x1="-6" y1="-1" x2="-12" y2="-4" stroke="#c85838" stroke-width="1.2"/>
+    <line x1="6" y1="-1" x2="12" y2="-4" stroke="#c85838" stroke-width="1.2"/>
+    <line x1="-12" y1="-4" x2="-14" y2="-7" stroke="#c85838" stroke-width="1"/>
+    <line x1="12" y1="-4" x2="14" y2="-7" stroke="#c85838" stroke-width="1"/>
+    <line x1="-5" y1="2" x2="-8" y2="5" stroke="#c85838" stroke-width=".8"/>
+    <line x1="-4" y1="3" x2="-6" y2="6" stroke="#c85838" stroke-width=".8"/>
+    <line x1="5" y1="2" x2="8" y2="5" stroke="#c85838" stroke-width=".8"/>
+    <line x1="4" y1="3" x2="6" y2="6" stroke="#c85838" stroke-width=".8"/>
+  </g>
+
+  <!-- Distant sailboat -->
+  <g transform="translate(180,370)" opacity=".5">
+    <rect x="-8" y="0" width="16" height="4" rx="2" fill="#8a6a4a"/>
+    <line x1="0" y1="0" x2="0" y2="-20" stroke="#8a6a4a" stroke-width="1"/>
+    <path d="M0 -20 L0 -2 L12 -8Z" fill="#fff" stroke="#ddd" stroke-width=".5"/>
+    <path d="M0 -18 L0 -3 L-8 -8Z" fill="#f8f8f8" stroke="#ddd" stroke-width=".5"/>
+  </g>
+
+  <!-- Palm tree on far right -->
+  <g transform="translate(740,460)">
+    <path d="M0 0 Q-3 -40 2 -80 Q5 -100 3 -120" stroke="#8B6914" stroke-width="6" fill="none" stroke-linecap="round"/>
+    <path d="M3 -120 Q-20 -115 -40 -100" stroke="#2d7a2d" stroke-width="3" fill="none" stroke-linecap="round"/>
+    <path d="M3 -120 Q20 -110 35 -95" stroke="#2d7a2d" stroke-width="3" fill="none" stroke-linecap="round"/>
+    <path d="M3 -120 Q-10 -130 -30 -125" stroke="#3a8a3a" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <path d="M3 -120 Q15 -128 30 -120" stroke="#3a8a3a" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <path d="M3 -120 Q0 -135 -5 -140" stroke="#2d7a2d" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <!-- Coconuts -->
+    <circle cx="0" cy="-118" r="3" fill="#6a4a2a"/>
+    <circle cx="5" cy="-116" r="2.5" fill="#7a5a3a"/>
+  </g>
+
+  <!-- ═══ WATER EDGE DETAIL ═══ -->
+  <g opacity=".15">
+    <path d="M0 472 Q50 468 100 472 Q200 466 300 470 Q400 465 500 468 Q600 464 700 468 Q750 466 800 470" fill="none" stroke="#5ab0d8" stroke-width="3"/>
+  </g>
+
+</svg>


### PR DESCRIPTION
## 运行说明 / Run info

- 模型 / Model: Qwen3.7-Max
- 运行框架 / Harness: QoderWork (desktop AI assistant)
- 思维等级 / Thinking effort: Default
- 是否一次成型 / One-shot? 是 / Yes，两个产出物均为一次生成、未修改的原始输出

## 产出物 / Artifacts

- **mythos-craft.html** (25.5 KB) — Three.js r128 体素世界：Perlin 噪声地形（5 级 FBM）、区块加载、第一人称 WASD+鼠标、6 种方块、5 类神话建筑（巫师塔/古神殿/巨树/龙巢/符文阵）
- **pelican-cycling.svg** (21.2 KB, 281 elements) — 海边鹈鹕骑行场景：渐变天空/海面/沙滩、远山帆船海鸥、棕榈树海星螃蟹、鹈鹕羽毛细节+大嘴喉囊、红色自行车辐条链条

## Checklist

- [x] `models/qwen3-7-max-qoderwork.json` 含 `harness` 和 `effort` 字段
- [x] 每个 run 的 `note` 双语（zh + en）填写完整
- [x] `contributor` 为 GitHub 用户名 FFFxueGawaine
- [x] 已运行 `bun scripts/update-registry.ts` 刷新 README Registry 表
- [x] 已运行 `bun scripts/validate-data.ts` 验证通过（43 models, 2 cases）

附带 DeepSeek-V4-Pro WorkBuddy 第二版 mythos-craft 变体。