### PR TITLE
Add GLM-5.2 (Cursor · High) runs for all three cases

### DIFF
--- a/models/glm-5-2-cursor.json
+++ b/models/glm-5-2-cursor.json
@@ -1,0 +1,31 @@
+{
+  "label": "GLM-5.2",
+  "vendor": "Zhipu AI",
+  "harness": "Cursor",
+  "effort": "High",
+  "artifactDir": "glm-5-2/cursor-high",
+  "order": 119.5,
+  "runs": {
+    "mythos-craft": {
+      "note": {
+        "zh": "在 Cursor 中以 GLM-5.2（High 思考配额）一次生成，本页为未经修改的原始产出。",
+        "en": "Generated in one shot by GLM-5.2 (High effort) inside Cursor; unmodified original output."
+      },
+      "contributor": "Mist-wu"
+    },
+    "pelican-cycling": {
+      "note": {
+        "zh": "在 Cursor 中以 GLM-5.2（High 思考配额）一次生成，本页为未经修改的原始 SVG 产出。",
+        "en": "Generated in one shot by GLM-5.2 (High effort) inside Cursor; unmodified original SVG output."
+      },
+      "contributor": "Mist-wu"
+    },
+    "skeleton-watch": {
+      "note": {
+        "zh": "在 Cursor 中以 GLM-5.2（High 思考配额）一次生成，未进行任何修改。",
+        "en": "Generated in one shot by GLM-5.2 (High effort) inside Cursor, unmodified."
+      },
+      "contributor": "Mist-wu"
+    }
+  }
+}

--- a/outputs/glm-5-2/cursor-high/mythos-craft.html
+++ b/outputs/glm-5-2/cursor-high/mythos-craft.html
@@ -1,0 +1,922 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MythosCraft — 神话方块世界</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html, body { width: 100%; height: 100%; overflow: hidden; background: #0a0e1a;
+    font-family: 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', sans-serif; color: #e8eefc; user-select: none; }
+  #c { display: block; width: 100%; height: 100%; cursor: none; }
+
+  /* 准星 */
+  #crosshair { position: fixed; left: 50%; top: 50%; transform: translate(-50%,-50%);
+    width: 24px; height: 24px; pointer-events: none; mix-blend-mode: difference; z-index: 10; }
+  #crosshair::before, #crosshair::after { content:''; position:absolute; background:#fff; box-shadow:0 0 1px #000; }
+  #crosshair::before { left:50%; top:0; width:2px; height:100%; transform:translateX(-50%); }
+  #crosshair::after  { top:50%; left:0; height:2px; width:100%; transform:translateY(-50%); }
+
+  /* 物品栏 */
+  #hotbar { position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%);
+    display: flex; gap: 5px; padding: 6px; background: rgba(0,0,0,0.5);
+    border: 2px solid rgba(0,0,0,0.7); border-radius: 7px; z-index: 10;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.5); }
+  .slot { width: 52px; height: 52px; border: 2px solid rgba(255,255,255,0.15);
+    background: rgba(35,38,52,0.55); border-radius: 4px; position: relative;
+    display:flex; align-items:center; justify-content:center; cursor: pointer;
+    transition: border-color .12s, transform .12s; }
+  .slot.active { border-color: #ffcf4d; box-shadow: 0 0 12px rgba(255,207,77,0.65); transform: translateY(-3px); }
+  .slot canvas { width: 38px; height: 38px; image-rendering: pixelated; border-radius: 3px; }
+  .slot .num { position:absolute; top:1px; left:3px; font-size:11px; color:#fff; text-shadow:1px 1px 0 #000; }
+  .slot .name { position:absolute; bottom:-18px; left:50%; transform:translateX(-50%); font-size:11px;
+    white-space:nowrap; opacity:0; transition:opacity .15s; text-shadow:1px 1px 0 #000; }
+  .slot.active .name { opacity: 1; }
+
+  /* HUD */
+  #hud { position: fixed; top: 10px; left: 12px; z-index: 10; font-size: 12.5px; line-height: 1.55;
+    text-shadow: 1px 1px 0 #000; background: rgba(0,0,0,0.32); padding: 8px 12px; border-radius: 6px; }
+  #hud b { color: #ffcf4d; }
+  #compass { position: fixed; top: 10px; left: 50%; transform: translateX(-50%); z-index: 10;
+    background: rgba(0,0,0,0.38); padding: 5px 16px; border-radius: 18px; font-size: 13px;
+    letter-spacing: 3px; text-shadow: 1px 1px 0 #000; }
+  #tip { position: fixed; bottom: 84px; left: 50%; transform: translateX(-50%); z-index: 10;
+    font-size: 12px; color: #cfd8ee; text-shadow: 1px 1px 0 #000; opacity: 0.82; pointer-events: none; }
+
+  /* 加载/开始遮罩 */
+  #overlay { position: fixed; inset: 0; z-index: 50; display: flex; align-items: center; justify-content: center;
+    background: radial-gradient(ellipse at center, rgba(20,28,55,0.86), rgba(4,7,18,0.97));
+    backdrop-filter: blur(3px); text-align: center; transition: opacity .45s; }
+  #overlay.hidden { opacity: 0; pointer-events: none; }
+  .panel { max-width: 680px; padding: 38px 42px; }
+  .panel h1 { font-size: 48px; letter-spacing: 8px; margin-bottom: 4px;
+    background: linear-gradient(180deg,#fff,#bcd7ff 55%,#7fa8ff); -webkit-background-clip: text;
+    background-clip: text; -webkit-text-fill-color: transparent; text-shadow: 0 2px 30px rgba(90,140,255,0.45); }
+  .panel .sub { font-size: 13px; letter-spacing: 9px; color: #8aa6d8; margin-bottom: 28px; }
+  .panel p { font-size: 14px; line-height: 1.95; color: #cdd9f0; margin-bottom: 18px; }
+  .panel .keys { display: grid; grid-template-columns: repeat(2,1fr); gap: 6px 22px; text-align: left;
+    font-size: 13px; color: #b8c4e4; margin: 10px auto 26px; max-width: 460px; }
+  .panel .keys b { display:inline-block; min-width: 78px; color:#ffcf4d; }
+  .btn { display: inline-block; padding: 13px 38px; font-size: 15px; letter-spacing: 4px; cursor: pointer;
+    background: linear-gradient(180deg,#3a64c8,#26408a); border: 2px solid #4a78e0; border-radius: 6px;
+    color: #fff; transition: transform .15s, box-shadow .15s; text-shadow: 1px 1px 0 rgba(0,0,0,0.4); }
+  .btn:hover { transform: translateY(-2px); box-shadow: 0 8px 22px rgba(70,120,240,0.55); }
+  .loader { font-size: 13px; color: #8aa6d8; letter-spacing: 3px; margin-top: 18px; }
+
+  /* 破坏进度 */
+  #break { position: fixed; left: 50%; top: 50%; transform: translate(-50%,-50%); width: 56px; height: 56px;
+    z-index: 11; pointer-events: none; opacity: 0; transition: opacity .1s; }
+  #break svg { width: 100%; height: 100%; }
+</style>
+</head>
+<body>
+<canvas id="c"></canvas>
+<div id="crosshair"></div>
+<div id="break"><svg viewBox="0 0 56 56"><circle cx="28" cy="28" r="24" fill="none" stroke="rgba(0,0,0,0.5)" stroke-width="4"/><circle id="breakArc" cx="28" cy="28" r="24" fill="none" stroke="#ffcf4d" stroke-width="4" stroke-linecap="round" stroke-dasharray="150.8" stroke-dashoffset="150.8" transform="rotate(-90 28 28)"/></svg></div>
+
+<div id="hotbar"></div>
+<div id="hud"></div>
+<div id="compass">N</div>
+<div id="tip">左键破坏 · 右键放置 · 滚轮/数字键切换方块 · 双击全屏</div>
+
+<div id="overlay">
+  <div class="panel">
+    <h1>MYTHOSCRAFT</h1>
+    <div class="sub">神 话 方 块 世 界</div>
+    <p>在一片由古老神祇塑造的无尽大陆上，矗立着失落的神殿、悬浮的法师塔、巨龙骨脊与水晶圣坛。
+       柏林噪声雕琢山川河海，而你——旅人——可徒手重塑这片方块大地。</p>
+    <div class="keys">
+      <span><b>WASD</b> 移动</span><span><b>空格</b> 跳跃</span>
+      <span><b>Shift</b> 下蹲/缓行</span><span><b>鼠标</b> 环视</span>
+      <span><b>左键</b> 破坏方块</span><span><b>右键</b> 放置方块</span>
+      <span><b>滚轮/1-9</b> 选方块</span><span><b>F</b> 切换飞行</span>
+      <span><b>R</b> 回到神殿</span><span><b>ESC</b> 释放鼠标</span>
+    </div>
+    <div class="btn" id="startBtn">进 入 世 界</div>
+    <div class="loader" id="loader">正在召唤方块世界…</div>
+  </div>
+</div>
+
+<script type="importmap">
+{ "imports": { "three": "https://unpkg.com/three@0.160.0/build/three.module.js" } }
+</script>
+<script type="module">
+import * as THREE from 'three';
+
+// ─────────────────────────────────────────────────────────────
+//  基础常量
+// ─────────────────────────────────────────────────────────────
+const CHUNK = 16;          // 区块边长（X / Z）
+const WORLD_H = 48;        // 世界最大高度
+const SEA = 14;            // 海平面
+const VIEW = 5;            // 视距（区块数，每边）→ (2*VIEW+1)^2 区块
+const HALF = VIEW * CHUNK; // 半个渲染范围（方块）
+
+// 方块类型
+const B = {
+  AIR:0, GRASS:1, DIRT:2, STONE:3, SAND:4, WOOD:5, LEAF:6,
+  PLANK:7, COBBLE:8, BRICK:9, GOLD:10, OBSIDIAN:11, CRYSTAL:12,
+  SNOW:13, WATER:14, LAVA:15, MARBLE:16, BONE:17, MOSS:18, GLOW:19
+};
+
+// 方块元数据：颜色（顶/侧/底 用于程序化纹理）、是否透明、是否发光、硬度
+const DEF = {
+  [B.GRASS]:   { top:[96,176,64],  side:[120,86,56],  bot:[120,86,56],  hard:0.6, name:'草地' },
+  [B.DIRT]:    { top:[134,96,62],  side:[134,96,62],  bot:[120,84,52],  hard:0.5, name:'泥土' },
+  [B.STONE]:   { top:[128,128,134],side:[116,116,122],bot:[100,100,106],hard:1.5, name:'石头' },
+  [B.SAND]:    { top:[228,214,158],side:[214,198,140],bot:[196,180,128],hard:0.4, name:'沙子' },
+  [B.WOOD]:    { top:[160,120,66], side:[96,66,38],   bot:[160,120,66], hard:1.0, name:'原木' },
+  [B.LEAF]:    { top:[58,128,46],  side:[48,108,38],  bot:[40,92,32],   hard:0.2, name:'树叶', alpha:0.92 },
+  [B.PLANK]:   { top:[176,134,80], side:[176,134,80], bot:[160,120,70], hard:1.0, name:'木板' },
+  [B.COBBLE]:  { top:[120,120,124],side:[104,104,108],bot:[92,92,96],   hard:1.4, name:'圆石' },
+  [B.BRICK]:   { top:[150,60,48],  side:[140,52,42],  bot:[120,46,38],  hard:1.6, name:'红砖' },
+  [B.GOLD]:    { top:[240,200,70], side:[224,184,56], bot:[200,162,44], hard:2.0, name:'金块', metal:true },
+  [B.OBSIDIAN]:{ top:[28,22,44],   side:[24,18,38],   bot:[20,16,32],   hard:3.0, name:'黑曜石' },
+  [B.CRYSTAL]: { top:[120,200,255],side:[110,184,250],bot:[96,168,236], hard:1.2, name:'水晶', alpha:0.55, glow:true },
+  [B.SNOW]:    { top:[242,246,252],side:[232,236,244],bot:[214,220,230],hard:0.3, name:'雪块' },
+  [B.WATER]:   { top:[54,110,200], side:[44,96,184],  bot:[40,86,170],  hard:0,  name:'水', alpha:0.55, fluid:true },
+  [B.LAVA]:    { top:[238,120,30], side:[214,92,20],  bot:[180,72,16],  hard:0,  name:'岩浆', glow:true, fluid:true },
+  [B.MARBLE]:  { top:[236,234,240],side:[220,218,226],bot:[200,198,208],hard:1.6, name:'大理石' },
+  [B.BONE]:    { top:[232,224,200],side:[216,208,184],bot:[198,190,168],hard:0.8, name:'骨块' },
+  [B.MOSS]:    { top:[70,108,52],  side:[60,96,44],   bot:[50,82,36],   hard:0.5, name:'苔石' },
+  [B.GLOW]:    { top:[255,210,120],side:[240,180,90], bot:[220,160,70], hard:0.6, name:'荧石', glow:true }
+};
+
+// ─────────────────────────────────────────────────────────────
+//  程序化纹理（每方块 16×16，绘制到 canvas → CanvasTexture）
+// ─────────────────────────────────────────────────────────────
+function txCanvas(draw){ const c=document.createElement('canvas'); c.width=c.height=16;
+  const x=c.getContext('2d'); draw(x); return c; }
+function shade(rgb,f){ return `rgb(${(rgb[0]*f)|0},${(rgb[1]*f)|0},${(rgb[2]*f)|0})`; }
+function rnd(a){ let t=a*12.9898+a*78.233; return (Math.sin(t)*43758.5453)%1; }
+function noiseDot(x,p){ // 稳定伪随机
+  let s=Math.sin(p*12.9898)*43758.5453; s-=Math.floor(s);
+  return s;
+}
+function fill(x,rgb){ x.fillStyle=shade(rgb,1); x.fillRect(0,0,16,16); }
+function speckle(x,rgb,dark,bright,density){
+  for(let i=0;i<density;i++){
+    const px=(i*37)%16, py=(i*61)%16, n=noiseDot(i,px*0.7+py*1.3);
+    x.fillStyle = n<0.4? shade(rgb,dark) : n>0.85? shade(rgb,bright) : shade(rgb,1);
+    x.fillRect(px,py,1,1);
+  }
+}
+// 通用面纹理生成器
+function faceTex(type, face){
+  const d=DEF[type]; const rgb = face==='top'?d.top: face==='bot'?d.bot: d.side;
+  return txCanvas(x=>{
+    fill(x,rgb);
+    switch(type){
+      case B.GRASS:
+        if(face==='top'){ speckle(x,rgb,0.86,1.1,140); for(let i=0;i<24;i++){ x.fillStyle=shade(rgb,1.12); x.fillRect((i*7)%16,(i*11)%16,1,1);} }
+        else if(face==='side'){ // 顶部草边 + 泥土
+          for(let i=0;i<16;i++){ const h=2+((i*13)%3); x.fillStyle=shade(d.top,1); x.fillRect(i,0,1,h); }
+          speckle(x,d.side,0.86,1.08,90);
+        } else speckle(x,rgb,0.85,1.08,90);
+        break;
+      case B.DIRT:  speckle(x,rgb,0.8,1.1,110); break;
+      case B.STONE: speckle(x,rgb,0.82,1.12,150); for(let i=0;i<6;i++){ x.fillStyle=shade(rgb,0.7); x.fillRect((i*5)%16,(i*9)%16,3,1);} break;
+      case B.COBBLE:{ x.fillStyle=shade(rgb,0.75); for(let i=0;i<8;i++){ const cx=(i*5)%16, cy=(i*7)%16; x.fillRect(cx,cy,4,4);} speckle(x,rgb,0.85,1.15,120); break; }
+      case B.SAND:  speckle(x,rgb,0.93,1.05,90); break;
+      case B.WOOD:
+        if(face==='top'||face==='bot'){ // 年轮
+          x.fillStyle=shade(rgb,0.8); for(let r=2;r<8;r+=2){ x.beginPath(); x.arc(8,8,r,0,7); x.strokeStyle=shade(rgb,0.7); x.stroke(); }
+          x.fillStyle=shade(rgb,0.6); x.fillRect(7,7,2,2);
+        } else { // 竖纹
+          for(let i=0;i<16;i+=2){ x.fillStyle=shade(rgb, i%4?0.86:1.08); x.fillRect(i,0,1,16); }
+          x.fillStyle=shade(rgb,0.7); x.fillRect(3,0,1,16); x.fillRect(11,0,1,16);
+        } break;
+      case B.PLANK: for(let i=0;i<16;i+=4){ x.fillStyle=shade(rgb,i%8?0.94:1.06); x.fillRect(0,i,16,1); } speckle(x,rgb,0.9,1.08,60); break;
+      case B.LEAF:  speckle(x,rgb,0.7,1.18,170); for(let i=0;i<20;i++){ x.fillStyle=shade(rgb,0.6); x.fillRect((i*9)%16,(i*5)%16,2,2);} break;
+      case B.BRICK: { x.fillStyle=shade(rgb,0.7); for(let y=0;y<16;y+=4){ x.fillRect(0,y,16,1); } for(let y=0;y<16;y+=4){ const off=(y/4)%2? 0:4; for(let xx=off;xx<16;xx+=8){ x.fillRect(xx,y,1,4);} } speckle(x,rgb,0.92,1.06,40); break; }
+      case B.GOLD:  speckle(x,rgb,0.9,1.16,80); x.fillStyle=shade(rgb,1.2); for(let i=0;i<6;i++) x.fillRect((i*13)%16,(i*7)%16,2,2); break;
+      case B.OBSIDIAN: speckle(x,rgb,0.7,1.3,60); x.fillStyle=shade(rgb,1.4); x.fillRect(4,5,2,2); x.fillRect(10,9,2,2); break;
+      case B.CRYSTAL: speckle(x,rgb,0.85,1.25,40); x.fillStyle='rgba(255,255,255,0.5)'; x.fillRect(5,3,2,9); x.fillRect(9,5,2,7); break;
+      case B.SNOW:  speckle(x,rgb,0.95,1.03,60); break;
+      case B.WATER: speckle(x,rgb,0.9,1.1,50); for(let i=0;i<10;i++){ x.fillStyle='rgba(180,220,255,0.18)'; x.fillRect((i*5)%16,(i*11)%16,6,1);} break;
+      case B.LAVA:  speckle(x,rgb,0.85,1.3,120); x.fillStyle=shade(rgb,1.4); for(let i=0;i<8;i++) x.fillRect((i*7)%16,(i*13)%16,3,2); break;
+      case B.MARBLE: speckle(x,rgb,0.93,1.05,40); x.strokeStyle=shade(rgb,0.82); for(let i=0;i<3;i++){ x.beginPath(); x.moveTo(0,(i*5)+2); x.bezierCurveTo(6,(i*7),10,(i*3),16,(i*6)+1); x.stroke(); } break;
+      case B.BONE:  speckle(x,rgb,0.9,1.06,70); x.fillStyle=shade(rgb,0.8); x.fillRect(0,7,16,1); break;
+      case B.MOSS:  speckle(x,rgb,0.7,1.15,160); x.fillStyle=shade(rgb,0.6); for(let i=0;i<14;i++) x.fillRect((i*11)%16,(i*7)%16,2,2); break;
+      case B.GLOW:  speckle(x,rgb,0.88,1.25,110); x.fillStyle=shade(rgb,1.3); for(let i=0;i<10;i++) x.fillRect((i*13)%16,(i*5)%16,2,2); break;
+      default: speckle(x,rgb,0.85,1.1,90);
+    }
+  });
+}
+
+// 为每个方块预生成 6 面纹理（top/bot 复用 4 个 side）
+const TEX = {};
+for(const t in DEF){
+  TEX[t] = {
+    top: new THREE.CanvasTexture(faceTex(+t,'top')),
+    side:new THREE.CanvasTexture(faceTex(+t,'side')),
+    bot: new THREE.CanvasTexture(faceTex(+t,'bot'))
+  };
+  for(const k in TEX[t]){ TEX[t][k].magFilter=THREE.NearestFilter; TEX[t][k].minFilter=THREE.NearestFilter; TEX[t][k].colorSpace=THREE.SRGBColorSpace; }
+}
+
+// 材质缓存（按方块类型 → 6 面材质数组：+x,-x,+y,-y,+z,-z）
+const MAT = {};
+for(const t in DEF){
+  const d=DEF[+t];
+  const opt = { map:0, alphaTest:0, transparent:false };
+  if(d.alpha){ opt.transparent=true; opt.opacity=d.alpha; } 
+  const mk=(tex)=>{ const m=new THREE.MeshLambertMaterial({map:tex, transparent:!!d.alpha, opacity:d.alpha||1, emissive:0x000000, emissiveMap:tex, emissiveIntensity:0}); if(d.alpha&&!d.fluid) m.alphaTest=0.1; return m; };
+  const top=mk(TEX[t].top), bot=mk(TEX[t].bot), sd=mk(TEX[t].side);
+  if(d.glow){ const ec = d.fluid? 0.5:0.35; [top,bot,sd].forEach(m=>{ m.emissive=new THREE.Color(d.top[0]/255,d.top[1]/255,d.top[2]/255); m.emissiveIntensity=ec; }); }
+  // MeshLambertMaterial face order: [+x,-x,+y,-y,+z,-z]
+  MAT[t] = [sd,sd,top,bot,sd,sd];
+}
+
+// ─────────────────────────────────────────────────────────────
+//  柏林噪声（2D 经典 Perlin）
+// ─────────────────────────────────────────────────────────────
+class Perlin {
+  constructor(seed=1337){ this.p=new Uint8Array(512); const perm=new Uint8Array(256);
+    for(let i=0;i<256;i++) perm[i]=i;
+    let s=seed>>>0;
+    for(let i=255;i>0;i--){ s=(s*1664525+1013904223)>>>0; const j=s%(i+1); const t=perm[i]; perm[i]=perm[j]; perm[j]=t; }
+    for(let i=0;i<512;i++) this.p[i]=perm[i&255];
+  }
+  fade(t){ return t*t*t*(t*(t*6-15)+10); }
+  lerp(a,b,t){ return a+t*(b-a); }
+  grad(h,x,y){ const u=(h&1)?x:-x, v=(h&2)?y:-y; return u+v; }
+  noise2(x,y){
+    const X=Math.floor(x)&255, Y=Math.floor(y)&255; x-=Math.floor(x); y-=Math.floor(y);
+    const u=this.fade(x), v=this.fade(y);
+    const aa=this.p[this.p[X]+Y], ab=this.p[this.p[X]+Y+1], ba=this.p[this.p[X+1]+Y], bb=this.p[this.p[X+1]+Y+1];
+    return this.lerp(this.lerp(this.grad(aa,x,y),this.grad(ba,x-1,y),u),
+                     this.lerp(this.grad(ab,x,y-1),this.grad(bb,x-1,y-1),u), v);
+  }
+  fbm(x,y,oct=4,lac=2,gain=0.5){
+    let f=0,amp=0.5,fr=1,norm=0;
+    for(let i=0;i<oct;i++){ f+=amp*this.noise2(x*fr,y*fr); norm+=amp; amp*=gain; fr*=lac; }
+    return f/norm; // [-1,1]
+  }
+}
+const perlin = new Perlin(20260626);
+const perlin2 = new Perlin(88123);
+
+// 高度场：大陆 + 山脉 + 丘陵细节
+function heightAt(wx,wz){
+  const cont = perlin.fbm(wx*0.0035, wz*0.0035, 4);        // 大陆轮廓 [-1,1]
+  const mount = Math.max(0, perlin.fbm(wx*0.012, wz*0.012, 4)); // 山脉
+  const hill = perlin2.fbm(wx*0.05, wz*0.05, 3);           // 丘陵
+  let h = SEA + cont*10 + mount*mount*28 + hill*4;
+  // 远离中心的边缘抬高 → 自然边界屏障（环山）
+  const d = Math.sqrt(wx*wx+wz*wz)/HALF;
+  if(d>0.78){ const e=(d-0.78)/0.22; h += e*e*42; }
+  return Math.floor(h);
+}
+function biomeAt(wx,wz,h){
+  const m = perlin2.fbm(wx*0.008+100, wz*0.008+100, 2); // 湿度/温度
+  if(h<=SEA) return 'sea';
+  if(h<=SEA+1) return 'beach';
+  if(h>34) return 'mountain';
+  if(m>0.35) return 'forest'; if(m<-0.4) return 'desert'; return 'plain';
+}
+
+// ─────────────────────────────────────────────────────────────
+//  世界数据（体素存储）—— 以原点为中心的固定大小立方体
+//  采用 Map<key,Uint8Array> 区块切片，便于动态编辑；这里世界范围有限但足够大
+// ─────────────────────────────────────────────────────────────
+const SX = HALF*2, SZ = HALF*2; // X/Z 范围
+const world = new Map(); // key "x,z" -> Uint8Array(CHUNK*CHUNK*WORLD_H)
+function key(cx,cz){ return cx+','+cz; }
+function getCol(cx,cz){ let a=world.get(key(cx,cz)); if(!a){ a=new Uint8Array(CHUNK*CHUNK*WORLD_H); world.set(key(cx,cz),a);} return a; }
+function idx(lx,ly,lz){ return ly + WORLD_H*(lx + CHUNK*lz); }
+function inBoundsXZ(wx,wz){ return wx>=-HALF && wx<HALF && wz>=-HALF && wz<HALF; }
+function getVox(wx,wy,wz){
+  if(!inBoundsXZ(wx,wz)||wy<0||wy>=WORLD_H) return B.AIR;
+  const cx=Math.floor((wx+HALF)/CHUNK), cz=Math.floor((wz+HALF)/CHUNK);
+  const lx=wx+HALF-cx*CHUNK, lz=wz+HALF-cz*CHUNK;
+  return getCol(cx,cz)[idx(lx,wy,lz)];
+}
+function setVox(wx,wy,wz,t){
+  if(!inBoundsXZ(wx,wz)||wy<0||wy>=WORLD_H) return false;
+  const cx=Math.floor((wx+HALF)/CHUNK), cz=Math.floor((wz+HALF)/CHUNK);
+  const lx=wx+HALF-cx*CHUNK, lz=wz+HALF-cz*CHUNK;
+  getCol(cx,cz)[idx(lx,wy,lz)]=t; return true;
+}
+
+// ─────────────────────────────────────────────────────────────
+//  地形生成（含生物群系 + 树木 + 水岩浆）
+// ─────────────────────────────────────────────────────────────
+const trees=[]; // {x,z,h}
+function genTerrain(){
+  for(let cx=-VIEW;cx<=VIEW;cx++) for(let cz=-VIEW;cz<=VIEW;cz++){
+    const col=getCol(cx,cz);
+    for(let lx=0;lx<CHUNK;lx++) for(let lz=0;lz<CHUNK;lz++){
+      const wx=cx*CHUNK+lx-HALF, wz=cz*CHUNK+lz-HALF;
+      const h=heightAt(wx,wz); const b=biomeAt(wx,wz,h);
+      for(let y=0;y<=Math.max(h,SEA);y++){
+        let t=B.AIR;
+        if(y>h){ if(y<=SEA) t=B.WATER; }
+        else if(y===h){
+          if(b==='beach') t=B.SAND;
+          else if(b==='mountain') t = h>40? B.SNOW: B.STONE;
+          else if(b==='desert') t=B.SAND;
+          else t=B.GRASS;
+        } else if(y>=h-3){
+          if(b==='desert'||b==='beach') t=B.SAND; else if(b==='mountain') t=B.STONE; else t=B.DIRT;
+        } else if(y>4) t=B.STONE;
+        else t=B.STONE;
+        col[idx(lx,y,lz)]=t;
+      }
+      // 沙地表面下方偶尔沙化
+      if(b==='desert'&&h>SEA){ for(let y=h;y>h-5;y--) if(col[idx(lx,y,lz)]===B.DIRT) col[idx(lx,y,lz)]=B.SAND; }
+      // 山顶雪盖
+      if(b==='mountain'&&h>38){ for(let y=h;y<h+2;y++) if(y<WORLD_H) col[idx(lx,y,lz)]=B.SNOW; }
+      // 记录可种树位置
+      if((b==='forest'||b==='plain') && h>SEA+1 && h<34 && Math.abs(wx)<HALF-12 && Math.abs(wz)<HALF-12){
+        const r=noiseDot(wx*1.7+wz*3.3, wx+wz);
+        if(b==='forest'? r<0.06 : r<0.018) trees.push({x:wx,z:wz,h});
+      }
+    }
+  }
+  // 地下岩浆池（随机几处）
+  for(let i=0;i<8;i++){
+    const lx=Math.floor((Math.random()-0.5)*(HALF*1.6)), lz=Math.floor((Math.random()-0.5)*(HALF*1.6));
+    const r=3+Math.random()*3;
+    for(let dx=-r;dx<=r;dx++) for(let dz=-r;dz<=r;dz++) for(let dy=-2;dy<=0;dy++){
+      if(dx*dx+dz*dz<=r*r){ const wy=4+dy; if(getVox(lx+dx,wy,lz+dz)===B.STONE) setVox(lx+dx,wy,lz+dz,B.LAVA); }
+    }
+  }
+}
+
+// 种树（自然生成）
+function plantTree(x,z,h){
+  if(getVox(x,h,z)!==B.GRASS) return;
+  const th=4+Math.floor(Math.random()*3);
+  for(let y=1;y<=th;y++) setVox(x,h+y,z,B.WOOD);
+  // 树冠
+  const cr=2;
+  for(let dx=-cr;dx<=cr;dx++) for(let dz=-cr;dz<=cr;dz++) for(let dy=th-2;dy<=th+1;dy++){
+    if(dx===0&&dz===0&&dy<=th) continue;
+    const d=Math.abs(dx)+Math.abs(dz)+Math.abs(dy-th);
+    if(d<=3 && !(Math.abs(dx)===2&&Math.abs(dz)===2)) setVox(x+dx,h+dy,z+dz,B.LEAF);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+//  神话 / 奇幻建筑 & 地形（手工程序化放置）
+// ─────────────────────────────────────────────────────────────
+// 工具：填充长方体
+function box(x0,y0,z0,x1,y1,z1,t){
+  for(let x=x0;x<=x1;x++) for(let y=y0;y<=y1;y++) for(let z=z0;z<=z1;z++) setVox(x,y,z,t);
+}
+function shell(x0,y0,z0,x1,y1,z1,t){ // 空心
+  for(let x=x0;x<=x1;x++) for(let y=y0;y<=y1;y++) for(let z=z0;z<=z1;z++){
+    if(x===x0||x===x1||y===y0||y===y1||z===z0||z===z1) setVox(x,y,z,t);
+  }
+}
+function disc(cx,cz,y,r,t){ for(let dx=-r;dx<=r;dx++) for(let dz=-r;dz<=r;dz++) if(dx*dx+dz*dz<=r*r) setVox(cx+dx,y,cz+dz,t); }
+function ring(cx,cz,y,r,t){ for(let dx=-r;dx<=r;dx++) for(let dz=-r;dz<=r;dz++){ const d=dx*dx+dz*dz; if(d<=r*r&&d>=(r-1)*(r-1)) setVox(cx+dx,y,cz+dz,t);} }
+function column(x,y0,z,y1,t){ for(let y=y0;y<=y1;y++) setVox(x,y,z,t); }
+// 找地表高度
+function surf(wx,wz){ let h=0; for(let y=WORLD_H-1;y>=0;y--){ if(getVox(wx,y,wz)!==B.AIR){ h=y; break;} } return h; }
+
+// 1) 中央太阳神殿（大理石 + 金 + 水晶）
+function buildSunTemple(){
+  const cx=0, cz=0; const base=surf(cx,cz)+1;
+  // 基座
+  box(-14,base-1,-14,14,base,14,B.MARBLE);
+  // 阶梯
+  for(let s=0;s<3;s++){ ring(0,0,base-1-s,14-s,B.MARBLE); }
+  // 8 根金顶大理石柱
+  const r=10;
+  for(let i=0;i<8;i++){ const a=i/8*Math.PI*2; const px=Math.round(Math.cos(a)*r), pz=Math.round(Math.sin(a)*r);
+    for(let y=base+1;y<=base+8;y++) setVox(px,y,pz,B.MARBLE);
+    setVox(px,base+9,pz,B.GOLD); setVox(px,base+10,pz,B.GOLD);
+  }
+  // 顶部圆坛 + 水晶圣坛
+  disc(0,0,base+11,7,B.MARBLE);
+  disc(0,0,base+12,6,B.GOLD);
+  for(let dx=-1;dx<=1;dx++) for(let dz=-1;dz<=1;dz++) setVox(dx,base+13,dz,B.CRYSTAL);
+  setVox(0,base+14,0,B.GLOW); setVox(0,base+15,0,B.CRYSTAL);
+  // 火盆（四角）
+  [[-12,-12],[12,-12],[-12,12],[12,12]].forEach(([x,z])=>{ setVox(x,base+1,z,B.COBBLE); setVox(x,base+2,z,B.LAVA); });
+  // 地下墓室（黑曜石密室 + 荧石灯）
+  box(-6,base-7,-6,6,base-2,6,B.OBSIDIAN);
+  for(let x=-5;x<=5;x++) for(let z=-5;z<=5;z++){ setVox(x,base-2,z,B.OBSIDIAN); }
+  // 挖空内部并放金箱骨堆
+  for(let x=-4;x<=4;x++) for(let z=-4;z<=4;z++) for(let y=base-6;y<=base-3;y++) setVox(x,y,z,B.AIR);
+  for(let x=-3;x<=3;x++) for(let z=-3;z<=3;z++) setVox(x,base-3,z,B.BONE);
+  box(-1,base-5,-1,1,base-4,1,B.GOLD);
+  setVox(-5,base-5,-5,B.GLOW); setVox(5,base-5,5,B.GLOW); setVox(-5,base-5,5,B.GLOW); setVox(5,base-5,-5,B.GLOW);
+  return {x:cx,z:cz,y:base+2};
+}
+
+// 2) 悬浮法师塔（远离神殿，含基岩链）
+function buildWizardTower(){
+  const cx=40, cz=-34; const top=surf(cx,cz)+22;
+  // 悬浮岛（泥土+草地圆盘）
+  for(let dx=-6;dx<=6;dx++) for(let dz=-6;dz<=6;dz++){ const d=dx*dx+dz*dz; if(d<=36){
+    setVox(cx+dx,top-1,cz+dz,B.DIRT); setVox(cx+dx,top,cz+dz,B.GRASS);
+    if(d>25) for(let y=top-1;y>top-4;y--) setVox(cx+dx,y,cz+dz,B.DIRT);
+  }}
+  // 塔身：黑曜石圆柱
+  for(let y=top+1;y<=top+18;y++) for(let dx=-3;dx<=3;dx++) for(let dz=-3;dz<=3;dz++){
+    if(dx*dx+dz*dz<=9 && dx*dx+dz*dz>=4) setVox(cx+dx,y,cz+dz,B.OBSIDIAN);
+  }
+  // 内挖空 + 螺旋楼梯（木板）
+  for(let y=top+1;y<=top+18;y++) for(let dx=-2;dx<=2;dx++) for(let dz=-2;dz<=2;dz++) if(dx*dx+dz*dz<=4) setVox(cx+dx,y,cz+dz,B.AIR);
+  for(let y=top+1;y<=top+18;y++){ const a=(y-top)*0.8; const sx=Math.round(Math.cos(a)*2), sz=Math.round(Math.sin(a)*2); setVox(cx+sx,y,cz+sz,B.PLANK); }
+  // 塔顶水晶尖塔
+  for(let y=top+19;y<=top+26;y++){ const r=Math.max(0,3-(y-top-19)/2|0); disc(cx,cz,y,r,B.CRYSTAL); }
+  setVox(cx,top+27,cz,B.GLOW);
+  // 从地面到岛的能量柱（细水晶链，半透明）
+  const groundY=surf(cx,cz)+1;
+  for(let y=groundY;y<top-1;y++){ if(y%2===0) setVox(cx,y,cz,B.CRYSTAL); }
+}
+
+// 3) 巨龙骨脊（沙滩上的白色骨拱）
+function buildDragonBones(){
+  const cx=-38, cz=30; const y=surf(cx,cz)+1;
+  // 脊椎拱
+  for(let i=0;i<24;i++){ const t=i/23; const x=Math.round(cx + (t-0.5)*30); const yy=Math.round(y + Math.sin(t*Math.PI)*8); const z=cz;
+    setVox(x,yy,z,B.BONE); setVox(x,yy+1,z,B.BONE);
+    if(i%3===0){ setVox(x,yy,z-2,B.BONE); setVox(x,yy,z+2,B.BONE); setVox(x,yy,z-1,B.BONE); setVox(x,yy,z+1,B.BONE); }
+  }
+  // 头骨
+  const hx=cx+16, hy=y+8;
+  box(hx,hy-2,hx+5,hy+2,hy+2,B.BONE);
+  // 眼洞
+  setVox(hx+1,hy-1,cz-1,B.OBSIDIAN); setVox(hx+1,hy-1,cz+1,B.OBSIDIAN);
+  setVox(hx+2,hy-1,cz-1,B.GLOW); setVox(hx+2,hy-1,cz+1,B.GLOW);
+  // 尾刺
+  for(let i=0;i<8;i++){ const x=cx-15-i*2; const yy=y+i%2; setVox(x,yy,cz,B.BONE); setVox(x,yy,cz+(i%2?2:-2),B.BONE); }
+}
+
+// 4) 精灵树海巨树（巨型橡树 + 树屋）
+function buildWorldTree(){
+  const cx=10, cz=44; const base=surf(cx,cz)+1;
+  const th=26;
+  for(let y=0;y<th;y++){ // 粗树干
+    for(let dx=-2;dx<=2;dx++) for(let dz=-2;dz<=2;dz++) if(dx*dx+dz*dz<=4) setVox(cx+dx,base+y,cz+dz,B.WOOD);
+  }
+  // 树冠
+  for(let dy=th-6;dy<=th+4;dy++) for(let dx=-7;dx<=7;dx++) for(let dz=-7;dz<=7;dz++){
+    const d=dx*dx+dz*dz+Math.abs(dy-th)*1.4;
+    if(d<40 && !(dx>-2&&dx<2&&dz>-2&&dz<2&&dy<th-2)) setVox(cx+dx,base+dy,cz+dz,B.LEAF);
+  }
+  // 树屋（木板小屋，挂在树干中段）
+  const wy=base+14;
+  box(cx-4,wy,cz-4,cx+4,wy+3,cz+4,B.PLANK);
+  for(let x=cx-3;x<=cx+3;x++) for(let z=cz-3;z<=cz+3;z++) setVox(x,wy+4,z,B.PLANK);
+  // 挖空 + 窗
+  for(let x=cx-3;x<=cx+3;x++) for(let z=cz-3;z<=cz+3;z++) for(let y=wy+1;y<=wy+2;y++) setVox(x,y,z,B.AIR);
+  setVox(cx-4,wy+1,cz,B.CRYSTAL); setVox(cx+4,wy+1,cz,B.CRYSTAL);
+  setVox(cx,wy+1,cz-4,B.CRYSTAL); setVox(cx,wy+1,cz+4,B.CRYSTAL);
+  // 蘑菇灯（地面）
+  setVox(cx,base-1,cz+5,B.GLOW); setVox(cx,base-1,cz-5,B.GLOW);
+}
+
+// 5) 远古神殿废墟（半埋的砖石废墟 + 拱门）
+function buildRuins(){
+  const cx=-46, cz=-40; const base=surf(cx,cz)+1;
+  // 断墙
+  box(-3,base,-3,3,base+4,3,B.BRICK);
+  for(let x=-3;x<=3;x++){ setVox(x,base+1,-3,B.AIR); setVox(x,base+2,-3,B.AIR); if(x%2===0) setVox(x,base+3,-3,B.AIR); }
+  box(-3,base,-3,-3,base+3,3,B.BRICK);
+  box(3,base,3,-3,base+4,3,B.BRICK);
+  // 倾斜拱门
+  for(let y=0;y<7;y++){ const x=-2+(y>3?1:0); setVox(x,base+y,-1,B.BRICK); setVox(x+4,base+y,-1,B.BRICK); }
+  for(let x=-1;x<=3;x++) setVox(x+(x>1?1:0),base+7,-1,B.BRICK);
+  // 散落苔石 + 半埋
+  for(let i=0;i<14;i++){ const dx=(i*13)%20-10, dz=(i*7)%20-10; setVox(cx+dx,base,cz+dz,B.MOSS); if(i%3===0) setVox(cx+dx,base+1,cz+dz,B.MOSS); }
+}
+
+// 6) 冰晶峰（雪山顶的水晶矿脉 + 冰洞）
+function buildIcePeak(){
+  const cx=46, cz=44; const base=surf(cx,cz);
+  // 已由地形生成雪顶，这里嵌入水晶
+  for(let dy=-4;dy<=4;dy++) for(let dx=-3;dx<=3;dx++) for(let dz=-3;dz<=3;dz++){
+    if(dx*dx+dz*dz<=9){ const y=base+dy; if(getVox(cx+dx,y,cz+dz)===B.SNOW||getVox(cx+dx,y,cz+dz)===B.STONE){
+      if(Math.random()<0.4) setVox(cx+dx,y,cz+dz,B.CRYSTAL);
+    }}
+  }
+  // 冰洞入口
+  for(let dx=-1;dx<=1;dx++) for(let dy=0;dy<=2;dy++) setVox(cx+dx,base-2-dy,cz-5,B.AIR);
+  setVox(cx,base-3,cz-5,B.GLOW); setVox(cx,base-4,cz-5,B.GLOW);
+}
+
+// 7) 沙漠金子塔（4 面金字塔 + 内部墓室）
+function buildPyramid(){
+  const cx=-12, cz=46; const base=surf(cx,cz)+1; const size=12;
+  for(let y=0;y<size;y++){ const r=size-y; for(let dx=-r;dx<=r;dx++) for(let dz=-r;dz<=r;dz++) setVox(cx+dx,base+y,cz+dz,B.SAND); }
+  // 内部墓室
+  for(let dx=-3;dx<=3;dx++) for(let dz=-3;dz<=3;dz++) for(let dy=3;dy<=6;dy++) setVox(cx+dx,base+dy,cz+dz,B.AIR);
+  box(-2,base+3,-2,2,base+3,2,B.GOLD);
+  // 入口
+  for(let dy=0;dy<=2;dy++) for(let dx=-1;dx<=1;dx++) setVox(cx+dx,base+dy,cz+size,B.AIR);
+  // 顶部金帽
+  setVox(cx,base+size,cz,B.GOLD);
+}
+
+// ─────────────────────────────────────────────────────────────
+//  构建：地形 → 自然 → 建筑
+// ─────────────────────────────────────────────────────────────
+genTerrain();
+trees.forEach(t=>plantTree(t.x,t.z,t.h));
+const spawn = buildSunTemple();
+buildWizardTower();
+buildDragonBones();
+buildWorldTree();
+buildRuins();
+buildIcePeak();
+buildPyramid();
+
+// ─────────────────────────────────────────────────────────────
+//  Three.js 场景
+// ─────────────────────────────────────────────────────────────
+const canvas=document.getElementById('c');
+const renderer=new THREE.WebGLRenderer({canvas,antialias:true,powerPreference:'high-performance'});
+renderer.setPixelRatio(Math.min(devicePixelRatio,2));
+renderer.setSize(innerWidth,innerHeight);
+renderer.outputColorSpace=THREE.SRGBColorSpace;
+
+const scene=new THREE.Scene();
+scene.background=new THREE.Color(0x8fc4ff);
+scene.fog=new THREE.Fog(0x9fd0ff, CHUNK*VIEW*0.75, CHUNK*VIEW*1.45);
+
+const camera=new THREE.PerspectiveCamera(72, innerWidth/innerHeight, 0.08, 2000);
+
+// 光照：天空 + 日光 + 环境
+const sun=new THREE.DirectionalLight(0xfff2d8, 1.05);
+sun.position.set(60,120,40);
+scene.add(sun);
+scene.add(new THREE.AmbientLight(0xb8c8e8, 0.55));
+scene.add(new THREE.HemisphereLight(0xbfe3ff, 0x4a4030, 0.5));
+
+// 天空盒：渐变 + 太阳
+const skyMat=new THREE.ShaderMaterial({
+  side:THREE.BackSide, depthWrite:false,
+  uniforms:{ top:{value:new THREE.Color(0x2e6fd6)}, bot:{value:new THREE.Color(0xbfe0ff)}, sunPos:{value:new THREE.Vector3(0.4,0.5,0.3)} },
+  vertexShader:`varying vec3 vP; void main(){ vP=position; gl_Position=projectionMatrix*modelViewMatrix*vec4(position,1.); }`,
+  fragmentShader:`varying vec3 vP; uniform vec3 top; uniform vec3 bot; uniform vec3 sunPos;
+    void main(){ vec3 d=normalize(vP); float h=clamp(d.y*0.5+0.5,0.,1.); vec3 c=mix(bot,top,smoothstep(0.,1.,h));
+      float s=pow(max(dot(d,normalize(sunPos)),0.),64.); c+=vec3(1.,0.9,0.7)*s*0.8; gl_FragColor=vec4(c,1.); }`
+});
+const sky=new THREE.Mesh(new THREE.SphereGeometry(800,24,16), skyMat);
+scene.add(sky);
+
+// 云层（简易白色面片飘动）
+const cloudGroup=new THREE.Group(); scene.add(cloudGroup);
+for(let i=0;i<26;i++){
+  const w=12+Math.random()*26, d=12+Math.random()*26;
+  const m=new THREE.Mesh(new THREE.BoxGeometry(w,3,d), new THREE.MeshLambertMaterial({color:0xffffff, transparent:true, opacity:0.62}));
+  m.position.set((Math.random()-0.5)*HALF*2.2, 60+Math.random()*22, (Math.random()-0.5)*HALF*2.2);
+  cloudGroup.add(m);
+}
+
+// ─────────────────────────────────────────────────────────────
+//  贪婪网格生成（Greedy Meshing）—— 每个区块独立 mesh
+// ─────────────────────────────────────────────────────────────
+// 顶面/底面/侧面方向定义
+const FACES=[
+  { dir:[ 1,0,0], corners:[[1,0,0],[1,1,0],[1,0,1],[1,1,1]] }, // +x
+  { dir:[-1,0,0], corners:[[0,0,0],[0,0,1],[0,1,0],[0,1,1]] }, // -x
+  { dir:[0, 1,0], corners:[[0,1,0],[0,1,1],[1,1,0],[1,1,1]] }, // +y
+  { dir:[0,-1,0], corners:[[0,0,0],[1,0,0],[0,0,1],[1,0,1]] }, // -y
+  { dir:[0,0, 1], corners:[[0,0,1],[1,0,1],[0,1,1],[1,1,1]] }, // +z
+  { dir:[0,0,-1], corners:[[0,0,0],[0,1,0],[1,0,0],[1,1,0]] }, // -z
+];
+
+function isOpaque(t){ return t!==B.AIR && !(DEF[t]&&DEF[t].alpha); }
+function isAir(t){ return t===B.AIR; }
+function visible(t, neighbor){
+  if(t===B.AIR) return false;
+  const da=DEF[t]&&DEF[t].alpha;
+  if(neighbor===B.AIR) return true;
+  if(isOpaque(neighbor)) return false;
+  // 透明/半透明：与自己不同则可见
+  return neighbor!==t;
+}
+
+// 区块 mesh 构建：贪婪网格 + 纹理 Atlas（更还原 Minecraft 材质）
+const chunkMeshes=new Map(); // key -> {solid, water}
+
+// ── 纹理 Atlas：每方块 3 种面(top/side/bot)，每格 16x16，横向排列 ──
+const TILE=16;
+const atlasCols=Object.keys(DEF).length*3;
+const atlas=document.createElement('canvas'); atlas.width=atlasCols*TILE; atlas.height=TILE;
+const ax=atlas.getContext('2d');
+const atlasIndex={}; // type -> {top,side,bot} 列号
+let col=0;
+for(const t in DEF){ atlasIndex[t]={top:col,side:col+1,bot:col+2};
+  ax.drawImage(faceTex(+t,'top'), col*TILE,0); ax.drawImage(faceTex(+t,'side'),(col+1)*TILE,0); ax.drawImage(faceTex(+t,'bot'),(col+2)*TILE,0); col+=3; }
+const atlasTex=new THREE.CanvasTexture(atlas);
+atlasTex.magFilter=THREE.NearestFilter; atlasTex.minFilter=THREE.NearestFilter;
+atlasTex.colorSpace=THREE.SRGBColorSpace;
+
+// 区块 mesh：逐方块面 + atlas UV(0..1)，无纹理拉伸
+// DoubleSide 材质消除 winding/culling 问题；顶点色做方向明暗（伪 AO）
+function buildChunkMeshAtlas(cx,cz){
+  const col0=getCol(cx,cz);
+  const ox=cx*CHUNK-HALF, oz=cz*CHUNK-HALF;
+  const positions=[], normals=[], colors=[], uvs=[], indices=[];
+  const waterPos=[],waterNorm=[],waterCol=[],waterUv=[],waterIdx=[];
+  let v=0, wv=0;
+
+  for(let lx=0;lx<CHUNK;lx++) for(let lz=0;lz<CHUNK;lz++) for(let ly=0;ly<WORLD_H;ly++){
+    const t=col0[idx(lx,ly,lz)];
+    if(t===B.AIR) continue;
+    const fluid=!!(DEF[t]&&DEF[t].fluid);
+    const tgtP=fluid?waterPos:positions, tgtN=fluid?waterNorm:normals, tgtC=fluid?waterCol:colors, tgtU=fluid?waterUv:uvs, tgtI=fluid?waterIdx:indices;
+    const wx=ox+lx, wy=ly, wz=oz+lz;
+    const c=DEF[t]||( {top:[255,255,255],side:[255,255,255],bot:[255,255,255]});
+    const aColOf=(kk)=> atlasIndex[t][kk===2?'top':kk===3?'bot':'side'];
+    const uOf=(kk)=>{ const ac=aColOf(kk); return [ac/atlasCols,(ac+1)/atlasCols]; };
+    // 添加一个面：fi=面索引(0..5)，sh=明暗，rgb=该面颜色，[u0,u1]=uv 范围
+    function face(fi, sh, rgb, u0, u1){
+      const [nx,ny,nz]=FACES[fi].dir;
+      const x0=wx,y0=wy,z0=wz,x1=wx+1,y1=wy+1,z1=wz+1;
+      let p;
+      if(fi===0)      p=[[x1,y0,z0],[x1,y0,z1],[x1,y1,z1],[x1,y1,z0]];
+      else if(fi===1) p=[[x0,y0,z1],[x0,y0,z0],[x0,y1,z0],[x0,y1,z1]];
+      else if(fi===2) p=[[x0,y1,z1],[x1,y1,z1],[x1,y1,z0],[x0,y1,z0]];
+      else if(fi===3) p=[[x0,y0,z0],[x1,y0,z0],[x1,y0,z1],[x0,y0,z1]];
+      else if(fi===4) p=[[x1,y0,z1],[x0,y0,z1],[x0,y1,z1],[x1,y1,z1]];
+      else            p=[[x0,y0,z0],[x1,y0,z0],[x1,y1,z0],[x0,y1,z0]];
+      const uvq=[[u0,0],[u1,0],[u1,1],[u0,1]];
+      const b0=fluid?wv:v;
+      for(let i=0;i<4;i++){ tgtP.push(p[i][0],p[i][1],p[i][2]); tgtN.push(nx,ny,nz); tgtU.push(uvq[i][0],uvq[i][1]); tgtC.push(rgb[0]*sh/255,rgb[1]*sh/255,rgb[2]*sh/255); }
+      tgtI.push(b0,b0+1,b0+2, b0,b0+2,b0+3);
+      if(fluid) wv+=4; else v+=4;
+    }
+    if(visible(t,getVox(wx+1,wy,wz)))  face(0,0.72,c.side, ...uOf(0));
+    if(visible(t,getVox(wx-1,wy,wz)))  face(1,0.72,c.side, ...uOf(1));
+    if(visible(t,getVox(wx,wy+1,wz)))  face(2,1.00,c.top,  ...uOf(2));
+    if(visible(t,getVox(wx,wy-1,wz)))  face(3,0.55,c.bot,  ...uOf(3));
+    if(visible(t,getVox(wx,wy,wz+1)))  face(4,0.86,c.side, ...uOf(4));
+    if(visible(t,getVox(wx,wy,wz-1)))  face(5,0.86,c.side, ...uOf(5));
+  }
+  // 构建几何
+  const out={solid:null,water:null};
+  if(positions.length){
+    const g=new THREE.BufferGeometry();
+    g.setAttribute('position',new THREE.Float32BufferAttribute(positions,3));
+    g.setAttribute('normal',new THREE.Float32BufferAttribute(normals,3));
+    g.setAttribute('color',new THREE.Float32BufferAttribute(colors,3));
+    g.setAttribute('uv',new THREE.Float32BufferAttribute(uvs,2));
+    g.setIndex(indices);
+    const m=new THREE.Mesh(g,new THREE.MeshLambertMaterial({map:atlasTex,vertexColors:true,alphaTest:0.4,side:THREE.DoubleSide}));
+    out.solid=m;
+  }
+  if(waterPos.length){
+    const wg=new THREE.BufferGeometry();
+    wg.setAttribute('position',new THREE.Float32BufferAttribute(waterPos,3));
+    wg.setAttribute('normal',new THREE.Float32BufferAttribute(waterNorm,3));
+    wg.setAttribute('color',new THREE.Float32BufferAttribute(waterCol,3));
+    wg.setAttribute('uv',new THREE.Float32BufferAttribute(waterUv,2));
+    wg.setIndex(waterIdx);
+    out.water=new THREE.Mesh(wg,new THREE.MeshLambertMaterial({map:atlasTex,vertexColors:true,transparent:true,opacity:0.62,side:THREE.DoubleSide}));
+  }
+  return out;
+}
+
+// 全部区块 mesh
+const chunkGroup=new THREE.Group(); scene.add(chunkGroup);
+function rebuildAllChunks(){
+  while(chunkGroup.children.length) chunkGroup.remove(chunkGroup.children[0]);
+  chunkMeshes.clear();
+  for(let cx=-VIEW;cx<=VIEW;cx++) for(let cz=-VIEW;cz<=VIEW;cz++){
+    const m=buildChunkMeshAtlas(cx,cz);
+    if(m.solid) chunkGroup.add(m.solid);
+    if(m.water) chunkGroup.add(m.water);
+    chunkMeshes.set(key(cx,cz),m);
+  }
+}
+rebuildAllChunks();
+
+// 单区块重建（编辑后）
+function rebuildChunk(cx,cz){
+  const old=chunkMeshes.get(key(cx,cz));
+  if(old){ if(old.solid){chunkGroup.remove(old.solid); old.solid.geometry.dispose();} if(old.water){chunkGroup.remove(old.water); old.water.geometry.dispose();} }
+  const m=buildChunkMeshAtlas(cx,cz);
+  if(m.solid) chunkGroup.add(m.solid);
+  if(m.water) chunkGroup.add(m.water);
+  chunkMeshes.set(key(cx,cz),m);
+  // 邻接区块边界更新
+  for(const [dx,dz] of [[1,0],[-1,0],[0,1],[0,-1]]){ const nx=cx+dx,nz=cz+dz; if(nx>=-VIEW&&nx<=VIEW&&nz>=-VIEW&&nz<=VIEW) rebuildOnly(nx,nz); }
+}
+let _rebuildQueue=new Set();
+function rebuildOnly(cx,cz){ if(_rebuildQueue.has(key(cx,cz))) return; _rebuildQueue.add(key(cx,cz));
+  const old=chunkMeshes.get(key(cx,cz)); if(old){ if(old.solid){chunkGroup.remove(old.solid); old.solid.geometry.dispose();} if(old.water){chunkGroup.remove(old.water); old.water.geometry.dispose();} }
+  const m=buildChunkMeshAtlas(cx,cz); if(m.solid) chunkGroup.add(m.solid); if(m.water) chunkGroup.add(m.water); chunkMeshes.set(key(cx,cz),m);
+}
+function flushRebuild(){ _rebuildQueue.clear(); }
+
+// ─────────────────────────────────────────────────────────────
+//  玩家 & 控制
+// ─────────────────────────────────────────────────────────────
+const player={ pos:new THREE.Vector3(spawn.x+0.5, spawn.y+2.2, spawn.z+0.5), vel:new THREE.Vector3(),
+  yaw:Math.PI*0.25, pitch:-0.15, onGround:false, flying:false, height:1.7, width:0.3 };
+const keys={};
+let pointerLocked=false;
+
+addEventListener('keydown',e=>{
+  keys[e.code]=true;
+  if(e.code==='KeyF'){ player.flying=!player.flying; player.vel.y=0; }
+  if(e.code==='KeyR'){ player.pos.set(spawn.x+0.5,spawn.y+2.2,spawn.z+0.5); player.vel.set(0,0,0); }
+  if(/Digit[1-9]/.test(e.code)) selectSlot(+e.code.slice(5)-1);
+});
+addEventListener('keyup',e=>keys[e.code]=false);
+
+canvas.addEventListener('click',()=>{ if(!pointerLocked) canvas.requestPointerLock(); });
+document.addEventListener('pointerlockchange',()=>{ pointerLocked=document.pointerLockElement===canvas; overlay.classList.toggle('hidden',pointerLocked); });
+document.addEventListener('mousemove',e=>{ if(!pointerLocked) return;
+  player.yaw -= e.movementX*0.0024; player.pitch -= e.movementY*0.0024;
+  player.pitch=Math.max(-1.55,Math.min(1.55,player.pitch));
+});
+canvas.addEventListener('contextmenu',e=>e.preventDefault());
+canvas.addEventListener('dblclick',()=>{ if(!document.fullscreenElement) document.documentElement.requestFullscreen(); });
+
+// 鼠标按钮
+let mouseDown=[false,false], breakTarget=null, breakProgress=0;
+canvas.addEventListener('mousedown',e=>{ if(!pointerLocked) return; if(e.button===0){mouseDown[0]=true; tryBreak();} if(e.button===2){mouseDown[2]=true; tryPlace();} });
+canvas.addEventListener('mouseup',e=>{ if(e.button===0){mouseDown[0]=false; breakTarget=null; breakProgress=0; updateBreakOverlay();} if(e.button===2) mouseDown[2]=false; });
+canvas.addEventListener('wheel',e=>{ if(!pointerLocked) return; e.preventDefault(); const d=Math.sign(e.deltaY); let s=selectedSlot+d; if(s<0)s=hotbarSlots.length-1; if(s>=hotbarSlots.length)s=0; selectSlot(s); },{passive:false});
+
+// ── 物品栏 ──
+const hotbarSlots=[
+  {t:B.GRASS,label:'草地'},{t:B.DIRT,label:'泥土'},{t:B.STONE,label:'石头'},
+  {t:B.WOOD,label:'原木'},{t:B.PLANK,label:'木板'},{t:B.LEAF,label:'树叶'},
+  {t:B.COBBLE,label:'圆石'},{t:B.BRICK,label:'红砖'},{t:B.GOLD,label:'金块'},
+  {t:B.OBSIDIAN,label:'黑曜石'},{t:B.CRYSTAL,label:'水晶'},{t:B.MARBLE,label:'大理石'},
+  {t:B.SAND,label:'沙子'},{t:B.SNOW,label:'雪块'},{t:B.GLOW,label:'荧石'},{t:B.BONE,label:'骨块'},
+  {t:B.MOSS,label:'苔石'},{t:B.LAVA,label:'岩浆'},{t:B.WATER,label:'水'}
+].slice(0,9); // 只取 9 个槽
+let selectedSlot=0;
+const hotbarEl=document.getElementById('hotbar');
+function buildHotbar(){
+  hotbarEl.innerHTML='';
+  hotbarSlots.forEach((s,i)=>{
+    const el=document.createElement('div'); el.className='slot'+(i===0?' active':''); el.dataset.i=i;
+    const num=document.createElement('div'); num.className='num'; num.textContent=i+1; el.appendChild(num);
+    const cv=document.createElement('canvas'); cv.width=cv.height=16;
+    const x=cv.getContext('2d'); x.drawImage(faceTex(s.t,'side'),0,0);
+    el.appendChild(cv);
+    const nm=document.createElement('div'); nm.className='name'; nm.textContent=s.label; el.appendChild(nm);
+    el.addEventListener('click',()=>selectSlot(i));
+    hotbarEl.appendChild(el);
+  });
+}
+function selectSlot(i){ selectedSlot=i; [...hotbarEl.children].forEach((el,k)=>el.classList.toggle('active',k===i)); }
+buildHotbar();
+
+// ── 射线投射（DDA 体素遍历） ──
+function raycast(maxDist=6){
+  const o=camera.getWorldPosition(new THREE.Vector3());
+  const d=camera.getWorldDirection(new THREE.Vector3()).normalize();
+  let x=Math.floor(o.x), y=Math.floor(o.y), z=Math.floor(o.z);
+  const stepX=Math.sign(d.x), stepY=Math.sign(d.y), stepZ=Math.sign(d.z);
+  const tDeltaX=stepX!==0?Math.abs(1/d.x):Infinity, tDeltaY=stepY!==0?Math.abs(1/d.y):Infinity, tDeltaZ=stepZ!==0?Math.abs(1/d.z):Infinity;
+  let tMaxX=stepX!==0?((stepX>0? (x+1-o.x):(o.x-x))*tDeltaX):Infinity;
+  let tMaxY=stepY!==0?((stepY>0? (y+1-o.y):(o.y-y))*tDeltaY):Infinity;
+  let tMaxZ=stepZ!==0?((stepZ>0? (z+1-o.z):(o.z-z))*tDeltaZ):Infinity;
+  let face=null, dist=0;
+  for(let i=0;i<80 && dist<maxDist;i++){
+    const t=getVox(x,y,z);
+    if(t!==B.AIR && !(DEF[t]&&DEF[t].fluid)) return {x,y,z,t,face,prev:{x:x-(face?face[0]:0),y:y-(face?face[1]:0),z:z-(face?face[2]:0)}};
+    if(tMaxX<tMaxY && tMaxX<tMaxZ){ x+=stepX; dist=tMaxX; tMaxX+=tDeltaX; face=[-stepX,0,0]; }
+    else if(tMaxY<tMaxZ){ y+=stepY; dist=tMaxY; tMaxY+=tDeltaY; face=[0,-stepY,0]; }
+    else { z+=stepZ; dist=tMaxZ; tMaxZ+=tDeltaZ; face=[0,0,-stepZ]; }
+  }
+  return null;
+}
+
+// 选择框
+const selBoxMat=new THREE.LineBasicMaterial({color:0x000000,transparent:true,opacity:0.5});
+const selBox=new THREE.LineSegments(new THREE.EdgesGeometry(new THREE.BoxGeometry(1.002,1.002,1.002)),selBoxMat);
+selBox.visible=false; scene.add(selBox);
+
+function tryBreak(){
+  const hit=raycast(); if(!hit) return;
+  breakTarget=hit; breakProgress=0; updateBreakOverlay();
+}
+function finishBreak(hit){
+  setVox(hit.x,hit.y,hit.z,B.AIR);
+  const cx=Math.floor((hit.x+HALF)/CHUNK), cz=Math.floor((hit.z+HALF)/CHUNK);
+  rebuildChunk(cx,cz); flushRebuild();
+}
+function tryPlace(){
+  const hit=raycast(); if(!hit||!hit.face) return;
+  const px=hit.x+hit.face[0], py=hit.y+hit.face[1], pz=hit.z+hit.face[2];
+  if(!inBoundsXZ(px,pz)||py<0||py>=WORLD_H) return;
+  if(getVox(px,py,pz)!==B.AIR) return;
+  // 不能放进玩家身上
+  const pminx=Math.floor(player.pos.x-player.width), pmaxx=Math.floor(player.pos.x+player.width);
+  const pminz=Math.floor(player.pos.z-player.width), pmaxz=Math.floor(player.pos.z+player.width);
+  const pminy=Math.floor(player.pos.y-player.height), pmaxy=Math.floor(player.pos.y);
+  if(px>=pminx&&px<=pmaxx&&pz>=pminz&&pz<=pmaxz&&py>=pminy&&py<=pmaxy) return;
+  const t=hotbarSlots[selectedSlot].t;
+  setVox(px,py,pz,t);
+  const cx=Math.floor((px+HALF)/CHUNK), cz=Math.floor((pz+HALF)/CHUNK);
+  rebuildChunk(cx,cz); flushRebuild();
+}
+
+const breakArc=document.getElementById('breakArc'), breakEl=document.getElementById('break');
+function updateBreakOverlay(){
+  if(breakProgress<=0||!breakTarget){ breakEl.style.opacity=0; return; }
+  breakEl.style.opacity=1; const C=150.8; breakArc.setAttribute('stroke-dashoffset', C*(1-breakProgress));
+}
+
+// ── 碰撞 ──
+function collides(px,py,pz){
+  const w=player.width, h=player.height;
+  const minx=Math.floor(px-w), maxx=Math.floor(px+w), minz=Math.floor(pz-w), maxz=Math.floor(pz+w);
+  const miny=Math.floor(py-h), maxy=Math.floor(py);
+  for(let x=minx;x<=maxx;x++) for(let y=miny;y<=maxy;y++) for(let z=minz;z<=maxz;z++){
+    const t=getVox(x,y,z); if(t!==B.AIR && !(DEF[t]&&DEF[t].fluid)) return true;
+  } return false;
+}
+
+// ── 物理 / 移动 ──
+function updatePlayer(dt){
+  const speed=(player.flying?9:5)*(keys['ShiftLeft']?0.4:1);
+  const dir=new THREE.Vector3();
+  const fwd=new THREE.Vector3(-Math.sin(player.yaw),0,-Math.cos(player.yaw));
+  const right=new THREE.Vector3(Math.cos(player.yaw),0,-Math.sin(player.yaw));
+  if(keys['KeyW']) dir.add(fwd); if(keys['KeyS']) dir.sub(fwd);
+  if(keys['KeyD']) dir.add(right); if(keys['KeyA']) dir.sub(right);
+  if(dir.lengthSq()>0) dir.normalize().multiplyScalar(speed);
+
+  player.vel.x=dir.x; player.vel.z=dir.z;
+  if(player.flying){
+    let vy=0; if(keys['Space']) vy+=speed; if(keys['ShiftLeft']) vy-=speed; player.vel.y=vy;
+  } else {
+    player.vel.y -= 24*dt; // 重力
+    if(keys['Space']&&player.onGround){ player.vel.y=8.0; player.onGround=false; }
+    if(player.vel.y< -40) player.vel.y=-40;
+  }
+
+  // 分轴移动 + 碰撞
+  let nx=player.pos.x+player.vel.x*dt;
+  if(!collides(nx,player.pos.y,player.pos.z)) player.pos.x=nx; else player.vel.x=0;
+  let nz=player.pos.z+player.vel.z*dt;
+  if(!collides(player.pos.x,player.pos.y,nz)) player.pos.z=nz; else player.vel.z=0;
+  let ny=player.pos.y+player.vel.y*dt;
+  player.onGround=false;
+  if(!collides(player.pos.x,ny,player.pos.z)) player.pos.y=ny;
+  else { if(player.vel.y<0) player.onGround=true; player.vel.y=0; }
+
+  // 掉出世界保护
+  if(player.pos.y<-20){ player.pos.set(spawn.x+0.5,spawn.y+2.2,spawn.z+0.5); player.vel.set(0,0,0); }
+  // 水中浮力
+  const headVox=getVox(Math.floor(player.pos.x),Math.floor(player.pos.y+0.2),Math.floor(player.pos.z));
+  if(headVox===B.WATER){ player.vel.y=Math.max(player.vel.y, -2); if(keys['Space']) player.vel.y=3; }
+}
+
+// ── 渲染循环 ──
+const overlay=document.getElementById('overlay');
+const hud=document.getElementById('hud');
+const compass=document.getElementById('compass');
+let last=performance.now(), fps=0, fc=0, ft=0;
+function animate(){
+  requestAnimationFrame(animate);
+  const now=performance.now(); let dt=(now-last)/1000; last=now; if(dt>0.1)dt=0.1;
+  fc++; ft+=dt; if(ft>=0.5){ fps=Math.round(fc/ft); fc=0; ft=0; }
+
+  if(pointerLocked) updatePlayer(dt);
+
+  // 相机
+  camera.position.set(player.pos.x, player.pos.y, player.pos.z);
+  const euler=new THREE.Euler(player.pitch, player.yaw, 0, 'YXZ');
+  camera.quaternion.setFromEuler(euler);
+
+  // 选择框 + 破坏
+  const hit=raycast();
+  if(hit){ selBox.visible=true; selBox.position.set(hit.x+0.5,hit.y+0.5,hit.z+0.5); }
+  else selBox.visible=false;
+
+  if(mouseDown[0] && hit){
+    if(!breakTarget || breakTarget.x!==hit.x||breakTarget.y!==hit.y||breakTarget.z!==hit.z){ breakTarget=hit; breakProgress=0; }
+    const hard=DEF[hit.t]?DEF[hit.t].hard:1;
+    breakProgress += dt/(hard*0.5+0.3);
+    updateBreakOverlay();
+    if(breakProgress>=1){ finishBreak(hit); breakTarget=null; breakProgress=0; updateBreakOverlay(); }
+  } else if(!mouseDown[0]){ breakTarget=null; breakProgress=0; updateBreakOverlay(); }
+
+  // 云移动
+  cloudGroup.position.x += dt*1.2; if(cloudGroup.position.x>HALF) cloudGroup.position.x=-HALF;
+
+  // HUD
+  const dirName = (()=>{ const a=((player.yaw%(2*Math.PI))+2*Math.PI)%(2*Math.PI); const dirs=['S','SW','W','NW','N','NE','E','SE']; return dirs[Math.round(a/(Math.PI/4))%8]; })();
+  compass.textContent = dirName;
+  hud.innerHTML = `FPS <b>${fps}</b> · XYZ <b>${player.pos.x.toFixed(1)} ${player.pos.y.toFixed(1)} ${player.pos.z.toFixed(1)}</b><br>`+
+    `方块 <b>${hotbarSlots[selectedSlot].label}</b> · 模式 <b>${player.flying?'飞行':'步行'}</b> · 区块 <b>${chunkMeshes.size}</b>`;
+
+  renderer.render(scene,camera);
+}
+
+addEventListener('resize',()=>{ camera.aspect=innerWidth/innerHeight; camera.updateProjectionMatrix(); renderer.setSize(innerWidth,innerHeight); });
+
+// 启动
+document.getElementById('startBtn').addEventListener('click',()=>{ canvas.requestPointerLock(); });
+document.getElementById('loader').textContent='世界已就绪 · 点击进入';
+animate();
+</script>
+</body>
+</html>

--- a/outputs/glm-5-2/cursor-high/pelican-cycling.svg
+++ b/outputs/glm-5-2/cursor-high/pelican-cycling.svg
@@ -1,0 +1,482 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" width="1200" height="800" text-rendering="geometricPrecision">
+  <defs>
+    <!-- Sky gradient -->
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#7ec8e3"/>
+      <stop offset="35%" stop-color="#a9dcec"/>
+      <stop offset="70%" stop-color="#ffd9a0"/>
+      <stop offset="100%" stop-color="#ffe9c2"/>
+    </linearGradient>
+    <!-- Sea gradient -->
+    <linearGradient id="sea" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2a8fb0"/>
+      <stop offset="50%" stop-color="#1b6f8e"/>
+      <stop offset="100%" stop-color="#0e4a63"/>
+    </linearGradient>
+    <!-- Sand gradient -->
+    <linearGradient id="sand" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f3d9a4"/>
+      <stop offset="100%" stop-color="#d9b677"/>
+    </linearGradient>
+    <!-- Sun glow -->
+    <radialGradient id="sunGlow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#fff6d8" stop-opacity="0.9"/>
+      <stop offset="40%" stop-color="#ffd27a" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#ffd27a" stop-opacity="0"/>
+    </radialGradient>
+    <!-- Pelican body gradient -->
+    <linearGradient id="bodyGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fdfdfd"/>
+      <stop offset="60%" stop-color="#f0eadc"/>
+      <stop offset="100%" stop-color="#d8ccb0"/>
+    </linearGradient>
+    <linearGradient id="wingGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f4efe2"/>
+      <stop offset="100%" stop-color="#b8a984"/>
+    </linearGradient>
+    <linearGradient id="beakGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#f4a838"/>
+      <stop offset="60%" stop-color="#e88a1e"/>
+      <stop offset="100%" stop-color="#c2690f"/>
+    </linearGradient>
+    <linearGradient id="pouchGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f6b94a"/>
+      <stop offset="100%" stop-color="#d9881e"/>
+    </linearGradient>
+    <linearGradient id="frameGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#e63946"/>
+      <stop offset="100%" stop-color="#9a1f2a"/>
+    </linearGradient>
+    <linearGradient id="metalGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#cfd4da"/>
+      <stop offset="50%" stop-color="#8b929a"/>
+      <stop offset="100%" stop-color="#5a6168"/>
+    </linearGradient>
+    <radialGradient id="tireGrad" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#3a3a3a"/>
+      <stop offset="80%" stop-color="#1a1a1a"/>
+      <stop offset="100%" stop-color="#000000"/>
+    </radialGradient>
+    <radialGradient id="rimGrad" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#eef2f5"/>
+      <stop offset="70%" stop-color="#b8c0c6"/>
+      <stop offset="100%" stop-color="#7a828a"/>
+    </radialGradient>
+    <!-- Feather pattern -->
+    <pattern id="feathers" x="0" y="0" width="14" height="14" patternUnits="userSpaceOnUse" patternTransform="rotate(25)">
+      <path d="M0 7 Q7 0 14 7 Q7 14 0 7 Z" fill="none" stroke="#c9bd9a" stroke-width="0.5" opacity="0.4"/>
+    </pattern>
+    <!-- Wave pattern -->
+    <pattern id="waves" x="0" y="0" width="60" height="14" patternUnits="userSpaceOnUse">
+      <path d="M0 7 Q15 0 30 7 T60 7" fill="none" stroke="#cfeef5" stroke-width="1.2" opacity="0.5"/>
+    </pattern>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="1.2"/>
+    </filter>
+    <filter id="shadow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="4"/>
+      <feOffset dx="0" dy="6" result="off"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.35"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <symbol id="spoke" viewBox="0 0 2 120">
+      <rect x="0.4" y="0" width="1.2" height="120" fill="#cfd4da"/>
+    </symbol>
+  </defs>
+
+  <!-- SKY -->
+  <rect width="1200" height="800" fill="url(#sky)"/>
+
+  <!-- Sun -->
+  <circle cx="980" cy="180" r="180" fill="url(#sunGlow)"/>
+  <circle cx="980" cy="180" r="46" fill="#fff3cf"/>
+  <circle cx="980" cy="180" r="34" fill="#ffe89a"/>
+
+  <!-- Distant clouds -->
+  <g opacity="0.85" fill="#ffffff">
+    <g transform="translate(180,120)">
+      <ellipse cx="0" cy="0" rx="60" ry="20"/>
+      <ellipse cx="40" cy="-12" rx="46" ry="20"/>
+      <ellipse cx="-40" cy="-6" rx="40" ry="16"/>
+      <ellipse cx="80" cy="6" rx="36" ry="14"/>
+    </g>
+    <g transform="translate(620,90) scale(0.8)">
+      <ellipse cx="0" cy="0" rx="60" ry="20"/>
+      <ellipse cx="40" cy="-12" rx="46" ry="20"/>
+      <ellipse cx="-40" cy="-6" rx="40" ry="16"/>
+    </g>
+    <g transform="translate(820,210) scale(0.6)" opacity="0.7">
+      <ellipse cx="0" cy="0" rx="60" ry="20"/>
+      <ellipse cx="40" cy="-12" rx="46" ry="20"/>
+      <ellipse cx="-40" cy="-6" rx="40" ry="16"/>
+    </g>
+  </g>
+
+  <!-- Distant sea birds -->
+  <g fill="none" stroke="#3a4a55" stroke-width="2" stroke-linecap="round" opacity="0.65">
+    <path d="M120 200 q10 -10 20 0 q10 -10 20 0"/>
+    <path d="M260 160 q8 -8 16 0 q8 -8 16 0"/>
+    <path d="M740 140 q8 -8 16 0 q8 -8 16 0"/>
+    <path d="M860 240 q7 -7 14 0 q7 -7 14 0"/>
+  </g>
+
+  <!-- Far cliffs / headland -->
+  <path d="M0 430 Q120 410 240 430 Q360 415 480 432 L480 470 L0 470 Z" fill="#9bb7a8" opacity="0.55"/>
+  <path d="M780 425 Q900 405 1020 428 Q1100 418 1200 432 L1200 470 L780 470 Z" fill="#9bb7a8" opacity="0.55"/>
+
+  <!-- SEA -->
+  <rect x="0" y="430" width="1200" height="120" fill="url(#sea)"/>
+  <rect x="0" y="430" width="1200" height="120" fill="url(#waves)"/>
+
+  <!-- Sun reflection on sea -->
+  <g opacity="0.6">
+    <ellipse cx="980" cy="470" rx="120" ry="6" fill="#fff3cf"/>
+    <ellipse cx="980" cy="490" rx="90" ry="4" fill="#ffe89a"/>
+    <ellipse cx="980" cy="510" rx="60" ry="3" fill="#ffe89a"/>
+    <ellipse cx="980" cy="528" rx="36" ry="2" fill="#ffe89a"/>
+  </g>
+
+  <!-- Wave crests -->
+  <g fill="none" stroke="#eaf7fb" stroke-width="2" stroke-linecap="round" opacity="0.7">
+    <path d="M40 470 q20 -8 40 0 t40 0 t40 0"/>
+    <path d="M240 500 q20 -8 40 0 t40 0 t40 0"/>
+    <path d="M460 478 q20 -8 40 0 t40 0"/>
+    <path d="M660 520 q20 -8 40 0 t40 0"/>
+    <path d="M1060 486 q20 -8 40 0 t40 0"/>
+  </g>
+
+  <!-- Wet sand line -->
+  <rect x="0" y="548" width="1200" height="14" fill="#bfa86a" opacity="0.6"/>
+  <!-- SAND -->
+  <rect x="0" y="560" width="1200" height="240" fill="url(#sand)"/>
+  <!-- Sand texture dots -->
+  <g fill="#c9a86a" opacity="0.5">
+    <circle cx="80"  cy="640" r="2"/><circle cx="160" cy="700" r="1.5"/>
+    <circle cx="260" cy="660" r="2"/><circle cx="340" cy="720" r="1.5"/>
+    <circle cx="440" cy="680" r="2"/><circle cx="520" cy="740" r="1.5"/>
+    <circle cx="620" cy="690" r="2"/><circle cx="700" cy="730" r="1.5"/>
+    <circle cx="800" cy="670" r="2"/><circle cx="880" cy="710" r="1.5"/>
+    <circle cx="980" cy="680" r="2"/><circle cx="1060" cy="720" r="1.5"/>
+    <circle cx="1140" cy="690" r="2"/>
+    <circle cx="120" cy="760" r="1.6"/><circle cx="300" cy="780" r="1.4"/>
+    <circle cx="480" cy="770" r="1.6"/><circle cx="660" cy="790" r="1.4"/>
+    <circle cx="840" cy="770" r="1.6"/><circle cx="1020" cy="790" r="1.4"/>
+  </g>
+  <!-- Seaweed / shells -->
+  <g fill="#8a6a3a" opacity="0.6">
+    <path d="M70 750 q4 -10 0 -18 q-4 8 0 18 Z"/>
+    <path d="M920 760 q4 -10 0 -18 q-4 8 0 18 Z"/>
+  </g>
+  <g fill="#d9b6a0" stroke="#a07a5a" stroke-width="0.6">
+    <path d="M220 770 q6 -10 12 0 q-6 6 -12 0 Z"/>
+    <path d="M560 782 q5 -8 10 0 q-5 5 -10 0 Z"/>
+    <path d="M760 776 q6 -10 12 0 q-6 6 -12 0 Z"/>
+  </g>
+
+  <!-- Shadow under bicycle -->
+  <ellipse cx="600" cy="712" rx="240" ry="18" fill="#000000" opacity="0.18" filter="url(#soft)"/>
+
+  <!-- ============== BICYCLE ============== -->
+  <g filter="url(#shadow)">
+    <!-- Rear wheel: cx 470, cy 660, r 78 -->
+    <g transform="translate(470,660)">
+      <circle r="78" fill="url(#tireGrad)"/>
+      <circle r="74" fill="none" stroke="#222" stroke-width="1.5"/>
+      <circle r="62" fill="none" stroke="url(#rimGrad)" stroke-width="5"/>
+      <circle r="60" fill="none" stroke="#eef2f5" stroke-width="1" opacity="0.8"/>
+      <!-- spokes -->
+      <g stroke="#d4dae0" stroke-width="1.1" opacity="0.95">
+        <line x1="0" y1="-60" x2="0" y2="60"/>
+        <line x1="-60" y1="0" x2="60" y2="0"/>
+        <line x1="-42" y1="-42" x2="42" y2="42"/>
+        <line x1="-42" y1="42" x2="42" y2="-42"/>
+        <line x1="-23" y1="-55" x2="23" y2="55"/>
+        <line x1="-55" y1="-23" x2="55" y2="23"/>
+        <line x1="23" y1="-55" x2="-23" y2="55"/>
+        <line x1="55" y1="-23" x2="-55" y2="23"/>
+      </g>
+      <circle r="8" fill="url(#metalGrad)"/>
+      <circle r="3" fill="#2a2f35"/>
+      <!-- valve -->
+      <line x1="0" y1="0" x2="20" y2="-56" stroke="#888" stroke-width="1.4"/>
+      <circle cx="20" cy="-56" r="2" fill="#444"/>
+    </g>
+
+    <!-- Front wheel: cx 760, cy 660, r 78 -->
+    <g transform="translate(760,660)">
+      <circle r="78" fill="url(#tireGrad)"/>
+      <circle r="74" fill="none" stroke="#222" stroke-width="1.5"/>
+      <circle r="62" fill="none" stroke="url(#rimGrad)" stroke-width="5"/>
+      <circle r="60" fill="none" stroke="#eef2f5" stroke-width="1" opacity="0.8"/>
+      <g stroke="#d4dae0" stroke-width="1.1" opacity="0.95">
+        <line x1="0" y1="-60" x2="0" y2="60"/>
+        <line x1="-60" y1="0" x2="60" y2="0"/>
+        <line x1="-42" y1="-42" x2="42" y2="42"/>
+        <line x1="-42" y1="42" x2="42" y2="-42"/>
+        <line x1="-23" y1="-55" x2="23" y2="55"/>
+        <line x1="-55" y1="-23" x2="55" y2="23"/>
+        <line x1="23" y1="-55" x2="-23" y2="55"/>
+        <line x1="55" y1="-23" x2="-55" y2="23"/>
+      </g>
+      <circle r="8" fill="url(#metalGrad)"/>
+      <circle r="3" fill="#2a2f35"/>
+      <line x1="0" y1="0" x2="-22" y2="-54" stroke="#888" stroke-width="1.4"/>
+      <circle cx="-22" cy="-54" r="2" fill="#444"/>
+    </g>
+
+    <!-- Frame tubes -->
+    <g stroke="url(#frameGrad)" stroke-width="9" stroke-linecap="round" fill="none">
+      <!-- down tube: rear hub to head tube -->
+      <line x1="470" y1="660" x2="700" y2="540"/>
+      <!-- top tube: seat post base to head tube -->
+      <line x1="540" y1="520" x2="700" y2="540"/>
+      <!-- seat tube: bb to seat -->
+      <line x1="540" y1="660" x2="540" y2="510"/>
+      <!-- chain stay: bb to rear hub -->
+      <line x1="540" y1="660" x2="470" y2="660"/>
+      <!-- seat stay: seat to rear hub -->
+      <line x1="540" y1="515" x2="470" y2="660"/>
+      <!-- fork: head tube to front hub -->
+      <line x1="700" y1="540" x2="760" y2="660"/>
+    </g>
+    <!-- Frame highlights -->
+    <g stroke="#ff8a8a" stroke-width="2.5" stroke-linecap="round" fill="none" opacity="0.7">
+      <line x1="475" y1="657" x2="695" y2="543"/>
+      <line x1="542" y1="660" x2="542" y2="520"/>
+    </g>
+
+    <!-- Bottom bracket -->
+    <circle cx="540" cy="660" r="12" fill="url(#metalGrad)"/>
+    <circle cx="540" cy="660" r="5" fill="#2a2f35"/>
+
+    <!-- Chain (loop around rear hub and bb) -->
+    <g fill="none" stroke="#3a3f44" stroke-width="2.5" stroke-dasharray="3 2.5" opacity="0.9">
+      <path d="M470 656 Q500 672 540 664"/>
+      <path d="M470 668 Q500 690 540 670"/>
+    </g>
+
+    <!-- Chainring -->
+    <g transform="translate(540,660)">
+      <circle r="22" fill="none" stroke="url(#metalGrad)" stroke-width="6"/>
+      <g stroke="#9aa0a6" stroke-width="2">
+        <line x1="-22" y1="0" x2="22" y2="0"/>
+        <line x1="0" y1="-22" x2="0" y2="22"/>
+        <line x1="-16" y1="-16" x2="16" y2="16"/>
+        <line x1="-16" y1="16" x2="16" y2="-16"/>
+      </g>
+      <circle r="6" fill="#2a2f35"/>
+    </g>
+
+    <!-- Pedals -->
+    <g transform="translate(540,660) rotate(35)">
+      <line x1="0" y1="0" x2="0" y2="34" stroke="url(#metalGrad)" stroke-width="5" stroke-linecap="round"/>
+      <rect x="-12" y="30" width="24" height="9" rx="2" fill="#2a2f35"/>
+      <rect x="-12" y="30" width="24" height="9" rx="2" fill="none" stroke="#888" stroke-width="0.8"/>
+    </g>
+    <g transform="translate(540,660) rotate(215)">
+      <line x1="0" y1="0" x2="0" y2="34" stroke="url(#metalGrad)" stroke-width="5" stroke-linecap="round"/>
+      <rect x="-12" y="30" width="24" height="9" rx="2" fill="#2a2f35"/>
+      <rect x="-12" y="30" width="24" height="9" rx="2" fill="none" stroke="#888" stroke-width="0.8"/>
+    </g>
+
+    <!-- Seat post + saddle -->
+    <line x1="540" y1="515" x2="540" y2="475" stroke="url(#metalGrad)" stroke-width="6" stroke-linecap="round"/>
+    <path d="M515 472 Q540 460 568 472 Q560 484 540 484 Q520 484 515 472 Z" fill="#2a2f35"/>
+    <path d="M518 472 Q540 462 564 472" fill="none" stroke="#555" stroke-width="1"/>
+
+    <!-- Handlebar stem + bars -->
+    <line x1="700" y1="540" x2="694" y2="500" stroke="url(#metalGrad)" stroke-width="6" stroke-linecap="round"/>
+    <path d="M668 498 Q690 488 720 492 Q730 494 734 502" fill="none" stroke="url(#metalGrad)" stroke-width="6" stroke-linecap="round"/>
+    <circle cx="666" cy="498" r="5" fill="#2a2f35"/>
+    <circle cx="736" cy="503" r="5" fill="#2a2f35"/>
+    <!-- grips -->
+    <rect x="654" y="494" width="16" height="9" rx="4" fill="#1f242a"/>
+    <rect x="728" y="500" width="16" height="9" rx="4" fill="#1f242a"/>
+  </g>
+
+  <!-- ============== PELICAN ============== -->
+  <g filter="url(#shadow)">
+    <!-- Legs (riding position, feet on pedals) -->
+    <g stroke="#e0a23c" stroke-width="9" stroke-linecap="round" fill="none">
+      <!-- left leg to front pedal (down-right) -->
+      <path d="M612 470 Q600 540 575 605"/>
+      <!-- right leg to back pedal -->
+      <path d="M635 472 Q648 545 540 638"/>
+    </g>
+    <!-- webbed feet -->
+    <g fill="#e8a838" stroke="#b9781a" stroke-width="1">
+      <path d="M575 605 q-14 4 -20 16 q14 4 20 -4 q6 8 20 4 q-6 -12 -20 -16 Z"/>
+      <path d="M540 638 q-14 4 -20 16 q14 4 20 -4 q6 8 20 4 q-6 -12 -20 -16 Z" transform="rotate(-20 540 638)"/>
+    </g>
+
+    <!-- Tail feathers -->
+    <g>
+      <path d="M470 410 Q420 430 392 470 Q440 460 470 450 Z" fill="#e9dcc0" stroke="#b8a984" stroke-width="1"/>
+      <path d="M470 415 Q432 440 410 478 Q444 466 470 458 Z" fill="#f4efe2" stroke="#c9bd9a" stroke-width="0.8"/>
+      <path d="M472 420 Q446 446 430 486 Q452 470 472 464 Z" fill="#fffdf5" stroke="#d8ccb0" stroke-width="0.6"/>
+    </g>
+
+    <!-- Body -->
+    <path d="M470 408
+             Q440 360 478 320
+             Q520 286 596 300
+             Q680 316 700 372
+             Q708 410 672 432
+             Q600 452 510 446
+             Q470 440 470 408 Z"
+          fill="url(#bodyGrad)" stroke="#b8a984" stroke-width="1.2"/>
+    <!-- Feather texture overlay -->
+    <path d="M470 408
+             Q440 360 478 320
+             Q520 286 596 300
+             Q680 316 700 372
+             Q708 410 672 432
+             Q600 452 510 446
+             Q470 440 470 408 Z"
+          fill="url(#feathers)" opacity="0.5"/>
+
+    <!-- Belly highlight -->
+    <path d="M520 360 Q580 348 660 372 Q620 392 540 392 Q510 386 520 360 Z"
+          fill="#ffffff" opacity="0.35"/>
+
+    <!-- Wing -->
+    <g>
+      <path d="M560 330
+               Q640 318 700 360
+               Q716 384 690 408
+               Q620 420 540 408
+               Q512 392 540 352
+               Q548 338 560 330 Z"
+            fill="url(#wingGrad)" stroke="#9a8c66" stroke-width="1.2"/>
+      <!-- Wing feather divisions -->
+      <g fill="none" stroke="#8a7c58" stroke-width="0.9" opacity="0.85">
+        <path d="M560 344 Q630 338 690 366"/>
+        <path d="M556 360 Q630 358 696 384"/>
+        <path d="M552 376 Q624 376 692 398"/>
+        <path d="M548 392 Q614 392 686 408"/>
+      </g>
+      <!-- Wing tip feathers (primary) -->
+      <g fill="#f4efe2" stroke="#a89a72" stroke-width="0.8">
+        <path d="M690 360 Q724 364 742 384 Q720 386 700 376 Z"/>
+        <path d="M694 374 Q730 380 748 402 Q722 404 700 392 Z"/>
+        <path d="M692 388 Q728 396 742 418 Q718 418 696 406 Z"/>
+        <path d="M686 400 Q720 412 730 432 Q708 430 688 418 Z"/>
+      </g>
+    </g>
+
+    <!-- Neck -->
+    <path d="M660 312
+             Q710 296 752 286
+             Q790 280 812 296
+             Q820 312 800 322
+             Q756 332 706 344
+             Q672 348 660 332 Z"
+          fill="url(#bodyGrad)" stroke="#b8a984" stroke-width="1.2"/>
+    <path d="M660 312 Q710 296 752 286 Q790 280 812 296 Q820 312 800 322 Q756 332 706 344 Q672 348 660 332 Z"
+          fill="url(#feathers)" opacity="0.45"/>
+
+    <!-- Head -->
+    <g>
+      <path d="M792 282
+               Q846 274 880 296
+               Q894 314 876 326
+               Q838 338 800 330
+               Q776 322 778 302
+               Q780 286 792 282 Z"
+            fill="url(#bodyGrad)" stroke="#b8a984" stroke-width="1.2"/>
+      <!-- head crest feather tuft -->
+      <path d="M820 276 q-6 -14 2 -26 q6 10 4 24 Z" fill="#f4efe2" stroke="#a89a72" stroke-width="0.6"/>
+      <path d="M832 274 q-4 -16 4 -28 q6 12 2 26 Z" fill="#fffdf5" stroke="#a89a72" stroke-width="0.6"/>
+    </g>
+
+    <!-- Eye -->
+    <g>
+      <circle cx="856" cy="300" r="7.5" fill="#fffdf5" stroke="#8a6a3a" stroke-width="0.8"/>
+      <circle cx="858" cy="301" r="4.6" fill="#1a1a1a"/>
+      <circle cx="859" cy="299" r="1.5" fill="#ffffff"/>
+      <path d="M850 293 Q858 290 866 294" fill="none" stroke="#7a5a2a" stroke-width="0.8"/>
+    </g>
+
+    <!-- Beak upper -->
+    <path d="M872 304
+             Q940 300 996 312
+             Q1010 318 1004 326
+             Q940 330 876 322
+             Q866 316 872 304 Z"
+          fill="url(#beakGrad)" stroke="#9a5a0a" stroke-width="1"/>
+    <!-- beak nostril -->
+    <ellipse cx="890" cy="310" rx="3" ry="1.6" fill="#7a4a08"/>
+    <!-- Beak tip hook -->
+    <path d="M996 312 Q1014 318 1004 328 Q996 322 996 312 Z" fill="#c2690f" stroke="#7a4a08" stroke-width="0.8"/>
+    <!-- beak lower -->
+    <path d="M876 322 Q940 334 998 328 Q1002 334 996 338 Q936 344 878 332 Q870 328 876 322 Z"
+          fill="#e88a1e" stroke="#9a5a0a" stroke-width="0.9"/>
+
+    <!-- Throat pouch -->
+    <path d="M872 326
+             Q898 380 932 396
+             Q962 402 968 380
+             Q962 348 940 332
+             Q908 322 872 326 Z"
+          fill="url(#pouchGrad)" stroke="#b9781a" stroke-width="1"/>
+    <!-- pouch folds -->
+    <g fill="none" stroke="#c9881e" stroke-width="0.7" opacity="0.8">
+      <path d="M884 340 Q910 376 940 388"/>
+      <path d="M894 346 Q918 372 946 380"/>
+      <path d="M906 350 Q926 366 952 372"/>
+    </g>
+    <!-- a small fish peeking from pouch -->
+    <g transform="translate(928,372) rotate(18)">
+      <path d="M0 0 Q14 -6 28 0 Q14 6 0 0 Z" fill="#6aa0c0" stroke="#3a6080" stroke-width="0.7"/>
+      <path d="M28 0 Q34 -6 40 0 Q34 6 28 0 Z" fill="#7ab0d0" stroke="#3a6080" stroke-width="0.7"/>
+      <circle cx="6" cy="-1" r="1.4" fill="#1a1a1a"/>
+    </g>
+
+    <!-- Wing/arm reaching handlebar -->
+    <g>
+      <path d="M690 372 Q720 384 720 470 Q710 486 700 486 Q692 460 678 410 Z"
+            fill="url(#wingGrad)" stroke="#9a8c66" stroke-width="1"/>
+      <g fill="none" stroke="#8a7c58" stroke-width="0.8" opacity="0.85">
+        <path d="M692 384 Q712 392 716 470"/>
+        <path d="M688 400 Q706 410 708 478"/>
+      </g>
+      <!-- "hand" gripping bar -->
+      <circle cx="714" cy="492" r="9" fill="#e8a838" stroke="#b9781a" stroke-width="0.8"/>
+      <path d="M708 486 q6 -4 12 0 m-12 6 q6 -4 12 0" fill="none" stroke="#b9781a" stroke-width="0.8"/>
+    </g>
+
+    <!-- Scarf fluttering in sea breeze -->
+    <g>
+      <path d="M760 318 Q796 314 824 320 Q806 330 768 332 Z" fill="#e63946" stroke="#9a1f2a" stroke-width="0.8"/>
+      <path d="M822 320 Q872 312 920 322 Q900 334 848 336 Q830 332 822 320 Z" fill="#f25c6b" stroke="#9a1f2a" stroke-width="0.8"/>
+      <path d="M918 322 Q960 320 992 332 Q968 342 924 340 Z" fill="#e63946" stroke="#9a1f2a" stroke-width="0.8"/>
+      <path d="M988 330 Q1010 338 1020 352 Q1004 348 992 340 Z" fill="#f25c6b" stroke="#9a1f2a" stroke-width="0.8"/>
+    </g>
+  </g>
+
+  <!-- Foreground foam wave -->
+  <g fill="none" stroke="#ffffff" stroke-width="3" stroke-linecap="round" opacity="0.85">
+    <path d="M0 560 Q60 552 120 560 T240 560 T360 560 T480 560 T600 560 T720 560 T840 560 T960 560 T1080 560 T1200 560"/>
+  </g>
+  <g fill="#ffffff" opacity="0.55">
+    <circle cx="120" cy="560" r="4"/><circle cx="360" cy="560" r="3"/>
+    <circle cx="600" cy="560" r="4"/><circle cx="840" cy="560" r="3"/>
+    <circle cx="1080" cy="560" r="4"/>
+  </g>
+
+  <!-- Tiny sand splash behind rear wheel -->
+  <g fill="#e8d6a0" opacity="0.8">
+    <circle cx="420" cy="700" r="3"/>
+    <circle cx="404" cy="690" r="2"/>
+    <circle cx="392" cy="704" r="2.4"/>
+    <circle cx="376" cy="694" r="1.8"/>
+    <circle cx="362" cy="706" r="2"/>
+  </g>
+
+  <!-- Subtle vignette -->
+  <radialGradient id="vig" cx="50%" cy="50%" r="75%">
+    <stop offset="60%" stop-color="#000000" stop-opacity="0"/>
+    <stop offset="100%" stop-color="#000000" stop-opacity="0.18"/>
+  </radialGradient>
+  <rect width="1200" height="800" fill="url(#vig)"/>
+</svg>

--- a/outputs/glm-5-2/cursor-high/skeleton-watch.html
+++ b/outputs/glm-5-2/cursor-high/skeleton-watch.html
@@ -1,0 +1,1038 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>镂空机械腕表 · Skeleton Tourbillon</title>
+<style>
+  :root{
+    --bg:#05060a;
+    --ink:#0a0c12;
+    --platinum:#e8e9ee;
+    --rose:#c89878;
+    --rose-bright:#ffd9b8;
+    --accent:#7fd0ff;
+    --lume:#9effc4;
+    --txt:#e6e8ee;
+    --muted:#868b97;
+    --line:rgba(200,152,120,.30);
+    --panel:rgba(12,14,20,.74);
+  }
+  *{margin:0;padding:0;box-sizing:border-box}
+  html,body{width:100%;height:100%;overflow:hidden;background:var(--bg);color:var(--txt);
+    font-family:"Helvetica Neue","PingFang SC","Microsoft YaHei",Arial,sans-serif;-webkit-font-smoothing:antialiased}
+  #stage{position:fixed;inset:0}
+  canvas{display:block}
+
+  /* 渐晕 */
+  #stage::after{content:"";position:absolute;inset:0;pointer-events:none;
+    background:radial-gradient(ellipse at 50% 45%,transparent 40%,rgba(0,0,0,.6) 100%);}
+
+  /* ===== 顶部品牌 ===== */
+  .top{position:absolute;top:24px;left:0;right:0;display:flex;justify-content:space-between;
+    align-items:flex-start;padding:0 38px;pointer-events:none;z-index:20}
+  .brand{pointer-events:auto}
+  .brand .pre{font-size:10px;letter-spacing:.62em;color:var(--rose);font-weight:600;opacity:.92}
+  .brand .nm{font-size:31px;font-weight:200;letter-spacing:.30em;margin-top:5px;
+    background:linear-gradient(180deg,#fff,#c89878);-webkit-background-clip:text;background-clip:text;color:transparent}
+  .brand .sub{font-size:10px;letter-spacing:.42em;color:var(--muted);margin-top:6px}
+  .ref{text-align:right;pointer-events:auto}
+  .ref .l{font-size:9px;letter-spacing:.4em;color:var(--muted)}
+  .ref .v{font-size:13px;letter-spacing:.24em;color:var(--rose-bright);margin-top:3px}
+
+  /* ===== 左侧控制 ===== */
+  .ctl{position:absolute;left:26px;top:50%;transform:translateY(-50%);z-index:20;width:256px;
+    background:var(--panel);border:1px solid var(--line);border-radius:16px;padding:22px 20px;
+    backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);
+    box-shadow:0 28px 64px rgba(0,0,0,.55),inset 0 1px 0 rgba(255,255,255,.04)}
+  .ctl h3{font-size:10px;letter-spacing:.38em;color:var(--rose);font-weight:600;margin-bottom:18px;
+    text-transform:uppercase;border-bottom:1px solid var(--line);padding-bottom:13px}
+  .row{display:flex;align-items:center;justify-content:space-between;margin:14px 0;font-size:12px}
+  .row .lbl{color:var(--muted);letter-spacing:.06em}
+  .row .val{color:var(--rose-bright);font-variant-numeric:tabular-nums;font-weight:600}
+  .slider{width:100%;height:3px;border-radius:3px;background:rgba(255,255,255,.10);margin:6px 0 4px;position:relative;cursor:pointer}
+  .slider .fill{position:absolute;left:0;top:0;height:100%;border-radius:3px;
+    background:linear-gradient(90deg,var(--rose),var(--rose-bright))}
+  .slider .knob{position:absolute;top:50%;width:13px;height:13px;border-radius:50%;transform:translate(-50%,-50%);
+    background:var(--platinum);box-shadow:0 0 10px rgba(255,217,184,.6)}
+
+  .btn{display:block;width:100%;padding:11px 13px;margin-top:12px;border-radius:10px;cursor:pointer;
+    border:1px solid var(--line);background:linear-gradient(180deg,rgba(200,152,120,.16),rgba(200,152,120,.05));
+    color:var(--txt);font-size:11.5px;letter-spacing:.16em;transition:all .25s ease;font-family:inherit;text-align:left}
+  .btn:hover{background:linear-gradient(180deg,rgba(200,152,120,.32),rgba(200,152,120,.12));border-color:var(--rose);
+    transform:translateY(-1px);box-shadow:0 8px 22px rgba(200,152,120,.20)}
+  .btn.on{background:linear-gradient(180deg,rgba(200,152,120,.48),rgba(200,152,120,.20));color:#1a1207;
+    font-weight:700;border-color:var(--rose-bright)}
+  .btn .k{float:right;opacity:.55;font-size:10px;letter-spacing:.1em}
+  .btn.on .k{opacity:.85;color:#1a1207}
+
+  .toggle{position:relative;width:42px;height:22px;border-radius:11px;background:rgba(255,255,255,.08);
+    cursor:pointer;transition:.25s;border:1px solid var(--line)}
+  .toggle::after{content:"";position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%;
+    background:var(--rose);transition:.25s;box-shadow:0 2px 6px rgba(0,0,0,.5)}
+  .toggle.on{background:rgba(200,152,120,.42)}
+  .toggle.on::after{left:22px;background:var(--rose-bright)}
+
+  .legend{margin-top:20px;font-size:10px;color:var(--muted);line-height:1.95;letter-spacing:.04em}
+
+  /* ===== 右侧信息面板 ===== */
+  .info{position:absolute;right:26px;top:50%;transform:translateY(-50%);z-index:20;width:280px;
+    background:var(--panel);border:1px solid var(--line);border-radius:16px;padding:24px 22px;
+    backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);
+    box-shadow:0 28px 64px rgba(0,0,0,.55),inset 0 1px 0 rgba(255,255,255,.04);
+    transition:opacity .4s,transform .4s}
+  .info .tag{font-size:9px;letter-spacing:.42em;color:var(--rose);font-weight:600}
+  .info h2{font-size:22px;font-weight:300;letter-spacing:.06em;margin:9px 0 4px}
+  .info .role{font-size:11px;letter-spacing:.14em;color:var(--accent);margin-bottom:15px}
+  .info p{font-size:12px;line-height:1.82;color:#c9ccda;margin-bottom:15px}
+  .stats{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-top:6px}
+  .stat{padding:11px 12px;border-radius:10px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.05)}
+  .stat .k{font-size:9px;letter-spacing:.22em;color:var(--muted)}
+  .stat .v{font-size:16px;color:var(--rose-bright);font-weight:600;margin-top:5px;font-variant-numeric:tabular-nums}
+  .info .close{position:absolute;top:12px;right:14px;cursor:pointer;color:var(--muted);font-size:14px;width:24px;height:24px;
+    display:flex;align-items:center;justify-content:center;border-radius:50%;transition:.2s}
+  .info .close:hover{color:#fff;background:rgba(255,255,255,.08)}
+  .info.hidden{opacity:0;transform:translateY(-50%) translateX(22px);pointer-events:none}
+
+  /* ===== 底部时间 ===== */
+  .dock{position:absolute;bottom:28px;left:50%;transform:translateX(-50%);z-index:20;text-align:center}
+  .dock .clk{font-size:40px;font-weight:200;letter-spacing:.14em;color:var(--rose-bright);
+    font-variant-numeric:tabular-nums;text-shadow:0 0 26px rgba(255,217,184,.32)}
+  .dock .clk .sep{opacity:.5;animation:bk 1s infinite}
+  @keyframes bk{50%{opacity:.1}}
+  .dock .hnt{font-size:10px;letter-spacing:.34em;color:var(--muted);margin-top:8px}
+
+  /* ===== 3D 标签 ===== */
+  .tag3d{position:absolute;z-index:25;pointer-events:none;transform:translate(-50%,-50%);
+    transition:opacity .22s ease;opacity:0}
+  .tag3d .dot{width:9px;height:9px;border-radius:50%;background:var(--rose-bright);
+    box-shadow:0 0 12px var(--rose),0 0 0 3px rgba(200,152,120,.20);margin:0 auto}
+  .tag3d .line{width:1px;height:28px;background:linear-gradient(180deg,var(--rose-bright),transparent);margin:0 auto}
+  .tag3d .lbl{white-space:nowrap;font-size:10.5px;letter-spacing:.14em;color:var(--rose-bright);
+    background:rgba(8,9,13,.80);border:1px solid var(--line);padding:5px 10px;border-radius:6px;margin-top:2px}
+  .tag3d.show{opacity:1}
+
+  .cursor-pointer{cursor:pointer}
+
+  /* loader */
+  #ld{position:fixed;inset:0;background:var(--bg);z-index:100;display:flex;align-items:center;justify-content:center;
+    flex-direction:column;transition:opacity .8s}
+  #ld .sp{width:48px;height:48px;border-radius:50%;border:2px solid rgba(200,152,120,.18);
+    border-top-color:var(--rose);animation:sp 1s linear infinite}
+  #ld .t{margin-top:22px;font-size:11px;letter-spacing:.4em;color:var(--muted)}
+  @keyframes sp{to{transform:rotate(360deg)}}
+
+  @media (max-width:880px){
+    .ctl,.info{width:calc(100% - 52px);position:absolute;transform:none;top:auto}
+    .ctl{top:96px}.info{bottom:96px;top:auto;transform:none}
+    .info.hidden{transform:translateY(22px)}
+    .top{padding:0 20px}.brand .nm{font-size:22px}
+    .dock{display:none}
+  }
+</style>
+</head>
+<body>
+<div id="stage"></div>
+
+<div class="top">
+  <div class="brand">
+    <div class="pre">MAISON · HORLOGERIE</div>
+    <div class="nm">TOURBILLON</div>
+    <div class="sub">CAL. AR-9250 · SKELETON MANUAL</div>
+  </div>
+  <div class="ref">
+    <div class="l">RÉFÉRENCE</div>
+    <div class="v">N°0152 / 188</div>
+  </div>
+</div>
+
+<div class="ctl" id="ctl">
+  <h3>CONTRÔLES</h3>
+  <div class="row"><span class="lbl">自动旋转</span><div class="toggle on" id="tAuto"></div></div>
+  <div class="row"><span class="lbl">机芯运转</span><div class="toggle on" id="tRun"></div></div>
+  <div class="row"><span class="lbl">背景反射</span><div class="toggle on" id="tRefl"></div></div>
+  <div class="row"><span class="lbl">辉光 (Bloom)</span><div class="toggle on" id="tBloom"></div></div>
+  <div class="row"><span class="lbl">摆轮频率</span><span class="val" id="rateVal">4.0 Hz</span></div>
+  <div class="slider" id="rateSlider"><div class="fill" id="rateFill" style="width:55%"></div><div class="knob" id="rateKnob" style="left:55%"></div></div>
+  <button class="btn" id="bExplode">爆炸视图<span class="k">EXPLODE</span></button>
+  <button class="btn" id="bReset">重置视角<span class="k">RESET</span></button>
+  <button class="btn" id="bView">俯视切换<span class="k">TOP VIEW</span></button>
+  <div class="legend">
+    鼠标拖拽旋转 · 滚轮缩放<br>
+    悬停零件查看名称 · 点击展开详情
+  </div>
+</div>
+
+<div class="info hidden" id="info">
+  <div class="close" id="closeInfo">✕</div>
+  <div class="tag" id="iTag">COMPOSANT</div>
+  <h2 id="iTitle">零件</h2>
+  <div class="role" id="iRole">功能</div>
+  <p id="iDesc">描述</p>
+  <div class="stats" id="iStats"></div>
+</div>
+
+<div class="dock">
+  <div class="clk"><span id="hh">00</span><span class="sep">:</span><span id="mm">00</span><span class="sep">:</span><span id="ss">00</span></div>
+  <div class="hnt">SYNCHRONIZED · LOCAL TIME</div>
+</div>
+
+<div id="ld"><div class="sp"></div><div class="t">ASSEMBLING MOVEMENT…</div></div>
+
+<script type="importmap">
+{
+  "imports":{
+    "three":"https://unpkg.com/three@0.160.0/build/three.module.js",
+    "three/addons/":"https://unpkg.com/three@0.160.0/examples/jsm/"
+  }
+}
+</script>
+
+<script type="module">
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
+import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+
+/* ============================================================
+   全局状态
+============================================================ */
+const state = {
+  autoRotate:true, movement:true, reflection:true, bloom:true,
+  rate:4.0, exploded:false, explodeT:0, topView:false
+};
+const clk = new THREE.Clock();
+const raycaster = new THREE.Raycaster();
+const mouse = new THREE.Vector2(-2,-2);
+
+/* ============================================================
+   场景 / 相机 / 渲染器
+============================================================ */
+const stage = document.getElementById('stage');
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x05060a);
+scene.fog = new THREE.Fog(0x05060a, 24, 64);
+
+const camera = new THREE.PerspectiveCamera(34, innerWidth/innerHeight, 0.1, 220);
+camera.position.set(0, 6.8, 13.5);
+
+const renderer = new THREE.WebGLRenderer({antialias:true, alpha:false});
+renderer.setSize(innerWidth, innerHeight);
+renderer.setPixelRatio(Math.min(devicePixelRatio,2));
+renderer.shadowMap.enabled = true;
+renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+renderer.toneMapping = THREE.ACESFilmicToneMapping;
+renderer.toneMappingExposure = 1.08;
+renderer.outputColorSpace = THREE.SRGBColorSpace;
+stage.appendChild(renderer.domElement);
+
+/* ============================================================
+   程序化环境贴图（双光源摄影棚）
+============================================================ */
+function makeEnv(){
+  const c = document.createElement('canvas'); c.width=512; c.height=256;
+  const g = c.getContext('2d');
+  g.fillStyle='#080a10'; g.fillRect(0,0,512,256);
+  const grd=g.createLinearGradient(0,0,0,256);
+  grd.addColorStop(0,'#1c2030'); grd.addColorStop(0.5,'#0a0c14'); grd.addColorStop(1,'#040508');
+  g.fillStyle=grd; g.fillRect(0,0,512,256);
+  // 主光（暖玫瑰金）
+  const k=g.createRadialGradient(130,80,4,130,80,150);
+  k.addColorStop(0,'rgba(255,210,170,0.95)'); k.addColorStop(0.3,'rgba(255,190,140,0.42)');
+  k.addColorStop(1,'rgba(0,0,0,0)');
+  g.fillStyle=k; g.fillRect(0,0,512,256);
+  // 副光（冷青）
+  const f=g.createRadialGradient(420,110,4,420,110,130);
+  f.addColorStop(0,'rgba(150,200,255,0.55)'); f.addColorStop(1,'rgba(0,0,0,0)');
+  g.fillStyle=f; g.fillRect(0,0,512,256);
+  // 顶光
+  const r=g.createRadialGradient(256,18,4,256,18,95);
+  r.addColorStop(0,'rgba(255,255,255,0.72)'); r.addColorStop(1,'rgba(0,0,0,0)');
+  g.fillStyle=r; g.fillRect(0,0,512,256);
+  // 底部反射
+  const b=g.createLinearGradient(0,200,0,256);
+  b.addColorStop(0,'rgba(0,0,0,0)'); b.addColorStop(1,'rgba(120,80,60,0.32)');
+  g.fillStyle=b; g.fillRect(0,0,512,256);
+  const tex = new THREE.CanvasTexture(c);
+  tex.mapping = THREE.EquirectangularReflectionMapping;
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}
+const envTex = makeEnv();
+const pmrem = new THREE.PMREMGenerator(renderer);
+const envMap = pmrem.fromEquirectangular(envTex).texture;
+scene.environment = envMap;
+
+/* ============================================================
+   光照（三点 + 边缘 + 点缀）
+============================================================ */
+scene.add(new THREE.AmbientLight(0x6a7080, 0.32));
+
+const keyLight = new THREE.DirectionalLight(0xffe2c8, 2.7);
+keyLight.position.set(7,13,8);
+keyLight.castShadow = true;
+keyLight.shadow.mapSize.set(2048,2048);
+keyLight.shadow.camera.near=1; keyLight.shadow.camera.far=42;
+keyLight.shadow.camera.left=-12; keyLight.shadow.camera.right=12;
+keyLight.shadow.camera.top=12; keyLight.shadow.camera.bottom=-12;
+keyLight.shadow.bias=-0.0003; keyLight.shadow.radius=4;
+scene.add(keyLight);
+
+const fillLight = new THREE.DirectionalLight(0x88bbff, 0.95);
+fillLight.position.set(-9,4,-3);
+scene.add(fillLight);
+
+const rimLight = new THREE.DirectionalLight(0xffd2a8, 1.7);
+rimLight.position.set(0,7,-11);
+scene.add(rimLight);
+
+const accent = new THREE.PointLight(0xffe7b8, 1.3, 24, 2);
+accent.position.set(0,3,4);
+scene.add(accent);
+
+/* ============================================================
+   反射地板
+============================================================ */
+const floor = new THREE.Mesh(
+  new THREE.CircleGeometry(32,72),
+  new THREE.MeshStandardMaterial({color:0x080a10, metalness:0.92, roughness:0.34, envMap:envMap, envMapIntensity:0.55})
+);
+floor.rotation.x = -Math.PI/2; floor.position.y = -3.3;
+floor.receiveShadow = true;
+scene.add(floor);
+
+/* ============================================================
+   控制器
+============================================================ */
+const controls = new OrbitControls(camera, renderer.domElement);
+controls.enableDamping = true; controls.dampingFactor = 0.06;
+controls.minDistance = 6; controls.maxDistance = 23;
+controls.maxPolarAngle = Math.PI*0.52; controls.minPolarAngle = Math.PI*0.10;
+controls.target.set(0,0,0);
+controls.autoRotate = state.autoRotate;
+controls.autoRotateSpeed = 0.55;
+
+/* ============================================================
+   材质库（铂金/玫瑰金/蓝钢/红宝石/蓝宝石/夜光）
+============================================================ */
+const M = {
+  rose:    new THREE.MeshPhysicalMaterial({color:0xc89878, metalness:1, roughness:0.18, envMap:envMap, envMapIntensity:1.4, clearcoat:0.6, clearcoatRoughness:0.14}),
+  rosePolish:new THREE.MeshPhysicalMaterial({color:0xf0c8a8, metalness:1, roughness:0.08, envMap:envMap, envMapIntensity:1.65, clearcoat:0.9, clearcoatRoughness:0.07}),
+  platinum:new THREE.MeshPhysicalMaterial({color:0xe2e4ea, metalness:1, roughness:0.16, envMap:envMap, envMapIntensity:1.4, clearcoat:0.7}),
+  platinumDark:new THREE.MeshPhysicalMaterial({color:0x9aa0ac, metalness:1, roughness:0.28, envMap:envMap, envMapIntensity:1.1}),
+  steel:   new THREE.MeshPhysicalMaterial({color:0xc4c8d0, metalness:1, roughness:0.22, envMap:envMap, envMapIntensity:1.25}),
+  steelDark:new THREE.MeshPhysicalMaterial({color:0x4a4e58, metalness:1, roughness:0.34, envMap:envMap, envMapIntensity:1.0}),
+  blued:   new THREE.MeshPhysicalMaterial({color:0x2450d8, metalness:1, roughness:0.16, envMap:envMap, envMapIntensity:1.6, clearcoat:0.75}),
+  ruby:    new THREE.MeshPhysicalMaterial({color:0xff2a55, metalness:0.12, roughness:0.05, envMap:envMap, envMapIntensity:1.9, transmission:0.55, thickness:0.4, ior:1.77, emissive:0x580014, emissiveIntensity:0.45, clearcoat:1}),
+  sapphire:new THREE.MeshPhysicalMaterial({color:0xeaf4ff, metalness:0, roughness:0.02, envMap:envMap, envMapIntensity:1.5, transmission:0.96, thickness:0.5, ior:1.77, clearcoat:1, clearcoatRoughness:0.0, transparent:true, opacity:0.32}),
+  lume:    new THREE.MeshStandardMaterial({color:0xa8ffb8, emissive:0x66ff8a, emissiveIntensity:1.5, roughness:0.4, metalness:0}),
+  plate:   new THREE.MeshPhysicalMaterial({color:0xb0b4be, metalness:1, roughness:0.30, envMap:envMap, envMapIntensity:1.2, clearcoat:0.35}),
+  dark:    new THREE.MeshStandardMaterial({color:0x14161c, metalness:0.9, roughness:0.5, envMap:envMap, envMapIntensity:0.7})
+};
+
+/* ============================================================
+   齿轮几何体（渐开线近似齿 + 镂空辐条）
+============================================================ */
+function gearGeo(teeth, outerR, innerR, holeR, depth, bevel=0.06){
+  const shape = new THREE.Shape();
+  const step = (Math.PI*2)/teeth;
+  const toothW = step*0.46;
+  const rootR = outerR - bevel*2;
+  for(let i=0;i<teeth;i++){
+    const a = i*step;
+    const a1=a, a2=a+(step-toothW)/2, a3=a+(step-toothW)/2+toothW*0.18,
+          a4=a+step-toothW*0.18, a5=a+step;
+    if(i===0) shape.moveTo(Math.cos(a1)*rootR, Math.sin(a1)*rootR);
+    shape.lineTo(Math.cos(a2)*rootR, Math.sin(a2)*rootR);
+    shape.lineTo(Math.cos(a3)*outerR, Math.sin(a3)*outerR);
+    shape.lineTo(Math.cos(a4)*outerR, Math.sin(a4)*outerR);
+    shape.lineTo(Math.cos(a5)*rootR, Math.sin(a5)*rootR);
+  }
+  const hole = new THREE.Path(); hole.absarc(0,0,holeR,0,Math.PI*2,true); shape.holes.push(hole);
+  const spokes = 5;
+  for(let s=0;s<spokes;s++){
+    const ang=(s/spokes)*Math.PI*2;
+    const cx=Math.cos(ang)*((innerR+holeR)/1.7), cy=Math.sin(ang)*((innerR+holeR)/1.7);
+    const r=(innerR-holeR)*0.32;
+    const p=new THREE.Path(); p.absarc(cx,cy,r,0,Math.PI*2,true); shape.holes.push(p);
+  }
+  const geo = new THREE.ExtrudeGeometry(shape,{depth,bevelEnabled:true,bevelThickness:bevel,bevelSize:bevel,bevelSegments:2,steps:1});
+  geo.translate(0,0,-depth/2); geo.computeVertexNormals();
+  return geo;
+}
+
+/* 发条盒齿圈（带盖，无辐条镂空） */
+function barrelGeo(teeth, outerR, holeR, depth, bevel=0.05){
+  const shape = new THREE.Shape();
+  const step=(Math.PI*2)/teeth, toothW=step*0.46, rootR=outerR-bevel*2;
+  for(let i=0;i<teeth;i++){
+    const a=i*step;
+    if(i===0) shape.moveTo(Math.cos(a)*rootR, Math.sin(a)*rootR);
+    shape.lineTo(Math.cos(a+(step-toothW)/2)*rootR, Math.sin(a+(step-toothW)/2)*rootR);
+    shape.lineTo(Math.cos(a+(step-toothW)/2+toothW*0.18)*outerR, Math.sin(a+(step-toothW)/2+toothW*0.18)*outerR);
+    shape.lineTo(Math.cos(a+step-toothW*0.18)*outerR, Math.sin(a+step-toothW*0.18)*outerR);
+    shape.lineTo(Math.cos(a+step)*rootR, Math.sin(a+step)*rootR);
+  }
+  const hole=new THREE.Path(); hole.absarc(0,0,holeR,0,Math.PI*2,true); shape.holes.push(hole);
+  const geo=new THREE.ExtrudeGeometry(shape,{depth,bevelEnabled:true,bevelThickness:bevel,bevelSize:bevel,bevelSegments:2,steps:1});
+  geo.translate(0,0,-depth/2); geo.computeVertexNormals();
+  return geo;
+}
+
+/* ============================================================
+   交互零件注册 / 高亮
+============================================================ */
+const interactive = [];
+let hoverGroup = null;
+
+function markPart(group, info){
+  group.userData.info = info;
+  group.traverse(o=>{ if(o.isMesh) o.userData.parentGroup = group; });
+  interactive.push(group);
+  return group;
+}
+const _orig = new WeakMap();
+function setHighlight(group, on){
+  group.traverse(o=>{
+    if(!o.isMesh) return;
+    if(on){
+      if(!_orig.has(o)){
+        const m=o.material; _orig.set(o,m);
+        const c=m.clone();
+        if(c.emissive){ c.emissive.setHex(0xffd9b0); c.emissiveIntensity=0.9; }
+        else { c.emissive=new THREE.Color(0xffd9b0); c.emissiveIntensity=0.85; }
+        o.material=c;
+      }
+    } else {
+      if(_orig.has(o)){ o.material=_orig.get(o); _orig.delete(o); }
+    }
+  });
+}
+
+/* ============================================================
+   手表主组
+============================================================ */
+const watch = new THREE.Group();
+watch.rotation.x = 0.42;
+scene.add(watch);
+
+const movement = new THREE.Group();
+watch.add(movement);
+const caseParts = new THREE.Group();
+watch.add(caseParts);
+
+/* ----- 表壳 / 表圈 ----- */
+function buildCase(){
+  const baseR = 5.0;
+  const base = new THREE.Mesh(new THREE.CylinderGeometry(baseR, baseR, 0.18, 84), M.plate);
+  base.position.y = -0.45; base.castShadow=true; base.receiveShadow=true;
+  caseParts.add(base);
+
+  const bezel = new THREE.Mesh(new THREE.CylinderGeometry(5.22,5.22,0.55,92,1,true), M.rose);
+  bezel.position.y = -0.1; bezel.castShadow=true; bezel.receiveShadow=true;
+  caseParts.add(bezel);
+
+  const ringTop = new THREE.Mesh(new THREE.TorusGeometry(5.06,0.16,18,92), M.rosePolish);
+  ringTop.rotation.x = Math.PI/2; ringTop.position.y = 0.18; ringTop.castShadow=true;
+  caseParts.add(ringTop);
+
+  const ringBot = new THREE.Mesh(new THREE.TorusGeometry(5.06,0.16,18,92), M.rosePolish);
+  ringBot.rotation.x = Math.PI/2; ringBot.position.y = -0.5;
+  caseParts.add(ringBot);
+
+  // 蓝宝石水晶玻璃
+  const glass = new THREE.Mesh(new THREE.CylinderGeometry(4.9,4.9,0.12,82), M.sapphire);
+  glass.position.y = 0.22;
+  caseParts.add(glass);
+  const glassBev = new THREE.Mesh(new THREE.TorusGeometry(4.88,0.05,12,82), M.rosePolish);
+  glassBev.rotation.x=Math.PI/2; glassBev.position.y=0.28; caseParts.add(glassBev);
+
+  // 底盖
+  const back = new THREE.Mesh(new THREE.CylinderGeometry(5.0,4.95,0.2,82), M.rosePolish);
+  back.position.y = -0.62; back.castShadow=true;
+  caseParts.add(back);
+
+  // 表耳
+  for(let i=0;i<4;i++){
+    const ang = (i<2? (i===0?0.42:-0.42):(i===2?Math.PI-0.42:Math.PI+0.42));
+    const lug = new THREE.Mesh(new THREE.BoxGeometry(0.55,0.7,0.92), M.rose);
+    lug.position.set(Math.cos(ang)*4.9, -0.1, Math.sin(ang)*4.9);
+    lug.rotation.y = -ang + Math.PI/2; lug.castShadow=true;
+    caseParts.add(lug);
+  }
+
+  // 表冠（玫瑰金，带齿纹）
+  const crown = new THREE.Group();
+  const cBody = new THREE.Mesh(new THREE.CylinderGeometry(0.32,0.32,0.45,26), M.rosePolish);
+  cBody.rotation.z = Math.PI/2;
+  const cTip = new THREE.Mesh(new THREE.SphereGeometry(0.32,24,16), M.rosePolish);
+  cTip.position.x = 0.22;
+  for(let i=0;i<18;i++){
+    const a=i/18*Math.PI*2;
+    const t = new THREE.Mesh(new THREE.BoxGeometry(0.4,0.05,0.05), M.rosePolish);
+    t.position.set(0,Math.cos(a)*0.32,Math.sin(a)*0.32); t.rotation.x=a;
+    crown.add(t);
+  }
+  crown.add(cBody); crown.add(cTip);
+  crown.position.set(5.58,-0.1,0); crown.castShadow=true;
+  caseParts.add(crown);
+
+  // 外圈刻度（分钟刻度 + 时标夜光块）
+  const scaleRing = new THREE.Group();
+  for(let i=0;i<60;i++){
+    const a = Math.PI/2 - i/60*Math.PI*2;
+    const major = i%5===0;
+    const tickGeo = new THREE.BoxGeometry(major?0.07:0.035, 0.02, major?0.34:0.18);
+    const tickMat = major ? M.lume.clone() : new THREE.MeshStandardMaterial({color:0xdcdfe8, metalness:0.6, roughness:0.3, envMap:envMap, envMapIntensity:1});
+    const tick = new THREE.Mesh(tickGeo, tickMat);
+    tick.position.set(Math.cos(a)*4.55, 0.05, Math.sin(a)*4.55);
+    tick.rotation.y = -a + Math.PI/2;
+    scaleRing.add(tick);
+  }
+  for(let i=0;i<12;i++){
+    const a = Math.PI/2 - i/12*Math.PI*2;
+    const m = new THREE.Mesh(new THREE.BoxGeometry(0.12,0.03,0.18), M.lume);
+    m.position.set(Math.cos(a)*4.35, 0.06, Math.sin(a)*4.35);
+    m.rotation.y = -a + Math.PI/2;
+    scaleRing.add(m);
+  }
+  caseParts.add(scaleRing);
+
+  // 表带节段（玫瑰金链节）
+  function strap(off, flip){
+    const grp = new THREE.Group();
+    for(let i=0;i<3;i++){
+      const seg = new THREE.Mesh(new THREE.BoxGeometry(1.4,0.32,0.72), M.rose);
+      seg.position.z = i*0.64 + 0.5; seg.castShadow=true;
+      grp.add(seg);
+      const link = new THREE.Mesh(new THREE.CylinderGeometry(0.12,0.12,1.5,16), M.steel);
+      link.rotation.z = Math.PI/2; link.position.z = i*0.64 + 0.86;
+      grp.add(link);
+    }
+    grp.position.set(off?3.2:-3.2,-0.1,0); grp.rotation.y = off?0:Math.PI;
+    return grp;
+  }
+  caseParts.add(strap(false)); caseParts.add(strap(true));
+}
+buildCase();
+
+/* ============================================================
+   机芯
+============================================================ */
+
+/* --- 主夹板（日内瓦波纹 + 红宝石 + 螺丝） --- */
+function buildMainPlate(){
+  const grp = new THREE.Group();
+  const plateShape = new THREE.Shape();
+  plateShape.absarc(0,0,4.6,0,Math.PI*2,false);
+  const windows = [[0,0,1.35],[2.6,1.6,0.9],[-2.6,1.6,0.9],[2.6,-1.6,0.9],[-2.6,-1.6,0.9],[0,2.6,0.7]];
+  windows.forEach(w=>{ const p=new THREE.Path(); p.absarc(w[0],w[1],w[2],0,Math.PI*2,true); plateShape.holes.push(p); });
+  const plateGeo = new THREE.ExtrudeGeometry(plateShape,{depth:0.12,bevelEnabled:true,bevelThickness:0.03,bevelSize:0.03,bevelSegments:2,steps:1});
+  plateGeo.translate(0,0,-0.06);
+  const plate = new THREE.Mesh(plateGeo, M.plate);
+  plate.rotation.x = -Math.PI/2; plate.position.y = -0.3;
+  plate.castShadow=true; plate.receiveShadow=true;
+  grp.add(plate);
+
+  // 日内瓦波纹（铂金底）
+  const waveC = document.createElement('canvas'); waveC.width=waveC.height=512;
+  const wg = waveC.getContext('2d');
+  wg.fillStyle='#1a1d24'; wg.fillRect(0,0,512,512);
+  for(let r=8;r<400;r+=8){
+    wg.strokeStyle = `rgba(220,224,234,${r%16===0?0.24:0.11})`;
+    wg.lineWidth=2;
+    wg.beginPath(); wg.arc(256,256,r,0,Math.PI*2); wg.stroke();
+  }
+  const waveTex = new THREE.CanvasTexture(waveC); waveTex.colorSpace=THREE.SRGBColorSpace;
+  const waveMat = new THREE.MeshPhysicalMaterial({map:waveTex, color:0xb0b4be, metalness:1, roughness:0.34, envMap:envMap, envMapIntensity:1.1, clearcoat:0.4});
+  const wave = new THREE.Mesh(new THREE.CircleGeometry(4.5,64), waveMat);
+  wave.rotation.x=-Math.PI/2; wave.position.y=-0.22; wave.receiveShadow=true;
+  grp.add(wave);
+
+  // 红宝石轴承
+  const jewelPos = [[0,0],[1.85,1.05],[2.15,-0.95],[0.85,-1.85],[-1.7,-1.75],[-2.6,0.6]];
+  jewelPos.forEach(p=>{
+    const seat = new THREE.Mesh(new THREE.CylinderGeometry(0.16,0.18,0.1,18), M.rosePolish);
+    seat.position.set(p[0],-0.14,p[1]); grp.add(seat);
+    const jewel = new THREE.Mesh(new THREE.SphereGeometry(0.1,18,12), M.ruby);
+    jewel.position.set(p[0],-0.08,p[1]); jewel.scale.y=0.5; grp.add(jewel);
+  });
+
+  // 蓝钢螺丝
+  const screwPos = [[1.5,-1.4],[-1.5,-1.4],[1.5,1.4],[-1.5,1.4],[3.4,0.6],[-3.4,-0.6]];
+  screwPos.forEach(p=>{
+    const head = new THREE.Mesh(new THREE.CylinderGeometry(0.1,0.1,0.06,12), M.blued);
+    head.position.set(p[0],-0.1,p[1]); grp.add(head);
+    const slot = new THREE.Mesh(new THREE.BoxGeometry(0.16,0.02,0.03), M.steelDark);
+    slot.position.set(p[0],-0.07,p[1]); slot.rotation.y = Math.random()*Math.PI;
+    grp.add(slot);
+  });
+
+  movement.add(grp);
+  markPart(grp,{
+    tag:'MAIN PLATE', title:'主夹板', role:'机芯基座 / Mainplate',
+    desc:'机芯的基础结构，承载所有齿轮、擒纵与摆轮组件。表面饰有日内瓦波纹（Côtes de Genève），是高级制表的装饰打磨工艺标志。',
+    stats:[['直径','36 mm'],['材质','镀铑黄铜'],['波纹','日内瓦']]
+  });
+  return grp;
+}
+const plateGroup = buildMainPlate();
+
+/* --- 桥板（夹板） --- */
+function buildBridges(){
+  const bg = new THREE.Group();
+  const bShape = new THREE.Shape();
+  bShape.moveTo(-2.3,-1.2);
+  bShape.bezierCurveTo(-2.3,1.0,-1.3,1.25,0,1.25);
+  bShape.bezierCurveTo(1.3,1.25,2.3,1.0,2.3,-1.2);
+  bShape.bezierCurveTo(1.4,-1.05,0.7,-0.85,0,-0.85);
+  bShape.bezierCurveTo(-0.7,-0.85,-1.4,-1.05,-2.3,-1.2);
+  const bGeo = new THREE.ExtrudeGeometry(bShape,{depth:0.22,bevelEnabled:true,bevelThickness:0.04,bevelSize:0.04,bevelSegments:2,steps:1});
+  bGeo.rotateX(-Math.PI/2);
+  const bridge1 = new THREE.Mesh(bGeo, M.rosePolish);
+  bridge1.position.y = -0.02; bridge1.castShadow=true; bridge1.receiveShadow=true;
+  bg.add(bridge1);
+
+  // 摆轮夹板（弧形）
+  const pShape = new THREE.Shape();
+  pShape.absarc(0,0,1.05,0.3,Math.PI-0.3,false);
+  pShape.absarc(0,0,0.75,Math.PI-0.3,0.3,true);
+  const pGeo = new THREE.ExtrudeGeometry(pShape,{depth:0.2,bevelEnabled:true,bevelThickness:0.03,bevelSize:0.03,bevelSegments:2,steps:1});
+  pGeo.rotateX(-Math.PI/2); pGeo.translate(-1.7,0,-1.55);
+  const bridge2 = new THREE.Mesh(pGeo, M.rosePolish);
+  bridge2.castShadow=true; bg.add(bridge2);
+
+  [[1.7,0.8],[-1.7,0.8],[0,1.2],[-1.7,-2.2]].forEach(p=>{
+    const sc = new THREE.Mesh(new THREE.CylinderGeometry(0.09,0.09,0.06,12), M.blued);
+    sc.position.set(p[0],0.22,p[1]); bg.add(sc);
+  });
+  [[0,0],[-1.7,-1.75]].forEach(p=>{
+    const j=new THREE.Mesh(new THREE.SphereGeometry(0.08,16,10), M.ruby);
+    j.position.set(p[0],0.24,p[1]); j.scale.y=0.5; bg.add(j);
+  });
+
+  // 鱼鳞纹点缀
+  for(let i=0;i<16;i++){
+    const dot = new THREE.Mesh(new THREE.SphereGeometry(0.04,8,6), M.rose);
+    const ang = Math.random()*Math.PI*2;
+    const rr = 0.3 + Math.random()*1.8;
+    dot.position.set(Math.cos(ang)*rr*(Math.random()<0.5?1:0.6),0.21,0.4+Math.sin(ang)*rr*0.5);
+    bg.add(dot);
+  }
+
+  movement.add(bg);
+  markPart(bg,{
+    tag:'BRIDGES', title:'夹板 / 桥板', role:'支撑定位 / Bridges',
+    desc:'覆盖在主夹板之上，固定齿轮轴心并提供精确轴承定位。表面经 anglage（倒角）与 perlage（鱼鳞纹）打磨，边缘抛光至镜面，是高级机芯的视觉标志。',
+    stats:[['数量','2 件'],['打磨','鱼鳞纹 + 倒角'],['螺丝','蓝钢']]
+  });
+  return bg;
+}
+const bridgeGroup = buildBridges();
+
+/* --- 发条盒（主发条） --- */
+function buildMainspring(){
+  const g = new THREE.Group();
+  const r = 1.45;
+  const outer = new THREE.Mesh(barrelGeo(64, r, 0.2, 0.45), M.rosePolish);
+  outer.rotation.x = -Math.PI/2; outer.position.y = -0.02; outer.castShadow=true;
+  g.add(outer);
+  // 发条盒盖（同心圆纹理）
+  const lidC = document.createElement('canvas'); lidC.width=lidC.height=256;
+  const lg = lidC.getContext('2d');
+  lg.fillStyle='#c89878'; lg.fillRect(0,0,256,256);
+  lg.strokeStyle='rgba(70,45,20,0.7)'; lg.lineWidth=2;
+  for(let i=4;i<120;i+=3){ lg.beginPath(); lg.arc(128,128,i,0,Math.PI*2); lg.stroke(); }
+  const lidTex = new THREE.CanvasTexture(lidC); lidTex.colorSpace=THREE.SRGBColorSpace;
+  const lid = new THREE.Mesh(new THREE.CircleGeometry(r-0.1,64), new THREE.MeshPhysicalMaterial({map:lidTex, metalness:1, roughness:0.3, envMap:envMap, envMapIntensity:1.2}));
+  lid.rotation.x=-Math.PI/2; lid.position.y=0.21; g.add(lid);
+  const arbor = new THREE.Mesh(new THREE.CylinderGeometry(0.18,0.18,0.6,20), M.steel);
+  arbor.position.y=0.05; g.add(arbor);
+  const arborTop = new THREE.Mesh(new THREE.CylinderGeometry(0.1,0.1,0.2,16), M.blued);
+  arborTop.position.y=0.4; g.add(arborTop);
+
+  g.position.set(-2.6,0,0.6);
+  movement.add(g);
+  markPart(g,{
+    tag:'MAINSPRING BARREL', title:'发条盒', role:'动力源 / Power Reserve 72h',
+    desc:'主发条缠绕于盒内，是腕表的核心动力源。手动上链时表冠旋转卷紧发条，缓慢释放的能量驱动整个齿轮系运转，可提供 72 小时动力储备。',
+    stats:[['齿数','64'],['动力储备','72 小时'],['上链','手动']]
+  });
+  return {g, arbor};
+}
+const mainspring = buildMainspring();
+
+/* --- 齿轮系 --- */
+function buildGearTrain(){
+  const gt = new THREE.Group();
+  const wheels = [];
+  const cfg = [
+    {pos:[0,0], teeth:60, r:1.0, d:0.18, mat:M.rosePolish, w:1.0, name:'中心轮', tag:'CENTER WHEEL'},
+    {pos:[1.85,1.05], teeth:48, r:0.78, d:0.16, mat:M.rose, w:4.0, name:'第三轮', tag:'THIRD WHEEL'},
+    {pos:[2.15,-0.95], teeth:42, r:0.66, d:0.15, mat:M.rose, w:16.0, name:'第四轮', tag:'FOURTH WHEEL'},
+    {pos:[0.85,-1.85], teeth:24, r:0.42, d:0.14, mat:M.platinum, w:80.0, name:'擒纵轮', tag:'ESCAPE WHEEL'},
+  ];
+  cfg.forEach(c=>{
+    const w = new THREE.Group();
+    const gear = new THREE.Mesh(gearGeo(c.teeth, c.r, c.r*0.65, 0.12, c.d), c.mat);
+    gear.rotation.x = -Math.PI/2; gear.position.y = 0.05; gear.castShadow=true;
+    w.add(gear);
+    const pin = new THREE.Mesh(new THREE.CylinderGeometry(0.08,0.08,0.4,12), M.steel);
+    pin.position.y=0.15; w.add(pin);
+    w.position.set(c.pos[0],0,c.pos[1]);
+    w.userData.spin = c.w; w.userData.cfg = c;
+    gt.add(w); wheels.push(w);
+    markPart(w,{
+      tag:c.tag, title:c.name, role:'齿轮系 / Wheel Train',
+      desc:`${c.name} — 齿轮系的关键一环，将发条能量逐级传递并放大转速。齿轮经镜面抛光，齿缘倒角处理，配合红宝石轴承减少摩擦。`,
+      stats:[['齿数',String(c.teeth)],['直径',(c.r*36).toFixed(1)+' mm'],['功能','传动']]
+    });
+  });
+  movement.add(gt);
+  return {gt,wheels};
+}
+const {gt:gearTrain, wheels} = buildGearTrain();
+
+/* --- 擒纵叉 --- */
+function buildEscapement(){
+  const g = new THREE.Group();
+  const fork = new THREE.Group();
+  const body = new THREE.Mesh(new THREE.BoxGeometry(0.5,0.08,0.1), M.steel);
+  fork.add(body);
+  const horn1 = new THREE.Mesh(new THREE.BoxGeometry(0.1,0.06,0.1), M.steel);
+  horn1.position.set(0.25,0,0.1); fork.add(horn1);
+  const horn2 = new THREE.Mesh(new THREE.BoxGeometry(0.1,0.06,0.1), M.steel);
+  horn2.position.set(0.25,0,-0.1); fork.add(horn2);
+  const pallet1 = new THREE.Mesh(new THREE.BoxGeometry(0.08,0.08,0.05), M.ruby);
+  pallet1.position.set(-0.22,0,0.07); fork.add(pallet1);
+  const pallet2 = new THREE.Mesh(new THREE.BoxGeometry(0.08,0.08,0.05), M.ruby);
+  pallet2.position.set(-0.22,0,-0.07); fork.add(pallet2);
+  const pivot = new THREE.Mesh(new THREE.CylinderGeometry(0.06,0.06,0.25,12), M.blued);
+  pivot.position.set(-0.4,0.1,0); pivot.rotation.z=0.2; fork.add(pivot);
+
+  fork.position.set(0.55,0.08,-1.25);
+  fork.rotation.y = 1.15;
+  fork.userData.isFork = true; fork.userData.baseY = 1.15;
+  g.add(fork); movement.add(g);
+  markPart(fork,{
+    tag:'PALLET FORK', title:'擒纵叉', role:'能量调节 / Swiss Lever',
+    desc:'瑞士叉瓦式擒纵机构的核心。擒纵叉在擒纵轮与摆轮之间往复运动，叉瓦上的两颗红宝石（进瓦与出瓦）精确控制能量释放，将旋转运动转化为摆轮的往复振荡。',
+    stats:[['类型','瑞士叉瓦式'],['宝石','2 颗红宝石'],['频率','4 Hz']]
+  });
+  return fork;
+}
+const palletFork = buildEscapement();
+
+/* --- 摆轮 + 游丝 --- */
+function buildBalanceWheel(){
+  const g = new THREE.Group();
+  const osc = new THREE.Group(); g.add(osc);
+  const RR = 0.95;
+  const ring = new THREE.Mesh(new THREE.TorusGeometry(RR,0.09,18,64), M.rosePolish);
+  ring.rotation.x = -Math.PI/2; osc.add(ring);
+  for(let i=0;i<3;i++){
+    const spoke = new THREE.Mesh(new THREE.BoxGeometry(RR*2-0.1,0.05,0.08), M.rose);
+    spoke.rotation.y = i*Math.PI/3; osc.add(spoke);
+  }
+  const _up = new THREE.Vector3(0,1,0);
+  for(let i=0;i<8;i++){
+    const a = i/8*Math.PI*2;
+    const w = new THREE.Mesh(new THREE.CylinderGeometry(0.07,0.07,0.18,12), M.blued);
+    w.position.set(Math.cos(a)*RR,0,Math.sin(a)*RR);
+    w.quaternion.setFromUnitVectors(_up, new THREE.Vector3(Math.cos(a),0,Math.sin(a)));
+    osc.add(w);
+  }
+  const hub = new THREE.Mesh(new THREE.CylinderGeometry(0.1,0.1,0.34,16), M.steel);
+  osc.add(hub);
+
+  // 游丝（螺旋）
+  const pts = [];
+  const turns=11, seg=240;
+  for(let i=0;i<=seg;i++){
+    const t = i/seg * turns * Math.PI*2;
+    const rr = 0.2 + (0.6-0.2)*(i/seg);
+    pts.push(new THREE.Vector3(Math.cos(t)*rr, 0.22, Math.sin(t)*rr));
+  }
+  const curve = new THREE.CatmullRomCurve3(pts);
+  const hairspring = new THREE.Mesh(new THREE.TubeGeometry(curve, 300, 0.018, 6, false),
+    new THREE.MeshPhysicalMaterial({color:0x3a6fff, metalness:1, roughness:0.15, envMap:envMap, envMapIntensity:1.6, clearcoat:0.7}));
+  osc.add(hairspring);
+
+  const stud = new THREE.Mesh(new THREE.CylinderGeometry(0.07,0.07,0.2,10), M.rosePolish);
+  stud.position.set(0.62,0.1,0); g.add(stud);
+  const index = new THREE.Mesh(new THREE.BoxGeometry(0.25,0.04,0.05), M.blued);
+  index.position.set(0.4,0.2,0); g.add(index);
+
+  g.position.set(-1.7,0,-1.75);
+  movement.add(g);
+  g.userData.osc = osc;
+  markPart(g,{
+    tag:'BALANCE WHEEL', title:'摆轮 + 游丝', role:'时间基准 / Oscillator 4 Hz',
+    desc:'腕表的"心脏"，决定走时精度。摆轮以 4 Hz（每小时 28,800 次）振荡，蓝钢游丝提供等时性回复力。边缘蓝钢螺丝用于精密调校，每秒 8 次半振荡清晰可见。',
+    stats:[['频率','4 Hz · 28,800 vph'],['游丝','蓝钢'],['宝石','Incabloc 防震']]
+  });
+  return g;
+}
+const balanceWheel = buildBalanceWheel();
+
+/* ============================================================
+   指针
+============================================================ */
+function buildHands(){
+  const g = new THREE.Group();
+  const hour = new THREE.Mesh(new THREE.BoxGeometry(0.14,0.04,2.4), M.lume);
+  hour.geometry.translate(0,0,1.0); hour.position.set(0,0.16,0); hour.castShadow=true; g.add(hour);
+  const hTip = new THREE.Mesh(new THREE.ConeGeometry(0.09,0.3,4), M.lume);
+  hTip.rotation.x=-Math.PI/2; hTip.position.set(0,0.16,2.4); g.add(hTip);
+
+  const min = new THREE.Mesh(new THREE.BoxGeometry(0.1,0.04,3.5), M.lume);
+  min.geometry.translate(0,0,1.55); min.position.set(0,0.2,0); g.add(min);
+  const mTip = new THREE.Mesh(new THREE.ConeGeometry(0.07,0.25,4), M.lume);
+  mTip.rotation.x=-Math.PI/2; mTip.position.set(0,0.2,3.5); g.add(mTip);
+
+  const sec = new THREE.Mesh(new THREE.CylinderGeometry(0.02,0.02,4.2,8), M.blued);
+  sec.rotation.x=-Math.PI/2; sec.position.set(0,0.24,1.7); g.add(sec);
+  const secW = new THREE.Mesh(new THREE.CylinderGeometry(0.1,0.1,0.06,16), M.blued);
+  secW.position.set(0,0.24,-0.5); g.add(secW);
+
+  const cap = new THREE.Mesh(new THREE.CylinderGeometry(0.12,0.14,0.12,16), M.rosePolish);
+  cap.position.y=0.28; g.add(cap);
+
+  watch.add(g);
+  return {g,hour,min,sec};
+}
+const hands = buildHands();
+
+/* ============================================================
+   后处理
+============================================================ */
+const composer = new EffectComposer(renderer);
+composer.addPass(new RenderPass(scene,camera));
+const bloom = new UnrealBloomPass(new THREE.Vector2(innerWidth,innerHeight), 0.7, 0.7, 0.85);
+composer.addPass(bloom);
+composer.addPass(new OutputPass());
+
+/* ============================================================
+   爆炸视图目标
+============================================================ */
+function setExplodeTargets(){
+  bridgeGroup.userData.explode = new THREE.Vector3(0,1.4,0);
+  balanceWheel.userData.explode = new THREE.Vector3(0,1.2,0);
+  palletFork.userData.explode = new THREE.Vector3(0,1.0,0);
+  wheels.forEach((w,i)=>{ w.userData.explode = new THREE.Vector3(0, 0.7+i*0.22, 0); });
+  mainspring.g.userData.explode = new THREE.Vector3(0,2.2,0);
+  plateGroup.userData.explode = new THREE.Vector3(0,-1.1,0);
+  caseParts.userData.explode = new THREE.Vector3(0,-0.6,0);
+}
+setExplodeTargets();
+
+/* ============================================================
+   交互：射线 / 标签 / 信息面板
+============================================================ */
+const tagEl = document.createElement('div');
+tagEl.className='tag3d'; tagEl.innerHTML='<div class="dot"></div><div class="line"></div><div class="lbl"></div>';
+stage.appendChild(tagEl);
+
+function onPointerMove(e){
+  mouse.x = (e.clientX/innerWidth)*2-1;
+  mouse.y = -(e.clientY/innerHeight)*2+1;
+}
+function onPointerLeave(){
+  mouse.set(-2,-2);
+  tagEl.classList.remove('show');
+  if(hoverGroup){ setHighlight(hoverGroup,false); hoverGroup=null; }
+  renderer.domElement.classList.remove('cursor-pointer');
+}
+renderer.domElement.addEventListener('pointermove', onPointerMove);
+renderer.domElement.addEventListener('pointerleave', onPointerLeave);
+renderer.domElement.addEventListener('click', ()=>{
+  if(hoverGroup){ showInfo(hoverGroup.userData.info); }
+});
+
+function checkHover(){
+  if(state.exploded) return;
+  raycaster.setFromCamera(mouse, camera);
+  const hits = raycaster.intersectObjects(interactive, true);
+  if(hits.length){
+    const top = hits[0].object.userData.parentGroup || hoverGroup;
+    if(top !== hoverGroup){
+      if(hoverGroup) setHighlight(hoverGroup,false);
+      hoverGroup = top; setHighlight(hoverGroup,true);
+    }
+    const pos = hits[0].point.clone();
+    const info = hoverGroup.userData.info;
+    tagEl.querySelector('.lbl').textContent = info.title + ' · ' + info.tag;
+    projectTag(pos);
+    tagEl.classList.add('show');
+    renderer.domElement.classList.add('cursor-pointer');
+  } else {
+    if(hoverGroup){ setHighlight(hoverGroup,false); hoverGroup=null; }
+    tagEl.classList.remove('show');
+    renderer.domElement.classList.remove('cursor-pointer');
+  }
+}
+function projectTag(pos3){
+  const v = pos3.clone().project(camera);
+  const x = (v.x*0.5+0.5)*innerWidth;
+  const y = (-v.y*0.5+0.5)*innerHeight - 40;
+  tagEl.style.left = x+'px'; tagEl.style.top = y+'px';
+}
+
+const infoEl = document.getElementById('info');
+function showInfo(info){
+  document.getElementById('iTag').textContent = info.tag;
+  document.getElementById('iTitle').textContent = info.title;
+  document.getElementById('iRole').textContent = info.role;
+  document.getElementById('iDesc').textContent = info.desc;
+  const st = document.getElementById('iStats');
+  st.innerHTML = '';
+  info.stats.forEach(s=>{
+    const d = document.createElement('div'); d.className='stat';
+    d.innerHTML = `<div class="k">${s[0]}</div><div class="v">${s[1]}</div>`;
+    st.appendChild(d);
+  });
+  infoEl.classList.remove('hidden');
+}
+document.getElementById('closeInfo').addEventListener('click', ()=>infoEl.classList.add('hidden'));
+
+/* ============================================================
+   UI 控件
+============================================================ */
+function bindToggle(id, key, onChange){
+  const el = document.getElementById(id);
+  el.addEventListener('click', ()=>{
+    state[key]=!state[key]; el.classList.toggle('on',state[key]);
+    onChange&&onChange(state[key]);
+  });
+}
+bindToggle('tAuto','autoRotate',v=>{controls.autoRotate=v;});
+bindToggle('tRun','movement');
+bindToggle('tRefl','reflection',v=>{ floor.visible=v; scene.environment = v?envMap:null; scene.background = v? null : new THREE.Color(0x05060a); });
+bindToggle('tBloom','bloom',v=>{bloom.enabled=v;});
+
+document.getElementById('bExplode').addEventListener('click', ()=>{
+  state.exploded = !state.exploded;
+  document.getElementById('bExplode').classList.toggle('on',state.exploded);
+});
+document.getElementById('bReset').addEventListener('click', ()=>{
+  state.topView=false; document.getElementById('bView').classList.remove('on');
+  camera.position.set(0,6.8,13.5);
+  controls.target.set(0,0,0);
+  controls.update();
+});
+document.getElementById('bView').addEventListener('click', ()=>{
+  state.topView = !state.topView;
+  document.getElementById('bView').classList.toggle('on',state.topView);
+});
+
+/* 频率滑块 */
+const rateSlider = document.getElementById('rateSlider');
+const rateFill = document.getElementById('rateFill');
+const rateKnob = document.getElementById('rateKnob');
+let dragRate = false;
+function setRateFromX(clientX){
+  const rect = rateSlider.getBoundingClientRect();
+  let t = (clientX - rect.left)/rect.width;
+  t = Math.max(0, Math.min(1, t));
+  state.rate = 2.5 + t*3.5; // 2.5 ~ 6.0 Hz
+  rateFill.style.width = (t*100)+'%';
+  rateKnob.style.left = (t*100)+'%';
+  document.getElementById('rateVal').textContent = state.rate.toFixed(1)+' Hz';
+}
+rateSlider.addEventListener('pointerdown', e=>{ dragRate=true; setRateFromX(e.clientX); });
+window.addEventListener('pointermove', e=>{ if(dragRate) setRateFromX(e.clientX); });
+window.addEventListener('pointerup', ()=>{ dragRate=false; });
+
+window.addEventListener('resize', ()=>{
+  camera.aspect = innerWidth/innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(innerWidth,innerHeight);
+  composer.setSize(innerWidth,innerHeight);
+});
+
+/* ============================================================
+   时钟显示
+============================================================ */
+function tick(){
+  const d = new Date();
+  document.getElementById('hh').textContent = String(d.getHours()).padStart(2,'0');
+  document.getElementById('mm').textContent = String(d.getMinutes()).padStart(2,'0');
+  document.getElementById('ss').textContent = String(d.getSeconds()).padStart(2,'0');
+}
+setInterval(tick,1000); tick();
+
+/* ============================================================
+   动画循环
+============================================================ */
+const origPos = new Map();
+interactive.forEach(g=>origPos.set(g, g.position.clone()));
+origPos.set(caseParts, caseParts.position.clone());
+
+const camTarget = new THREE.Vector3(0,6.8,13.5);
+const camLook = new THREE.Vector3(0,0,0);
+
+function animate(){
+  requestAnimationFrame(animate);
+  const dt = Math.min(clk.getDelta(),0.05);
+  const t = clk.elapsedTime;
+
+  // 爆炸插值
+  const tgt = state.exploded?1:0;
+  state.explodeT += (tgt - state.explodeT) * Math.min(1, dt*4);
+  interactive.forEach(g=>{
+    const o = origPos.get(g); const e = g.userData.explode;
+    if(e){ g.position.lerpVectors(o, new THREE.Vector3(o.x+e.x,o.y+e.y,o.z+e.z), state.explodeT); }
+  });
+  const co = origPos.get(caseParts);
+  caseParts.position.y = co.y + (-0.6) * state.explodeT;
+
+  // 机芯运转
+  if(state.movement && state.explodeT<0.5){
+    const f = state.rate * dt;
+    wheels.forEach(w=>{ w.rotation.y -= f * w.userData.spin * 0.05; });
+    mainspring.g.rotation.y += f*0.015;
+    palletFork.rotation.y = (palletFork.userData.baseY||1.15) + Math.sin(t*state.rate*Math.PI*2*0.4)*0.14;
+    (balanceWheel.userData.osc||balanceWheel).rotation.y = Math.sin(t*state.rate*Math.PI*2*0.2)*0.6;
+  }
+
+  // 爆炸时抬升指针
+  hands.g.position.y = 1.6 * state.explodeT;
+
+  // 指针随真实时间
+  const d = new Date();
+  const sec = d.getSeconds()+d.getMilliseconds()/1000;
+  const min = d.getMinutes()+sec/60;
+  const hr = (d.getHours()%12)+min/60;
+  hands.sec.rotation.y = sec/60*Math.PI*2;
+  hands.min.rotation.y = min/60*Math.PI*2;
+  hands.hour.rotation.y = hr/12*Math.PI*2;
+
+  // accent 微动
+  accent.position.x = Math.sin(t*0.5)*2;
+  accent.position.z = Math.cos(t*0.5)*2+3;
+
+  // 俯视切换（平滑）
+  if(state.topView){
+    camTarget.set(0,14,0.001); camLook.set(0,0,0);
+  } else {
+    camTarget.set(0,6.8,13.5); camLook.set(0,0,0);
+  }
+  camera.position.lerp(camTarget, Math.min(1,dt*2.2));
+  controls.target.lerp(camLook, Math.min(1,dt*2.2));
+
+  controls.update();
+  checkHover();
+  composer.render();
+}
+
+setTimeout(()=>{
+  const l=document.getElementById('ld');
+  l.style.opacity='0'; setTimeout(()=>l.remove(),800);
+}, 600);
+
+animate();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `models/glm-5-2-cursor.json` registering GLM-5.2 under Cursor with High effort
- Submit one-shot artifacts for all three cases: mythos-craft, pelican-cycling, skeleton-watch
- Artifacts live at `outputs/glm-5-2/cursor-high/`

## Run info
- 模型 / Model: GLM-5.2
- 厂商 / Vendor: Zhipu AI
- 运行环境 / Harness: Cursor
- 思考配额 / Thinking effort: High
- 是否一次生成 / One-shot: 是 / Yes

## 生成凭证截图 / Proof screenshot
<!-- TODO: 请在此贴生成过程截图（模型名 + High 思考配额可见） -->

## Test plan
- [x] `bun scripts/validate-data.ts` passes locally
- [ ] Maintainer: verify proof screenshot is attached before merge