### PR TITLE
Add Qoder Ultimate (Qoder, Max) skeleton-watch runs (2 takes)

### DIFF
--- a/models/qoder-ultimate-max.json
+++ b/models/qoder-ultimate-max.json
@@ -1,0 +1,27 @@
+{
+  "label": "Qoder Ultimate",
+  "vendor": "Alibaba",
+  "harness": "Qoder",
+  "effort": "Max",
+  "artifactDir": "qoder-ultimate/qoder-max",
+  "order": 136.5,
+  "runs": {
+    "skeleton-watch": [
+      {
+        "note": {
+          "zh": "在 Qoder 中以 Qoder Ultimate（Max 1M）使用仓库标准中文提示词在单次测评会话中一次生成，从空工作目录开始，未加载 harness 自带以外的任何 skill、插件、MCP、自定义规则或系统提示。原始产出把产品名与机芯型号写成了QODER · HAUTE HORLOGERIE与QDR-88，会在 Arena 盲评中暗示模型身份；本页仅替换为中性品牌与型号BOREAL · HAUTE HORLOGERIE与BT-100，其余未改。",
+          "en": "Generated in one shot within a single benchmark session by Qoder Ultimate (Max 1M) in Qoder, using the repository's canonical Chinese prompt, starting from an empty working directory, with no skills, plugins, MCP, custom rules or system prompts loaded beyond what the harness ships with. The original output named the product and movement QODER · HAUTE HORLOGERIE and QDR-88, which would hint at the model's identity in blind Arena review; on this page they were replaced with the neutral brand and calibre BOREAL · HAUTE HORLOGERIE and BT-100 only, nothing else was changed."
+        },
+        "contributor": "TheLuck-404"
+      },
+      {
+        "file": "skeleton-watch-2.html",
+        "note": {
+          "zh": "在 Qoder 中以 Qoder Ultimate（Max 1M）使用仓库标准中文提示词在单次测评会话中一次生成，从空工作目录开始，未加载 harness 自带以外的任何 skill、插件、MCP、自定义规则或系统提示。原始产出把产品名与机芯型号写成了MAISON QODER与QD-88，会在 Arena 盲评中暗示模型身份；本页仅替换为中性品牌与型号MAISON FASHION与MF-500，其余未改。",
+          "en": "Generated in one shot within a single benchmark session by Qoder Ultimate (Max 1M) in Qoder, using the repository's canonical Chinese prompt, starting from an empty working directory, with no skills, plugins, MCP, custom rules or system prompts loaded beyond what the harness ships with. The original output named the product and movement MAISON QODER and QD-88, which would hint at the model's identity in blind Arena review; on this page they were replaced with the neutral brand and calibre MAISON FASHION and MF-500 only, nothing else was changed."
+        },
+        "contributor": "TheLuck-404"
+      }
+    ]
+  }
+}

--- a/outputs/qoder-ultimate/qoder-max/skeleton-watch-2.html
+++ b/outputs/qoder-ultimate/qoder-max/skeleton-watch-2.html
@@ -1,0 +1,1366 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Calibre MF-500 · 镂空机械腕表 | Skeleton Mechanical Watch</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html, body { width: 100%; height: 100%; overflow: hidden; background: #050507; }
+  body {
+    font-family: Georgia, 'Times New Roman', 'STSong', 'SimSun', serif;
+    color: #e8e2d5;
+    -webkit-font-smoothing: antialiased;
+  }
+  #app { position: fixed; inset: 0; }
+  canvas { display: block; }
+
+  /* ---------- Loading ---------- */
+  #loading {
+    position: fixed; inset: 0; z-index: 100;
+    background: radial-gradient(ellipse at center, #0c0c10 0%, #050507 70%);
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    gap: 22px; transition: opacity 1s ease; 
+  }
+  #loading.hidden { opacity: 0; pointer-events: none; }
+  .load-ring {
+    width: 64px; height: 64px; border-radius: 50%;
+    border: 1px solid rgba(201,169,97,.15);
+    border-top-color: #c9a961;
+    animation: spin 1.1s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .load-text { letter-spacing: .5em; font-size: 12px; color: #c9a961; text-indent: .5em; }
+
+  /* ---------- Header ---------- */
+  #header {
+    position: fixed; top: 34px; left: 44px; z-index: 10; pointer-events: none;
+    animation: fadeDown 1.4s ease .3s both;
+  }
+  @keyframes fadeDown { from { opacity: 0; transform: translateY(-14px); } to { opacity: 1; transform: none; } }
+  #header .brand {
+    font-size: 21px; letter-spacing: .42em; color: #e8e2d5; font-weight: 400;
+  }
+  #header .brand em { font-style: normal; color: #c9a961; }
+  #header .sub {
+    margin-top: 9px; font-size: 11.5px; letter-spacing: .28em; color: rgba(232,226,213,.5);
+  }
+  #header .rule {
+    margin-top: 13px; width: 200px; height: 1px;
+    background: linear-gradient(90deg, #c9a961, transparent);
+  }
+
+  /* ---------- Hint ---------- */
+  #hint {
+    position: fixed; left: 44px; bottom: 30px; z-index: 10; pointer-events: none;
+    font-size: 11px; letter-spacing: .2em; color: rgba(232,226,213,.42);
+    animation: fadeDown 1.4s ease .9s both;
+  }
+  #hint span { color: rgba(201,169,97,.8); }
+
+  /* ---------- Tooltip ---------- */
+  #tooltip {
+    position: fixed; z-index: 40; pointer-events: none;
+    padding: 10px 16px 11px;
+    background: linear-gradient(160deg, rgba(24,22,18,.92), rgba(10,9,8,.92));
+    border: 1px solid rgba(201,169,97,.45);
+    border-radius: 3px;
+    box-shadow: 0 8px 32px rgba(0,0,0,.6), inset 0 1px 0 rgba(255,255,255,.06);
+    backdrop-filter: blur(6px);
+    opacity: 0; transform: translate(14px, -50%) scale(.96);
+    transition: opacity .18s ease, transform .18s ease;
+  }
+  #tooltip.show { opacity: 1; transform: translate(14px, -50%) scale(1); }
+  #tooltip .t-zh { font-size: 14.5px; color: #f0e9d8; letter-spacing: .12em; }
+  #tooltip .t-en { margin-top: 3px; font-size: 10px; letter-spacing: .22em; color: #c9a961; text-transform: uppercase; }
+
+  /* ---------- Info Panel ---------- */
+  #panel {
+    position: fixed; top: 50%; right: 36px; z-index: 20;
+    transform: translateY(-50%);
+    width: 292px;
+    background: linear-gradient(170deg, rgba(20,19,16,.88), rgba(8,8,9,.88));
+    border: 1px solid rgba(201,169,97,.28);
+    border-radius: 4px;
+    box-shadow: 0 20px 60px rgba(0,0,0,.55);
+    backdrop-filter: blur(10px);
+    transition: transform .5s cubic-bezier(.4,0,.2,1), opacity .5s;
+    animation: fadeDown 1.4s ease .6s both;
+  }
+  #panel.collapsed { transform: translateY(-50%) translateX(316px); opacity: 0; pointer-events: none; }
+  #panel .p-head {
+    padding: 18px 22px 14px;
+    border-bottom: 1px solid rgba(201,169,97,.18);
+  }
+  #panel .p-head h2 { font-size: 13px; letter-spacing: .3em; color: #c9a961; font-weight: 400; }
+  #panel .p-head .cal { margin-top: 5px; font-size: 18px; letter-spacing: .1em; color: #f0e9d8; }
+  #panel .specs { padding: 14px 22px 10px; }
+  #panel .spec-row {
+    display: flex; justify-content: space-between; align-items: baseline;
+    padding: 6.5px 0; border-bottom: 1px dotted rgba(232,226,213,.09);
+    font-size: 12px;
+  }
+  #panel .spec-row:last-child { border-bottom: none; }
+  #panel .spec-row .k { color: rgba(232,226,213,.5); letter-spacing: .1em; }
+  #panel .spec-row .v { color: #e8e2d5; letter-spacing: .05em; }
+  #panel .spec-row .v i { font-style: normal; color: #c9a961; }
+  #part-detail {
+    margin: 6px 16px 16px; padding: 14px 16px;
+    background: rgba(201,169,97,.06);
+    border: 1px solid rgba(201,169,97,.22);
+    border-radius: 3px;
+    display: none;
+  }
+  #part-detail.show { display: block; animation: fadeDown .35s ease both; }
+  #part-detail .d-zh { font-size: 14px; color: #f0e9d8; letter-spacing: .1em; }
+  #part-detail .d-en { margin-top: 3px; font-size: 9.5px; letter-spacing: .2em; color: #c9a961; text-transform: uppercase; }
+  #part-detail .d-desc { margin-top: 9px; font-size: 11.5px; line-height: 1.75; color: rgba(232,226,213,.72); }
+
+  /* ---------- Controls ---------- */
+  #controls {
+    position: fixed; bottom: 26px; left: 50%; z-index: 30;
+    transform: translateX(-50%);
+    display: flex; align-items: center; gap: 10px;
+    padding: 10px 14px;
+    background: linear-gradient(170deg, rgba(20,19,16,.85), rgba(8,8,9,.85));
+    border: 1px solid rgba(201,169,97,.25);
+    border-radius: 40px;
+    box-shadow: 0 14px 40px rgba(0,0,0,.5);
+    backdrop-filter: blur(10px);
+    animation: fadeUp 1.4s ease .8s both;
+  }
+  @keyframes fadeUp { from { opacity: 0; transform: translateX(-50%) translateY(16px); } to { opacity: 1; transform: translateX(-50%); } }
+  .btn {
+    appearance: none; border: 1px solid rgba(201,169,97,.35);
+    background: transparent; color: #d8d0bd;
+    font-family: inherit; font-size: 11.5px; letter-spacing: .14em;
+    padding: 8px 17px; border-radius: 30px; cursor: pointer;
+    transition: all .25s ease; white-space: nowrap;
+  }
+  .btn:hover { border-color: #c9a961; color: #f0e9d8; background: rgba(201,169,97,.1); }
+  .btn.active {
+    background: linear-gradient(160deg, #c9a961, #9a7a3e);
+    border-color: #c9a961; color: #14120c;
+  }
+  .ctl-sep { width: 1px; height: 20px; background: rgba(201,169,97,.25); }
+  .slider-wrap { display: flex; align-items: center; gap: 9px; padding: 0 6px; }
+  .slider-wrap label { font-size: 10.5px; letter-spacing: .16em; color: rgba(232,226,213,.55); white-space: nowrap; }
+  .slider-wrap output { font-size: 10.5px; color: #c9a961; min-width: 34px; text-align: right; }
+  input[type=range] {
+    appearance: none; -webkit-appearance: none; width: 104px; height: 2px;
+    background: linear-gradient(90deg, #c9a961 var(--f,0%), rgba(232,226,213,.18) var(--f,0%));
+    border-radius: 2px; outline: none; cursor: pointer;
+  }
+  input[type=range]::-webkit-slider-thumb {
+    -webkit-appearance: none; width: 12px; height: 12px; border-radius: 50%;
+    background: #e9cf96; border: 1px solid #8a6d35;
+    box-shadow: 0 2px 6px rgba(0,0,0,.5);
+  }
+
+  /* ---------- Vignette ---------- */
+  #vignette {
+    position: fixed; inset: 0; z-index: 5; pointer-events: none;
+    background: radial-gradient(ellipse at center, transparent 52%, rgba(0,0,0,.55) 100%);
+  }
+  @media (max-width: 900px) {
+    #panel { display: none; }
+    #header { left: 22px; top: 22px; }
+    #header .brand { font-size: 16px; }
+  }
+</style>
+</head>
+<body>
+<div id="app"></div>
+<div id="vignette"></div>
+
+<div id="loading">
+  <div class="load-ring"></div>
+  <div class="load-text">CALIBRE MF-500</div>
+</div>
+
+<div id="header">
+  <div class="brand">MAISON <em>FASHION</em></div>
+  <div class="sub">CALIBRE MF-500 &nbsp;·&nbsp; 镂空机械机芯 SQUELETTE</div>
+  <div class="rule"></div>
+</div>
+
+<div id="hint">
+  <span>拖动</span> 旋转 &nbsp;·&nbsp; <span>滚轮</span> 缩放 &nbsp;·&nbsp; <span>悬停 / 点击</span> 查看零件
+</div>
+
+<div id="tooltip">
+  <div class="t-zh"></div>
+  <div class="t-en"></div>
+</div>
+
+<div id="panel">
+  <div class="p-head">
+    <h2>机芯规格 MOVEMENT</h2>
+    <div class="cal">Calibre MF-500</div>
+  </div>
+  <div class="specs">
+    <div class="spec-row"><span class="k">机芯类型 Type</span><span class="v">手动上链镂空 Manual</span></div>
+    <div class="spec-row"><span class="k">振频 Frequency</span><span class="v"><i>21,600</i> vph · 3 Hz</span></div>
+    <div class="spec-row"><span class="k">动力储存 Reserve</span><span class="v"><i>72</i> 小时 hours</span></div>
+    <div class="spec-row"><span class="k">宝石数 Jewels</span><span class="v"><i>25</i> 钻</span></div>
+    <div class="spec-row"><span class="k">零件数 Parts</span><span class="v"><i>218</i></span></div>
+    <div class="spec-row"><span class="k">机芯直径 Ø</span><span class="v">32.6 mm</span></div>
+    <div class="spec-row"><span class="k">机芯厚度 H</span><span class="v">4.2 mm</span></div>
+    <div class="spec-row"><span class="k">游丝 Hairspring</span><span class="v">宝玑式上绕 Breguet</span></div>
+    <div class="spec-row"><span class="k">修饰 Finishing</span><span class="v">手工倒角 · 镀金</span></div>
+  </div>
+  <div id="part-detail">
+    <div class="d-zh"></div>
+    <div class="d-en"></div>
+    <div class="d-desc"></div>
+  </div>
+</div>
+
+<div id="controls">
+  <button class="btn" id="btn-explode">爆炸视图 EXPLODE</button>
+  <button class="btn active" id="btn-rotate">自动旋转 AUTO</button>
+  <button class="btn" id="btn-panel">机芯信息 INFO</button>
+  <button class="btn" id="btn-reset">重置 RESET</button>
+  <div class="ctl-sep"></div>
+  <div class="slider-wrap">
+    <label>速度 SPEED</label>
+    <input type="range" id="speed" min="0" max="100" step="1" value="1">
+    <output id="speed-out">1×</output>
+  </div>
+</div>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
+    "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/"
+  }
+}
+</script>
+
+<script type="module">
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';
+import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
+import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+
+/* ============================================================
+   Renderer / Scene / Camera
+============================================================ */
+const app = document.getElementById('app');
+const renderer = new THREE.WebGLRenderer({ antialias: true, powerPreference: 'high-performance' });
+renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+renderer.setSize(window.innerWidth, window.innerHeight);
+renderer.shadowMap.enabled = true;
+renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+renderer.toneMapping = THREE.ACESFilmicToneMapping;
+renderer.toneMappingExposure = 0.78;
+app.appendChild(renderer.domElement);
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x050507);
+scene.fog = new THREE.Fog(0x050507, 14, 30);
+
+const camera = new THREE.PerspectiveCamera(38, window.innerWidth / window.innerHeight, 0.1, 100);
+const CAM_HOME = new THREE.Vector3(2.8, 1.9, 7.6);
+camera.position.copy(CAM_HOME);
+
+const controls = new OrbitControls(camera, renderer.domElement);
+controls.enableDamping = true;
+controls.dampingFactor = 0.06;
+controls.minDistance = 3.2;
+controls.maxDistance = 15;
+controls.maxPolarAngle = Math.PI * 0.55;
+controls.autoRotate = true;
+controls.autoRotateSpeed = 0.8;
+controls.target.set(0, 0, 0);
+
+/* Environment for PBR reflections */
+const pmrem = new THREE.PMREMGenerator(renderer);
+scene.environment = pmrem.fromScene(new RoomEnvironment(renderer), 0.04).texture;
+
+/* ============================================================
+   Materials
+============================================================ */
+const M = {
+  roseGold: new THREE.MeshPhysicalMaterial({
+    color: 0xc48a6a, metalness: 1.0, roughness: 0.18,
+    clearcoat: 0.6, clearcoatRoughness: 0.2, envMapIntensity: 1.15
+  }),
+  roseGoldBrushed: new THREE.MeshPhysicalMaterial({
+    color: 0xb47a5c, metalness: 1.0, roughness: 0.38, envMapIntensity: 0.9
+  }),
+  gold: new THREE.MeshPhysicalMaterial({
+    color: 0xd9b060, metalness: 1.0, roughness: 0.22,
+    clearcoat: 0.4, clearcoatRoughness: 0.25, envMapIntensity: 1.1
+  }),
+  gilt: new THREE.MeshPhysicalMaterial({
+    color: 0xcfa64e, metalness: 1.0, roughness: 0.3, envMapIntensity: 1.0
+  }),
+  steel: new THREE.MeshPhysicalMaterial({
+    color: 0xcdd2d8, metalness: 1.0, roughness: 0.25, envMapIntensity: 0.75
+  }),
+  steelDark: new THREE.MeshPhysicalMaterial({
+    color: 0x8a8f96, metalness: 1.0, roughness: 0.35, envMapIntensity: 0.85
+  }),
+  germanSilver: new THREE.MeshPhysicalMaterial({
+    color: 0x9e988a, metalness: 0.95, roughness: 0.45, envMapIntensity: 0.4
+  }),
+  bluedSteel: new THREE.MeshPhysicalMaterial({
+    color: 0x2a4fd0, metalness: 0.95, roughness: 0.18,
+    clearcoat: 0.8, clearcoatRoughness: 0.15, envMapIntensity: 1.3
+  }),
+  ruby: new THREE.MeshPhysicalMaterial({
+    color: 0xd8103f, metalness: 0.1, roughness: 0.08,
+    clearcoat: 1.0, clearcoatRoughness: 0.05,
+    emissive: 0x550814, emissiveIntensity: 0.5, envMapIntensity: 1.2
+  }),
+  sapphire: new THREE.MeshPhysicalMaterial({
+    color: 0xdfe9f5, metalness: 0, roughness: 0.02,
+    transparent: true, opacity: 0.045,
+    clearcoat: 0.5, clearcoatRoughness: 0.03,
+    envMapIntensity: 0.5, specularIntensity: 0.6,
+    depthWrite: false
+  }),
+  lume: new THREE.MeshStandardMaterial({
+    color: 0x9fffc0, emissive: 0x53f08a, emissiveIntensity: 1.7,
+    metalness: 0, roughness: 0.6
+  }),
+  dialDark: new THREE.MeshPhysicalMaterial({
+    color: 0x14151a, metalness: 0.75, roughness: 0.42, envMapIntensity: 0.6
+  }),
+  floor: new THREE.MeshPhysicalMaterial({
+    color: 0x0a0a0d, metalness: 0.9, roughness: 0.32,
+    clearcoat: 0.5, clearcoatRoughness: 0.25, envMapIntensity: 0.55
+  })
+};
+
+/* ============================================================
+   Geometry helpers
+============================================================ */
+// Toothed gear shape with optional pointy (escapement-style) teeth,
+// hub hole and skeletonized spoke cutouts
+function gearShape({ teeth, rOut, toothH, toothRatio = 0.45, pointy = false, skew = 0,
+                     holeR = 0.045, rimR = 0, hubR = 0, spokes = 0, spokeW = 0.16 }) {
+  const rIn = rOut - toothH;
+  const step = (Math.PI * 2) / teeth;
+  const pts = [];
+  const arc = (r, a0, a1, n) => {
+    for (let j = 0; j <= n; j++) {
+      const a = a0 + (a1 - a0) * (j / n);
+      pts.push(new THREE.Vector2(Math.cos(a) * r, Math.sin(a) * r));
+    }
+  };
+  for (let i = 0; i < teeth; i++) {
+    const a = i * step;
+    const gapEnd = a + step * (1 - toothRatio);
+    arc(rIn, a, gapEnd, 2);
+    if (pointy) {
+      const tip = gapEnd + step * toothRatio * 0.5 + skew * step;
+      pts.push(new THREE.Vector2(Math.cos(tip) * rOut, Math.sin(tip) * rOut));
+    } else {
+      const lead = step * toothRatio * 0.18;
+      pts.push(new THREE.Vector2(Math.cos(gapEnd + lead) * rOut, Math.sin(gapEnd + lead) * rOut));
+      pts.push(new THREE.Vector2(Math.cos(a + step - lead) * rOut, Math.sin(a + step - lead) * rOut));
+    }
+  }
+  const shape = new THREE.Shape(pts);
+  if (holeR > 0) {
+    const h = new THREE.Path();
+    h.absarc(0, 0, holeR, 0, Math.PI * 2, true);
+    shape.holes.push(h);
+  }
+  if (spokes > 0 && rimR > hubR) {
+    const span = (Math.PI * 2) / spokes;
+    for (let k = 0; k < spokes; k++) {
+      const a0 = k * span + spokeW;
+      const a1 = (k + 1) * span - spokeW;
+      const hole = new THREE.Path();
+      const N = 10;
+      for (let j = 0; j <= N; j++) {
+        const a = a0 + (a1 - a0) * (j / N);
+        const p = new THREE.Vector2(Math.cos(a) * hubR, Math.sin(a) * hubR);
+        (j === 0) ? hole.moveTo(p.x, p.y) : hole.lineTo(p.x, p.y);
+      }
+      for (let j = N; j >= 0; j--) {
+        const a = a0 + (a1 - a0) * (j / N);
+        hole.lineTo(Math.cos(a) * rimR, Math.sin(a) * rimR);
+      }
+      shape.holes.push(hole);
+    }
+  }
+  return shape;
+}
+
+function extrude(shape, depth, bevel = 0.008) {
+  const g = new THREE.ExtrudeGeometry(shape, {
+    depth, bevelEnabled: bevel > 0, bevelThickness: bevel, bevelSize: bevel * 0.8,
+    bevelSegments: 2, curveSegments: 24
+  });
+  g.translate(0, 0, -depth / 2);
+  return g;
+}
+
+function makeGear(opts, material, depth = 0.045) {
+  const mesh = new THREE.Mesh(extrude(gearShape(opts), depth), material);
+  mesh.castShadow = mesh.receiveShadow = true;
+  return mesh;
+}
+
+// Annulus sector plate (used for bridges) with circular holes
+function sectorPlate(rIn, rOut, a0, a1, holes = [], depth = 0.05, material = M.germanSilver) {
+  const shape = new THREE.Shape();
+  const N = 40;
+  for (let j = 0; j <= N; j++) {
+    const a = a0 + (a1 - a0) * (j / N);
+    const x = Math.cos(a) * rOut, y = Math.sin(a) * rOut;
+    (j === 0) ? shape.moveTo(x, y) : shape.lineTo(x, y);
+  }
+  for (let j = N; j >= 0; j--) {
+    const a = a0 + (a1 - a0) * (j / N);
+    shape.lineTo(Math.cos(a) * rIn, Math.sin(a) * rIn);
+  }
+  shape.closePath();
+  for (const h of holes) {
+    const p = new THREE.Path();
+    p.absarc(h.x, h.y, h.r, 0, Math.PI * 2, true);
+    shape.holes.push(p);
+  }
+  const mesh = new THREE.Mesh(extrude(shape, depth, 0.01), material);
+  mesh.castShadow = mesh.receiveShadow = true;
+  return mesh;
+}
+
+// Flat spiral (mainspring / hairspring)
+function makeSpiral({ turns, r0, r1, tubeR, flatten = 1, material, segsPerTurn = 60 }) {
+  const pts = [];
+  const total = Math.floor(turns * segsPerTurn);
+  for (let i = 0; i <= total; i++) {
+    const t = i / total;
+    const a = t * turns * Math.PI * 2;
+    const r = r0 + (r1 - r0) * t;
+    pts.push(new THREE.Vector3(Math.cos(a) * r, Math.sin(a) * r, 0));
+  }
+  const curve = new THREE.CatmullRomCurve3(pts);
+  const geo = new THREE.TubeGeometry(curve, total, tubeR, 6, false);
+  const mesh = new THREE.Mesh(geo, material);
+  mesh.scale.z = flatten;
+  mesh.castShadow = true;
+  return mesh;
+}
+
+// Ruby jewel bearing with gold chaton
+function makeJewel(r = 0.05) {
+  const g = new THREE.Group();
+  const jewel = new THREE.Mesh(new THREE.CylinderGeometry(r, r * 0.85, 0.035, 20), M.ruby);
+  jewel.rotation.x = Math.PI / 2;
+  jewel.castShadow = true;
+  const chaton = new THREE.Mesh(new THREE.TorusGeometry(r * 1.28, r * 0.32, 8, 24), M.gold);
+  chaton.scale.z = 0.6;
+  g.add(jewel, chaton);
+  return g;
+}
+
+// Blued screw with slot
+function makeScrew(r = 0.042) {
+  const g = new THREE.Group();
+  const head = new THREE.Mesh(new THREE.CylinderGeometry(r, r * 0.9, 0.028, 16), M.bluedSteel);
+  head.rotation.x = Math.PI / 2;
+  head.castShadow = true;
+  const slot = new THREE.Mesh(new THREE.BoxGeometry(r * 1.7, r * 0.3, 0.008), M.steelDark);
+  slot.position.z = 0.016;
+  slot.rotation.z = Math.random() * Math.PI;
+  g.add(head, slot);
+  return g;
+}
+
+/* ============================================================
+   Part registry (hover / click / explode)
+============================================================ */
+const parts = [];
+const rayTargets = [];
+
+function registerPart(group, info) {
+  const matCache = new Map();
+  group.traverse(o => {
+    if (o.isMesh) {
+      if (!matCache.has(o.material)) matCache.set(o.material, o.material.clone());
+      o.material = matCache.get(o.material);
+      o.userData.part = info;
+      rayTargets.push(o);
+    }
+  });
+  info.group = group;
+  info.basePos = group.position.clone();
+  info.explode = info.explode || new THREE.Vector3();
+  info.mats = [...matCache.values()].map(m => ({
+    m, e: m.emissive ? m.emissive.getHex() : 0, i: m.emissiveIntensity ?? 1
+  }));
+  parts.push(info);
+  return info;
+}
+
+function setHighlight(info, on) {
+  if (!info) return;
+  for (const rec of info.mats) {
+    if (!rec.m.emissive) continue;
+    if (on) { rec.m.emissive.setHex(0xa07828); rec.m.emissiveIntensity = Math.max(rec.i, 0.55); }
+    else { rec.m.emissive.setHex(rec.e); rec.m.emissiveIntensity = rec.i; }
+  }
+}
+
+/* ============================================================
+   Watch construction
+============================================================ */
+const watch = new THREE.Group();
+watch.rotation.x = -0.32;
+watch.position.y = 0.15;
+scene.add(watch);
+
+const V3 = (x, y, z) => new THREE.Vector3(x, y, z);
+
+/* -------------------- Case middle + lugs -------------------- */
+{
+  const g = new THREE.Group();
+  const profile = [
+    new THREE.Vector2(1.74, -0.50), new THREE.Vector2(2.02, -0.40),
+    new THREE.Vector2(2.10, -0.16), new THREE.Vector2(2.10, 0.16),
+    new THREE.Vector2(2.02, 0.40), new THREE.Vector2(1.74, 0.50)
+  ];
+  const mid = new THREE.Mesh(new THREE.LatheGeometry(profile, 96), M.roseGold);
+  mid.rotation.x = Math.PI / 2;
+  mid.castShadow = mid.receiveShadow = true;
+  g.add(mid);
+  // brushed inner flank ring
+  const flank = new THREE.Mesh(new THREE.CylinderGeometry(1.76, 1.76, 0.92, 96, 1, true), M.roseGoldBrushed);
+  flank.rotation.x = Math.PI / 2;
+  g.add(flank);
+  // lugs
+  const lugGeo = new THREE.CapsuleGeometry(0.13, 0.52, 6, 12);
+  for (const sx of [-1, 1]) for (const sy of [-1, 1]) {
+    const lug = new THREE.Mesh(lugGeo, M.roseGold);
+    lug.position.set(0.82 * sx, 2.12 * sy, -0.06);
+    lug.rotation.x = 0.42 * sy;
+    lug.rotation.z = 0.10 * sx * sy;
+    lug.castShadow = true;
+    g.add(lug);
+  }
+  watch.add(g);
+  registerPart(g, {
+    id: 'case', name: '表壳', en: 'Case Middle & Lugs',
+    desc: '18K 玫瑰金三件式表壳，直径 42 mm。侧面缎面拉丝与表耳镜面抛光交替呈现，倒角均由工匠手工完成。',
+    explode: V3(0, 0, 0)
+  });
+}
+
+/* -------------------- Bezel -------------------- */
+{
+  const g = new THREE.Group();
+  const bezel = new THREE.Mesh(new THREE.TorusGeometry(1.90, 0.145, 24, 96), M.roseGold);
+  bezel.scale.z = 0.75;
+  bezel.position.z = 0.46;
+  bezel.castShadow = true;
+  const ring = new THREE.Mesh(new THREE.RingGeometry(1.74, 2.04, 96), M.roseGoldBrushed);
+  ring.position.z = 0.545;
+  g.add(bezel, ring);
+  watch.add(g);
+  registerPart(g, {
+    id: 'bezel', name: '表圈', en: 'Polished Bezel',
+    desc: '弧形抛光表圈，与蓝宝石水晶无缝衔接；内侧暗藏防水密封圈，保证 50 米防水性能。',
+    explode: V3(0, 0, 1.35)
+  });
+}
+
+/* -------------------- Sapphire crystals -------------------- */
+{
+  const g = new THREE.Group();
+  const R = 6, half = Math.asin(1.82 / R);
+  const dome = new THREE.Mesh(new THREE.SphereGeometry(R, 72, 24, 0, Math.PI * 2, 0, half), M.sapphire);
+  dome.rotation.x = Math.PI / 2;
+  dome.position.z = 0.52 - R * Math.cos(half);
+  const back = new THREE.Mesh(new THREE.CylinderGeometry(1.70, 1.70, 0.05, 72), M.sapphire);
+  back.rotation.x = Math.PI / 2;
+  back.position.z = -0.52;
+  g.add(dome, back);
+  watch.add(g);
+  registerPart(g, {
+    id: 'crystal', name: '蓝宝石水晶', en: 'Sapphire Crystal',
+    desc: '正反双面蓝宝石水晶（莫氏硬度 9），双面防眩光镀膜。盒形拱面設計，从侧面亦可窥见机芯运转。',
+    explode: V3(0, 0, 2.0)
+  });
+}
+
+/* -------------------- Caseback ring + crown -------------------- */
+{
+  const g = new THREE.Group();
+  const ring = new THREE.Mesh(new THREE.TorusGeometry(1.86, 0.11, 20, 96), M.roseGoldBrushed);
+  ring.scale.z = 0.7;
+  ring.position.z = -0.47;
+  g.add(ring);
+  // screws on caseback ring
+  for (let i = 0; i < 6; i++) {
+    const a = i * Math.PI / 3 + 0.26;
+    const s = makeScrew(0.05);
+    s.position.set(Math.cos(a) * 1.86, Math.sin(a) * 1.86, -0.55);
+    s.rotation.x = Math.PI;
+    g.add(s);
+  }
+  watch.add(g);
+  registerPart(g, {
+    id: 'caseback', name: '底盖固定环', en: 'Caseback Ring',
+    desc: '六枚螺丝固定的透视底盖框，透过蓝宝石底盖可欣赏机芯背面的手工鱼鳞纹打磨。',
+    explode: V3(0, 0, -1.6)
+  });
+}
+
+{
+  const g = new THREE.Group();
+  const stem = new THREE.Mesh(new THREE.CylinderGeometry(0.075, 0.075, 0.34, 16), M.roseGoldBrushed);
+  stem.rotation.z = Math.PI / 2;
+  stem.position.x = 2.12;
+  const head = new THREE.Mesh(new THREE.CylinderGeometry(0.235, 0.235, 0.24, 28), M.roseGold);
+  head.rotation.z = Math.PI / 2;
+  head.position.x = 2.40;
+  head.castShadow = true;
+  g.add(stem, head);
+  for (let i = 0; i < 22; i++) { // knurling
+    const a = (i / 22) * Math.PI * 2;
+    const k = new THREE.Mesh(new THREE.BoxGeometry(0.26, 0.035, 0.045), M.roseGoldBrushed);
+    k.position.set(2.40, Math.cos(a) * 0.235, Math.sin(a) * 0.235);
+    k.rotation.x = -a;
+    g.add(k);
+  }
+  const cap = new THREE.Mesh(new THREE.SphereGeometry(0.20, 24, 12), M.roseGold);
+  cap.scale.x = 0.45; cap.position.x = 2.53;
+  g.add(cap);
+  watch.add(g);
+  registerPart(g, {
+    id: 'crown', name: '表冠', en: 'Winding Crown',
+    desc: '滚花旋入式表冠，为主发条上链并调校时间；冠顶镌刻品牌徽记。',
+    explode: V3(1.1, 0, 0)
+  });
+}
+
+/* -------------------- Layout of the going train -------------------- */
+const POS = {
+  barrel: V3(0, 0.92, -0.13),
+  center: V3(0, 0, -0.10),
+  third:  V3(0.88, 0.38, -0.16),
+  fourth: V3(0.98, -0.55, -0.10),
+  escape: V3(0.34, -1.02, -0.13),
+  pallet: V3(-0.16, -1.02, -0.04),
+  balance: V3(-0.78, -0.78, 0.10)
+};
+
+/* -------------------- Main plate (skeletonized) -------------------- */
+{
+  const g = new THREE.Group();
+  const shape = new THREE.Shape();
+  shape.absarc(0, 0, 1.70, 0, Math.PI * 2, false);
+  const holes = [
+    { x: POS.barrel.x, y: POS.barrel.y, r: 0.58 },
+    { x: POS.center.x, y: POS.center.y, r: 0.30 },
+    { x: POS.third.x, y: POS.third.y, r: 0.26 },
+    { x: POS.fourth.x, y: POS.fourth.y, r: 0.26 },
+    { x: POS.escape.x, y: POS.escape.y, r: 0.17 },
+    { x: POS.balance.x, y: POS.balance.y, r: 0.46 },
+    { x: -0.95, y: 0.55, r: 0.24 },
+    { x: -1.05, y: 0.05, r: 0.17 }
+  ];
+  for (const h of holes) {
+    const p = new THREE.Path();
+    p.absarc(h.x, h.y, h.r, 0, Math.PI * 2, true);
+    shape.holes.push(p);
+  }
+  const plate = new THREE.Mesh(extrude(shape, 0.07, 0.012), M.germanSilver);
+  plate.position.z = -0.30;
+  plate.castShadow = plate.receiveShadow = true;
+  g.add(plate);
+  // perlage-style small bosses on the plate
+  for (let i = 0; i < 8; i++) {
+    const a = i * Math.PI / 4 + 0.4;
+    const boss = new THREE.Mesh(new THREE.CylinderGeometry(0.055, 0.055, 0.02, 14), M.gilt);
+    boss.rotation.x = Math.PI / 2;
+    boss.position.set(Math.cos(a) * 1.52, Math.sin(a) * 1.52, -0.255);
+    g.add(boss);
+  }
+  watch.add(g);
+  registerPart(g, {
+    id: 'plate', name: '主夹板', en: 'Skeletonized Main Plate',
+    desc: '德国银镂空主夹板，经切空、手工倒角与镀铑处理。开放式结构令齿轮系一览无余，仅保留必要的结构强度。',
+    explode: V3(0, 0, -0.85)
+  });
+}
+
+/* -------------------- Mainspring barrel -------------------- */
+const barrelGroup = new THREE.Group();
+{
+  barrelGroup.position.copy(POS.barrel);
+  // barrel toothed rim (great wheel)
+  const rim = makeGear({
+    teeth: 84, rOut: 0.74, toothH: 0.045, toothRatio: 0.5,
+    holeR: 0.05, rimR: 0.62, hubR: 0.16, spokes: 5, spokeW: 0.14
+  }, M.gilt, 0.05);
+  rim.position.z = -0.05;
+  // drum wall
+  const wall = new THREE.Mesh(new THREE.CylinderGeometry(0.62, 0.62, 0.16, 64, 1, true), M.gilt);
+  wall.rotation.x = Math.PI / 2;
+  wall.position.z = 0.03;
+  const wallMesh = wall;
+  wallMesh.material = M.gilt;
+  // skeleton cover: 5 thin spokes
+  const cover = makeGear({
+    teeth: 5, rOut: 0.60, toothH: 0.0001, toothRatio: 0.5,
+    holeR: 0.09, rimR: 0.56, hubR: 0.14, spokes: 5, spokeW: 0.10
+  }, M.roseGoldBrushed, 0.03);
+  cover.position.z = 0.115;
+  // visible mainspring coil
+  const spring = makeSpiral({ turns: 6.5, r0: 0.10, r1: 0.54, tubeR: 0.012, flatten: 5.2, material: M.bluedSteel });
+  spring.position.z = 0.03;
+  // arbor
+  const arbor = new THREE.Mesh(new THREE.CylinderGeometry(0.05, 0.05, 0.36, 16), M.steel);
+  arbor.rotation.x = Math.PI / 2;
+  barrelGroup.add(rim, wall, cover, spring, arbor);
+  watch.add(barrelGroup);
+  registerPart(barrelGroup, {
+    id: 'barrel', name: '主发条盒', en: 'Mainspring Barrel',
+    desc: '镂空发条盒内盘绕着蓝钢主发条 —— 机芯的动力之源，满链可提供 72 小时动力储存。大钢轮沿边缘缓慢释放扭矩。',
+    explode: V3(0, 0.85, 0.35)
+  });
+}
+
+/* -------------------- Going train wheels -------------------- */
+function trainWheel(pos, gearOpts, pinionR, info, explode) {
+  const g = new THREE.Group();
+  g.position.copy(pos);
+  const wheel = makeGear(gearOpts, M.gilt, 0.04);
+  const pinion = new THREE.Mesh(new THREE.CylinderGeometry(pinionR, pinionR, 0.10, 12), M.steel);
+  pinion.rotation.x = Math.PI / 2;
+  pinion.position.z = 0.06;
+  pinion.castShadow = true;
+  const arbor = new THREE.Mesh(new THREE.CylinderGeometry(0.022, 0.022, 0.42, 10), M.steel);
+  arbor.rotation.x = Math.PI / 2;
+  g.add(wheel, pinion, arbor);
+  watch.add(g);
+  registerPart(g, { ...info, explode });
+  return g;
+}
+
+const centerWheel = trainWheel(POS.center,
+  { teeth: 64, rOut: 0.56, toothH: 0.05, holeR: 0.04, rimR: 0.44, hubR: 0.12, spokes: 5, spokeW: 0.12 },
+  0.07,
+  { id: 'center', name: '中心轮', en: 'Center Wheel',
+    desc: '二轮（中心轮）位于机芯中央，每小时自转一周，直接驱动分针；金色轮辐经镜面抛光。' },
+  V3(0, 0, 0.55));
+
+const thirdWheel = trainWheel(POS.third,
+  { teeth: 56, rOut: 0.42, toothH: 0.045, holeR: 0.035, rimR: 0.32, hubR: 0.10, spokes: 4, spokeW: 0.14 },
+  0.055,
+  { id: 'third', name: '三轮（过轮）', en: 'Third Wheel',
+    desc: '过轮承上启下，将中心轮的扭矩加速传递给秒轮，齿数比经过精密计算以保证走时精度。' },
+  V3(0.75, 0.32, 0.42));
+
+const fourthWheel = trainWheel(POS.fourth,
+  { teeth: 60, rOut: 0.40, toothH: 0.042, holeR: 0.032, rimR: 0.30, hubR: 0.09, spokes: 4, spokeW: 0.14 },
+  0.05,
+  { id: 'fourth', name: '秒轮（四轮）', en: 'Fourth Wheel',
+    desc: '秒轮每分钟旋转一周，同时驱动擒纵轮；小秒针即由此轮轴心延伸驱动。' },
+  V3(0.85, -0.48, 0.48));
+
+/* -------------------- Escape wheel -------------------- */
+const escapeWheel = new THREE.Group();
+{
+  escapeWheel.position.copy(POS.escape);
+  const wheel = makeGear({
+    teeth: 15, rOut: 0.30, toothH: 0.085, toothRatio: 0.55, pointy: true, skew: 0.22,
+    holeR: 0.03, rimR: 0.185, hubR: 0.07, spokes: 4, spokeW: 0.18
+  }, M.steel, 0.03);
+  const arbor = new THREE.Mesh(new THREE.CylinderGeometry(0.02, 0.02, 0.36, 10), M.steel);
+  arbor.rotation.x = Math.PI / 2;
+  escapeWheel.add(wheel, arbor);
+  watch.add(escapeWheel);
+  registerPart(escapeWheel, {
+    id: 'escape', name: '擒纵轮', en: 'Escape Wheel',
+    desc: '15 齿镜面抛光钢质擒纵轮，齿形如浪。它以精确的节奏被擒纵叉逐齿释放，每一次跳动都是时间的脉搏。',
+    explode: V3(0.30, -0.90, 0.30)
+  });
+}
+
+/* -------------------- Pallet fork -------------------- */
+const palletFork = new THREE.Group();
+{
+  palletFork.position.copy(POS.pallet);
+  const body = new THREE.Mesh(new THREE.BoxGeometry(0.34, 0.055, 0.03), M.steel);
+  body.castShadow = true;
+  const armL = new THREE.Mesh(new THREE.BoxGeometry(0.05, 0.16, 0.03), M.steel);
+  armL.position.set(0.17, 0.06, 0);
+  armL.rotation.z = -0.5;
+  const armR = new THREE.Mesh(new THREE.BoxGeometry(0.05, 0.16, 0.03), M.steel);
+  armR.position.set(0.17, -0.06, 0);
+  armR.rotation.z = 0.5;
+  const jewelIn = new THREE.Mesh(new THREE.BoxGeometry(0.03, 0.07, 0.035), M.ruby);
+  jewelIn.position.set(0.20, 0.105, 0);
+  jewelIn.rotation.z = -0.5;
+  const jewelOut = new THREE.Mesh(new THREE.BoxGeometry(0.03, 0.07, 0.035), M.ruby);
+  jewelOut.position.set(0.20, -0.105, 0);
+  jewelOut.rotation.z = 0.5;
+  // fork horns toward balance
+  const horn = new THREE.Mesh(new THREE.BoxGeometry(0.10, 0.028, 0.028), M.steel);
+  horn.position.set(-0.20, 0.035, 0);
+  horn.rotation.z = 0.45;
+  const horn2 = horn.clone();
+  horn2.position.y = -0.035; horn2.rotation.z = -0.45;
+  const pivot = new THREE.Mesh(new THREE.CylinderGeometry(0.018, 0.018, 0.2, 10), M.steel);
+  pivot.rotation.x = Math.PI / 2;
+  palletFork.add(body, armL, armR, jewelIn, jewelOut, horn, horn2, pivot);
+  watch.add(palletFork);
+  registerPart(palletFork, {
+    id: 'pallet', name: '擒纵叉', en: 'Pallet Fork',
+    desc: '马式擒纵叉镶嵌两枚红宝石叉瓦，每秒往复六次，锁定并释放擒纵轮，将能量以脉冲形式传递给摆轮。',
+    explode: V3(-0.14, -0.95, 0.24)
+  });
+}
+
+/* -------------------- Balance wheel + hairspring -------------------- */
+const balanceGroup = new THREE.Group();   // whole assembly (position)
+const balanceWheel = new THREE.Group();   // oscillating part
+{
+  balanceGroup.position.copy(POS.balance);
+  // gold rim
+  const rim = new THREE.Mesh(new THREE.TorusGeometry(0.40, 0.045, 14, 64), M.gold);
+  rim.castShadow = true;
+  balanceWheel.add(rim);
+  // crossing arms
+  for (let i = 0; i < 2; i++) {
+    const arm = new THREE.Mesh(new THREE.BoxGeometry(0.78, 0.05, 0.035), M.gold);
+    arm.rotation.z = i * Math.PI / 2 + 0.4;
+    balanceWheel.add(arm);
+  }
+  // timing screws around the rim, oriented radially
+  for (let i = 0; i < 8; i++) {
+    const a = (i / 8) * Math.PI * 2;
+    const s = new THREE.Mesh(new THREE.CylinderGeometry(0.028, 0.028, 0.07, 10), M.gold);
+    s.position.set(Math.cos(a) * 0.455, Math.sin(a) * 0.455, 0);
+    s.rotation.z = a - Math.PI / 2; // cylinder Y-axis points outward
+    balanceWheel.add(s);
+  }
+  // balance staff
+  const staff = new THREE.Mesh(new THREE.CylinderGeometry(0.022, 0.022, 0.34, 12), M.steel);
+  staff.rotation.x = Math.PI / 2;
+  balanceWheel.add(staff);
+  // blued hairspring, slightly raised (Breguet overcoil look)
+  const hs = makeSpiral({ turns: 9, r0: 0.03, r1: 0.30, tubeR: 0.0045, flatten: 1.6, material: M.bluedSteel, segsPerTurn: 48 });
+  hs.position.z = 0.09;
+  balanceWheel.add(hs);
+  balanceGroup.add(balanceWheel);
+  // stud + regulator index (static)
+  const stud = new THREE.Mesh(new THREE.BoxGeometry(0.05, 0.05, 0.06), M.steel);
+  stud.position.set(0.31, 0.05, 0.10);
+  const index = new THREE.Mesh(new THREE.BoxGeometry(0.16, 0.028, 0.02), M.bluedSteel);
+  index.position.set(0.12, 0.02, 0.145);
+  index.rotation.z = 0.35;
+  balanceGroup.add(stud, index);
+  watch.add(balanceGroup);
+  registerPart(balanceGroup, {
+    id: 'balance', name: '摆轮与游丝', en: 'Balance Wheel & Hairspring',
+    desc: '机芯的心脏：金质螺丝摆轮以每小时 21,600 次的频率往复振荡，蓝钢宝玑游丝呼吸般收放，掌管着时间的节律。',
+    explode: V3(-0.85, -0.72, 0.62)
+  });
+}
+
+/* -------------------- Bridges (skeleton style) -------------------- */
+{
+  // barrel bridge
+  const g = new THREE.Group();
+  const b1 = sectorPlate(0.55, 1.62, Math.PI * 0.18, Math.PI * 0.82,
+    [{ x: 0, y: 1.0, r: 0.16 }, { x: -0.85, y: 0.75, r: 0.12 }, { x: 0.85, y: 0.75, r: 0.12 }],
+    0.055, M.germanSilver);
+  b1.position.z = 0.16;
+  g.add(b1);
+  const j1 = makeJewel(0.055); j1.position.set(POS.barrel.x, POS.barrel.y, 0.20); g.add(j1);
+  for (const p of [[-1.28, 0.85], [1.28, 0.85], [0, 1.5]]) {
+    const s = makeScrew(); s.position.set(p[0], p[1], 0.20); g.add(s);
+  }
+  watch.add(g);
+  registerPart(g, {
+    id: 'bridgeBarrel', name: '发条盒夹板', en: 'Barrel Bridge',
+    desc: '镂空发条盒夹板固定发条盒与上链轮系，边缘经手工拉丝与抛光倒角，蓝钢螺丝与红宝石轴眼点缀其间。',
+    explode: V3(0, 0.55, 1.0)
+  });
+}
+{
+  // train bridge (right side)
+  const g = new THREE.Group();
+  const b2 = sectorPlate(0.42, 1.60, -Math.PI * 0.28, Math.PI * 0.14,
+    [{ x: 1.05, y: 0.10, r: 0.13 }, { x: 1.15, y: -0.62, r: 0.13 }],
+    0.05, M.germanSilver);
+  b2.position.z = 0.14;
+  g.add(b2);
+  const j2 = makeJewel(0.045); j2.position.set(POS.third.x, POS.third.y, 0.175); g.add(j2);
+  const j3 = makeJewel(0.045); j3.position.set(POS.fourth.x, POS.fourth.y, 0.175); g.add(j3);
+  const j4 = makeJewel(0.04);  j4.position.set(POS.escape.x, POS.escape.y, 0.175); g.add(j4);
+  for (const p of [[1.45, 0.42], [1.35, -0.85]]) {
+    const s = makeScrew(); s.position.set(p[0], p[1], 0.175); g.add(s);
+  }
+  watch.add(g);
+  registerPart(g, {
+    id: 'bridgeTrain', name: '轮系夹板', en: 'Train Wheel Bridge',
+    desc: '轮系夹板横跨三轮、秒轮与擒纵轮，三枚红宝石轴承嵌于镀金套筒之中，减小枢轴摩擦。',
+    explode: V3(0.55, -0.30, 1.0)
+  });
+}
+{
+  // balance cock
+  const g = new THREE.Group();
+  const shape = new THREE.Shape();
+  shape.moveTo(-0.50, -0.14);
+  shape.lineTo(0.62, -0.10);
+  shape.quadraticCurveTo(0.86, 0, 0.62, 0.10);
+  shape.lineTo(-0.50, 0.14);
+  shape.quadraticCurveTo(-0.68, 0, -0.50, -0.14);
+  const hole = new THREE.Path();
+  hole.absarc(0.55, 0, 0.055, 0, Math.PI * 2, true);
+  shape.holes.push(hole);
+  const cock = new THREE.Mesh(extrude(shape, 0.045, 0.008), M.germanSilver);
+  cock.position.set(POS.balance.x - 0.55, POS.balance.y + 0.55, 0.30);
+  cock.rotation.z = -0.78;
+  cock.castShadow = true;
+  g.add(cock);
+  // shock protection (Incabloc-style): gold cup + ruby cap + lyre spring
+  const shock = new THREE.Group();
+  const cup = new THREE.Mesh(new THREE.CylinderGeometry(0.085, 0.10, 0.04, 20), M.gold);
+  cup.rotation.x = Math.PI / 2;
+  const cap = new THREE.Mesh(new THREE.CylinderGeometry(0.045, 0.045, 0.03, 16), M.ruby);
+  cap.rotation.x = Math.PI / 2;
+  cap.position.z = 0.03;
+  const lyre = new THREE.Mesh(new THREE.TorusGeometry(0.062, 0.008, 6, 20, Math.PI * 1.5), M.steel);
+  lyre.position.z = 0.035;
+  shock.add(cup, cap, lyre);
+  shock.position.set(POS.balance.x, POS.balance.y, 0.315);
+  g.add(shock);
+  const s = makeScrew(0.05);
+  s.position.set(POS.balance.x - 1.05, POS.balance.y + 0.95, 0.335);
+  g.add(s);
+  watch.add(g);
+  registerPart(g, {
+    id: 'cock', name: '摆轮夹板', en: 'Balance Cock',
+    desc: '单臂摆轮夹板饰以手工雕花纹理，顶端为避震器——红宝石轴承悬浮于竖琴形弹簧中，可抵御意外冲击。',
+    explode: V3(-0.60, 0.42, 1.35)
+  });
+}
+
+/* -------------------- Winding: ratchet & crown wheels -------------------- */
+{
+  const g = new THREE.Group();
+  const ratchet = makeGear({
+    teeth: 48, rOut: 0.46, toothH: 0.05, toothRatio: 0.55, pointy: true, skew: 0.18,
+    holeR: 0.05, rimR: 0.36, hubR: 0.12, spokes: 3, spokeW: 0.2
+  }, M.steel, 0.035);
+  ratchet.position.set(POS.barrel.x, POS.barrel.y, 0.26);
+  const rs = makeScrew(0.075);
+  rs.position.set(POS.barrel.x, POS.barrel.y, 0.30);
+  const crownW = makeGear({
+    teeth: 36, rOut: 0.30, toothH: 0.045, toothRatio: 0.55, pointy: true, skew: 0.18,
+    holeR: 0.04, rimR: 0.22, hubR: 0.09, spokes: 3, spokeW: 0.22
+  }, M.steel, 0.03);
+  crownW.position.set(0.95, 1.15, 0.26);
+  const cs = makeScrew(0.06);
+  cs.position.set(0.95, 1.15, 0.29);
+  g.add(ratchet, rs, crownW, cs);
+  watch.add(g);
+  registerPart(g, {
+    id: 'ratchet', name: '大小钢轮', en: 'Ratchet & Crown Wheels',
+    desc: '旋转表冠时，小钢轮带动大钢轮为发条盒上链；轮面饰以放射状太阳纹打磨，随光线流转生辉。',
+    explode: V3(0.30, 1.05, 0.85)
+  });
+}
+
+/* -------------------- Chapter ring + lume indexes -------------------- */
+{
+  const g = new THREE.Group();
+  const ring = new THREE.Mesh(new THREE.RingGeometry(1.42, 1.68, 96), M.dialDark);
+  ring.position.z = 0.30;
+  ring.receiveShadow = true;
+  const rail = new THREE.Mesh(new THREE.TorusGeometry(1.44, 0.012, 8, 96), M.gold);
+  rail.position.z = 0.315;
+  g.add(ring, rail);
+  for (let i = 0; i < 60; i++) {
+    const a = Math.PI / 2 - (i / 60) * Math.PI * 2;
+    const major = i % 5 === 0;
+    const idx = new THREE.Mesh(
+      new THREE.BoxGeometry(major ? 0.055 : 0.02, major ? 0.20 : 0.10, 0.028),
+      major ? M.lume : M.gold
+    );
+    const r = major ? 1.55 : 1.60;
+    idx.position.set(Math.cos(a) * r, Math.sin(a) * r, 0.315);
+    idx.rotation.z = a - Math.PI / 2;
+    if (major) {
+      const frame = new THREE.Mesh(new THREE.BoxGeometry(0.085, 0.23, 0.022), M.gold);
+      frame.position.copy(idx.position); frame.position.z = 0.310;
+      frame.rotation.z = idx.rotation.z;
+      g.add(frame);
+    }
+    g.add(idx);
+  }
+  watch.add(g);
+  registerPart(g, {
+    id: 'chapter', name: '时标圈', en: 'Chapter Ring & Lume Indexes',
+    desc: '烟熏黑时标圈环绕镂空机芯，十二枚金框立体时标填充夜光物料，暗处发出幽绿冷光。',
+    explode: V3(0, 0, 1.7)
+  });
+}
+
+/* -------------------- Hands (hour / minute / second) -------------------- */
+function makeHand({ len, w, tail, lumeLen, mat = M.gold }) {
+  const g = new THREE.Group();
+  const shape = new THREE.Shape();
+  shape.moveTo(-w * 0.5, -tail);
+  shape.lineTo(w * 0.5, -tail);
+  shape.lineTo(w * 0.34, len * 0.78);
+  shape.lineTo(0, len);
+  shape.lineTo(-w * 0.34, len * 0.78);
+  shape.closePath();
+  const inner = new THREE.Path(); // skeleton slot
+  inner.moveTo(-w * 0.18, len * 0.08);
+  inner.lineTo(-w * 0.12, len * 0.55);
+  inner.lineTo(w * 0.12, len * 0.55);
+  inner.lineTo(w * 0.18, len * 0.08);
+  inner.closePath();
+  shape.holes.push(inner);
+  const body = new THREE.Mesh(extrude(shape, 0.022, 0.004), mat);
+  body.castShadow = true;
+  g.add(body);
+  if (lumeLen > 0) {
+    const lume = new THREE.Mesh(new THREE.BoxGeometry(w * 0.5, lumeLen, 0.018), M.lume);
+    lume.position.set(0, len * 0.78 - lumeLen / 2 + 0.02, 0.02);
+    g.add(lume);
+  }
+  const hub = new THREE.Mesh(new THREE.CylinderGeometry(w * 0.85, w * 0.85, 0.04, 20), mat);
+  hub.rotation.x = Math.PI / 2;
+  g.add(hub);
+  return g;
+}
+
+const handsGroup = new THREE.Group();
+const hourHand = makeHand({ len: 0.86, w: 0.12, tail: 0.16, lumeLen: 0.34 });
+hourHand.position.z = 0.36;
+const minuteHand = makeHand({ len: 1.32, w: 0.10, tail: 0.20, lumeLen: 0.50 });
+minuteHand.position.z = 0.405;
+// central seconds: slim blued stick, lume tip, ring counterweight
+const secondHand = new THREE.Group();
+{
+  const stick = new THREE.Mesh(new THREE.BoxGeometry(0.022, 1.30, 0.014), M.bluedSteel);
+  stick.position.y = 0.62;
+  const tip = new THREE.Mesh(new THREE.BoxGeometry(0.030, 0.20, 0.016), M.lume);
+  tip.position.y = 1.18;
+  const counter = new THREE.Mesh(new THREE.TorusGeometry(0.07, 0.022, 8, 20), M.bluedSteel);
+  counter.position.y = -0.36;
+  const stem = new THREE.Mesh(new THREE.BoxGeometry(0.022, 0.30, 0.014), M.bluedSteel);
+  stem.position.y = -0.16;
+  const hub = new THREE.Mesh(new THREE.CylinderGeometry(0.05, 0.05, 0.035, 16), M.bluedSteel);
+  hub.rotation.x = Math.PI / 2;
+  secondHand.add(stick, tip, counter, stem, hub);
+  secondHand.position.z = 0.445;
+}
+handsGroup.add(hourHand, minuteHand, secondHand);
+// cannon pinion ruby cap
+const capJewel = new THREE.Mesh(new THREE.CylinderGeometry(0.035, 0.035, 0.05, 14), M.ruby);
+capJewel.rotation.x = Math.PI / 2;
+capJewel.position.z = 0.47;
+handsGroup.add(capJewel);
+watch.add(handsGroup);
+registerPart(handsGroup, {
+  id: 'hands', name: '指针', en: 'Luminous Hands',
+  desc: '镂空剑形金质时分针内填夜光物料，中央蓝钢秒针纤细如发，尾端环形配重使其重心恰好落于轴心。',
+  explode: V3(0, 0, 2.35)
+});
+
+/* ============================================================
+   Environment: floor, lights, particles
+============================================================ */
+{
+  const floor = new THREE.Mesh(new THREE.PlaneGeometry(60, 60), M.floor);
+  floor.rotation.x = -Math.PI / 2;
+  floor.position.y = -2.75;
+  floor.receiveShadow = true;
+  scene.add(floor);
+
+  const glow = new THREE.Mesh(
+    new THREE.CircleGeometry(7, 48),
+    new THREE.MeshBasicMaterial({
+      color: 0x1a150c, transparent: true, opacity: 0.9,
+      blending: THREE.AdditiveBlending, depthWrite: false
+    })
+  );
+  glow.rotation.x = -Math.PI / 2;
+  glow.position.y = -2.74;
+  scene.add(glow);
+}
+
+scene.add(new THREE.AmbientLight(0x1c1a20, 1.6));
+
+const keyLight = new THREE.SpotLight(0xfff2dc, 130, 40, Math.PI / 5, 0.45, 1.8);
+keyLight.position.set(5.5, 8, 6);
+keyLight.castShadow = true;
+keyLight.shadow.mapSize.set(2048, 2048);
+keyLight.shadow.bias = -0.0004;
+keyLight.shadow.radius = 6;
+scene.add(keyLight);
+
+const fillLight = new THREE.PointLight(0x6a7bff, 26, 30, 1.9);
+fillLight.position.set(-6, 2.5, 4);
+scene.add(fillLight);
+
+const rimLight = new THREE.PointLight(0xffb877, 40, 30, 1.9);
+rimLight.position.set(-3, 4.5, -6.5);
+scene.add(rimLight);
+
+const underLight = new THREE.PointLight(0xc9a961, 9, 12, 2);
+underLight.position.set(0, -2.2, 2.5);
+scene.add(underLight);
+
+const sweepLight = new THREE.PointLight(0xffffff, 14, 18, 2);
+scene.add(sweepLight);
+
+/* floating dust particles */
+let particles;
+{
+  const N = 260;
+  const pos = new Float32Array(N * 3);
+  for (let i = 0; i < N; i++) {
+    pos[i * 3] = (Math.random() - 0.5) * 16;
+    pos[i * 3 + 1] = Math.random() * 9 - 2.6;
+    pos[i * 3 + 2] = (Math.random() - 0.5) * 16;
+  }
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  particles = new THREE.Points(geo, new THREE.PointsMaterial({
+    color: 0xc9a961, size: 0.022, transparent: true, opacity: 0.5,
+    blending: THREE.AdditiveBlending, depthWrite: false, sizeAttenuation: true
+  }));
+  scene.add(particles);
+}
+
+/* ============================================================
+   Post-processing (Bloom)
+============================================================ */
+const composer = new EffectComposer(renderer);
+composer.addPass(new RenderPass(scene, camera));
+const bloom = new UnrealBloomPass(
+  new THREE.Vector2(window.innerWidth, window.innerHeight), 0.28, 0.55, 0.92);
+composer.addPass(bloom);
+composer.addPass(new OutputPass());
+
+/* ============================================================
+   Interaction: hover / click / tooltip / panel
+============================================================ */
+const raycaster = new THREE.Raycaster();
+const pointer = new THREE.Vector2(-10, -10);
+const tooltip = document.getElementById('tooltip');
+const tooltipZh = tooltip.querySelector('.t-zh');
+const tooltipEn = tooltip.querySelector('.t-en');
+const panel = document.getElementById('panel');
+const partDetail = document.getElementById('part-detail');
+
+let hovered = null, selected = null;
+let pointerDownAt = null;
+
+renderer.domElement.addEventListener('pointermove', e => {
+  pointer.x = (e.clientX / window.innerWidth) * 2 - 1;
+  pointer.y = -(e.clientY / window.innerHeight) * 2 + 1;
+  tooltip.style.left = e.clientX + 'px';
+  tooltip.style.top = e.clientY + 'px';
+});
+renderer.domElement.addEventListener('pointerdown', e => { pointerDownAt = [e.clientX, e.clientY]; });
+renderer.domElement.addEventListener('pointerup', e => {
+  if (!pointerDownAt) return;
+  const dx = e.clientX - pointerDownAt[0], dy = e.clientY - pointerDownAt[1];
+  pointerDownAt = null;
+  if (dx * dx + dy * dy > 25) return; // was a drag, not a click
+  selected = (hovered && selected !== hovered) ? hovered : null;
+  refreshHighlights();
+  updatePartDetail();
+});
+
+function updatePartDetail() {
+  if (selected) {
+    partDetail.querySelector('.d-zh').textContent = selected.name;
+    partDetail.querySelector('.d-en').textContent = selected.en;
+    partDetail.querySelector('.d-desc').textContent = selected.desc;
+    partDetail.classList.add('show');
+    panel.classList.remove('collapsed');
+    btnPanel.classList.add('active');
+  } else {
+    partDetail.classList.remove('show');
+  }
+}
+
+function refreshHighlights() {
+  for (const p of parts) setHighlight(p, p === hovered || p === selected);
+}
+
+function updateHover() {
+  raycaster.setFromCamera(pointer, camera);
+  const hits = raycaster.intersectObjects(rayTargets, false);
+  // look through the sapphire crystal: prefer the first non-crystal part
+  let info = null;
+  for (const h of hits) {
+    const p = h.object.userData.part;
+    if (p.id !== 'crystal') { info = p; break; }
+    if (!info) info = p;
+  }
+  if (info !== hovered) {
+    hovered = info;
+    if (hovered) {
+      tooltipZh.textContent = hovered.name;
+      tooltipEn.textContent = hovered.en;
+      tooltip.classList.add('show');
+      document.body.style.cursor = 'pointer';
+    } else {
+      tooltip.classList.remove('show');
+      document.body.style.cursor = '';
+    }
+    refreshHighlights();
+  }
+}
+
+/* ============================================================
+   Controls: explode / auto-rotate / panel / reset / speed
+============================================================ */
+const btnExplode = document.getElementById('btn-explode');
+const btnRotate = document.getElementById('btn-rotate');
+const btnPanel = document.getElementById('btn-panel');
+const btnReset = document.getElementById('btn-reset');
+const speedSlider = document.getElementById('speed');
+const speedOut = document.getElementById('speed-out');
+
+let explodeTarget = 0, explodeCurrent = 0;
+let timeScale = 1;
+let camTween = null;
+
+btnExplode.addEventListener('click', () => {
+  explodeTarget = explodeTarget > 0.5 ? 0 : 1;
+  btnExplode.classList.toggle('active', explodeTarget > 0.5);
+});
+btnRotate.addEventListener('click', () => {
+  controls.autoRotate = !controls.autoRotate;
+  btnRotate.classList.toggle('active', controls.autoRotate);
+});
+btnPanel.addEventListener('click', () => {
+  panel.classList.toggle('collapsed');
+  btnPanel.classList.toggle('active', !panel.classList.contains('collapsed'));
+});
+btnPanel.classList.add('active');
+btnReset.addEventListener('click', () => {
+  explodeTarget = 0;
+  btnExplode.classList.remove('active');
+  selected = null;
+  refreshHighlights();
+  updatePartDetail();
+  speedSlider.value = 1; syncSpeed();
+  camTween = { t: 0, fromP: camera.position.clone(), fromT: controls.target.clone() };
+});
+
+function syncSpeed() {
+  const v = Number(speedSlider.value);
+  timeScale = v;
+  speedOut.textContent = v + '×';
+  speedSlider.style.setProperty('--f', v + '%');
+}
+speedSlider.addEventListener('input', syncSpeed);
+syncSpeed();
+
+/* ============================================================
+   Animation loop
+============================================================ */
+const clock = new THREE.Clock();
+let simTime = 0;
+
+// angular velocities (rad per sim-second); center wheel = 1 rev/hour
+const W_CENTER = (Math.PI * 2) / 3600;
+const W_BARREL = W_CENTER / 6;         // barrel ~1 rev / 6 h
+const W_THIRD = W_CENTER * 7.5;        // intermediate ratio (opposite direction)
+const W_FOURTH = W_CENTER * 60;        // 1 rev/min (seconds wheel)
+const BEAT = 6;                        // 6 beats/s = 21,600 vph
+
+// start simulation at real current time
+const now = new Date();
+const t0 = (now.getHours() % 12) * 3600 + now.getMinutes() * 60 + now.getSeconds();
+
+function easeInOut(t) { return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2; }
+
+function animate() {
+  requestAnimationFrame(animate);
+  const dt = Math.min(clock.getDelta(), 0.05);
+  const el = clock.elapsedTime;
+  simTime += dt * Math.max(timeScale, 0);
+  const T = t0 + simTime;
+
+  /* --- movement kinematics --- */
+  barrelGroup.rotation.z = -W_BARREL * T;
+  centerWheel.rotation.z = -W_CENTER * T;
+  thirdWheel.rotation.z = W_THIRD * T;
+  fourthWheel.rotation.z = -W_FOURTH * T;
+
+  // escapement: discrete tick — quick snap then dwell, synced to beats
+  const beatPhase = T * BEAT;
+  const step = Math.floor(beatPhase);
+  const frac = beatPhase - step;
+  const snap = step + Math.min(1, frac * 7);
+  escapeWheel.rotation.z = -(Math.PI * 2 / 15) * (snap / 2);
+
+  // balance oscillation ±135°, pallet fork lever ±10°
+  balanceWheel.rotation.z = Math.sin(beatPhase * Math.PI) * (Math.PI * 0.75);
+  palletFork.rotation.z = Math.sin(beatPhase * Math.PI + 0.4) * 0.17;
+
+  /* --- hands show true (simulated) time --- */
+  const secs = T % 60, mins = (T / 60) % 60, hrs = (T / 3600) % 12;
+  secondHand.rotation.z = -secs / 60 * Math.PI * 2;
+  minuteHand.rotation.z = -mins / 60 * Math.PI * 2;
+  hourHand.rotation.z = -hrs / 12 * Math.PI * 2;
+
+  /* --- explode interpolation --- */
+  explodeCurrent += (explodeTarget - explodeCurrent) * Math.min(1, dt * 3.2);
+  const k = easeInOut(Math.max(0, Math.min(1, explodeCurrent)));
+  for (const p of parts) {
+    p.group.position.set(
+      p.basePos.x + p.explode.x * k * 1.35,
+      p.basePos.y + p.explode.y * k * 1.35,
+      p.basePos.z + p.explode.z * k * 1.35
+    );
+  }
+
+  /* --- camera reset tween --- */
+  if (camTween) {
+    camTween.t += dt / 1.2;
+    const e = easeInOut(Math.min(1, camTween.t));
+    camera.position.lerpVectors(camTween.fromP, CAM_HOME, e);
+    controls.target.lerpVectors(camTween.fromT, new THREE.Vector3(0, 0, 0), e);
+    if (camTween.t >= 1) camTween = null;
+  }
+
+  /* --- ambience: sweeping accent light, dust drift, gentle float --- */
+  sweepLight.position.set(Math.cos(el * 0.25) * 7, 3.5, Math.sin(el * 0.25) * 7);
+  particles.rotation.y = el * 0.012;
+  watch.position.y = 0.15 + Math.sin(el * 0.5) * 0.02;
+
+  updateHover();
+  controls.update();
+  composer.render();
+}
+
+window.addEventListener('resize', () => {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  composer.setSize(window.innerWidth, window.innerHeight);
+});
+
+animate();
+setTimeout(() => document.getElementById('loading').classList.add('hidden'), 700);
+</script>
+</body>
+</html>

--- a/outputs/qoder-ultimate/qoder-max/skeleton-watch.html
+++ b/outputs/qoder-ultimate/qoder-max/skeleton-watch.html
@@ -1,0 +1,762 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CALIBRE BT-100 · 镂空机械腕表</title>
+<style>
+  * { margin:0; padding:0; box-sizing:border-box; }
+  html,body { width:100%; height:100%; overflow:hidden; background:#050507; }
+  body{
+    font-family:"Segoe UI","PingFang SC","Microsoft YaHei",sans-serif;
+    color:#cfc9bd; user-select:none;
+    background:radial-gradient(ellipse 120% 90% at 50% 30%, #17171e 0%, #0a0a0e 55%, #030304 100%);
+  }
+  canvas{ display:block; }
+  #vignette{ position:fixed; inset:0; pointer-events:none; z-index:3;
+    background:radial-gradient(ellipse at 50% 45%, transparent 55%, rgba(0,0,0,.55) 100%); }
+  /* ---------- 顶部标题 ---------- */
+  #hdr{ position:fixed; top:28px; left:0; right:0; text-align:center; z-index:10; pointer-events:none; }
+  #hdr h1{ font-family:Georgia,"Times New Roman",serif; font-weight:400; letter-spacing:.42em;
+    font-size:22px; color:#e8dcc0; text-shadow:0 0 24px rgba(212,164,90,.35); }
+  #hdr .sub{ margin-top:8px; font-size:11px; letter-spacing:.5em; color:#8d8574; text-transform:uppercase; }
+  #hdr .rule{ width:180px; height:1px; margin:12px auto 0;
+    background:linear-gradient(90deg,transparent,#b08d4f,transparent); }
+  /* ---------- 底部控制条 ---------- */
+  #bar{ position:fixed; bottom:26px; left:50%; transform:translateX(-50%); z-index:10;
+    display:flex; gap:10px; padding:10px 14px; border-radius:40px;
+    background:rgba(14,14,18,.6); backdrop-filter:blur(14px);
+    border:1px solid rgba(176,141,79,.25); box-shadow:0 10px 40px rgba(0,0,0,.6); }
+  .btn{ padding:9px 20px; border-radius:30px; border:1px solid rgba(200,170,110,.28);
+    background:transparent; color:#c9bfa8; font-size:12.5px; letter-spacing:.15em; cursor:pointer;
+    transition:all .25s ease; white-space:nowrap; }
+  .btn:hover{ border-color:#d4a45a; color:#f0e2c0; box-shadow:0 0 14px rgba(212,164,90,.25) inset; }
+  .btn.on{ background:linear-gradient(180deg,#8a6a34,#5d451f); color:#fff2d5; border-color:#d4a45a; }
+  /* ---------- 信息面板 ---------- */
+  #panel{ position:fixed; top:50%; right:30px; transform:translateY(-50%); z-index:9;
+    width:295px; max-height:72vh; overflow-y:auto; padding:24px 24px 20px; border-radius:14px;
+    background:rgba(13,13,17,.72); backdrop-filter:blur(16px);
+    border:1px solid rgba(176,141,79,.22); box-shadow:0 18px 60px rgba(0,0,0,.65);
+    transition:opacity .4s ease, transform .4s ease; }
+  #panel.hide{ opacity:0; transform:translateY(-50%) translateX(30px); pointer-events:none; }
+  #panel h2{ font-family:Georgia,serif; font-weight:400; font-size:16px; letter-spacing:.14em;
+    color:#e6d6ac; margin-bottom:4px; }
+  #panel .tag{ font-size:10px; letter-spacing:.3em; color:#8b7a55; text-transform:uppercase; margin-bottom:14px; }
+  #panel .body{ font-size:12.5px; line-height:1.85; color:#b6afa0; }
+  #panel table{ width:100%; border-collapse:collapse; margin-top:6px; }
+  #panel td{ padding:5.5px 0; font-size:12px; border-bottom:1px solid rgba(255,255,255,.05); }
+  #panel td:first-child{ color:#8b8272; width:88px; }
+  #panel td:last-child{ color:#d8cfba; }
+  #panel .back{ display:inline-block; margin-top:14px; font-size:11px; letter-spacing:.15em;
+    color:#c9a45f; cursor:pointer; border-bottom:1px dashed rgba(201,164,95,.5); }
+  #panel .back:hover{ color:#f0d9a5; }
+  /* ---------- 悬停标签 ---------- */
+  #tip{ position:fixed; z-index:20; pointer-events:none; opacity:0; transition:opacity .15s;
+    transform:translate(-50%,calc(-100% - 18px)); }
+  #tip .in{ padding:7px 16px; border-radius:6px; font-size:12.5px; letter-spacing:.12em; color:#f4e8cd;
+    background:rgba(20,18,14,.88); border:1px solid rgba(212,164,90,.55);
+    box-shadow:0 6px 24px rgba(0,0,0,.6), 0 0 12px rgba(212,164,90,.15); white-space:nowrap; }
+  #tip .in::after{ content:""; position:absolute; left:50%; bottom:-5px; transform:translateX(-50%) rotate(45deg);
+    width:8px; height:8px; background:rgba(20,18,14,.88);
+    border-right:1px solid rgba(212,164,90,.55); border-bottom:1px solid rgba(212,164,90,.55); }
+  /* ---------- 左下提示 ---------- */
+  #hint{ position:fixed; left:30px; bottom:30px; z-index:9; font-size:11px; letter-spacing:.18em;
+    color:#6f6858; line-height:2.1; pointer-events:none; }
+  #hint b{ color:#a89568; font-weight:600; }
+  #loading{ position:fixed; inset:0; z-index:50; display:flex; flex-direction:column; gap:18px;
+    align-items:center; justify-content:center; background:#050507; transition:opacity .8s ease; }
+  #loading.done{ opacity:0; pointer-events:none; }
+  #loading .lg{ font-family:Georgia,serif; letter-spacing:.5em; color:#c9a45f; font-size:15px; }
+  #loading .ln{ width:160px; height:1px; background:#2a2620; overflow:hidden; }
+  #loading .ln i{ display:block; width:40%; height:100%; background:#c9a45f; animation:ld 1.1s infinite linear; }
+  @keyframes ld{ from{transform:translateX(-100%)} to{transform:translateX(400%)} }
+  @media (max-width:900px){ #panel{ display:none; } }
+</style>
+</head>
+<body>
+<div id="loading"><div class="lg">BOREAL · HAUTE HORLOGERIE</div><div class="ln"><i></i></div></div>
+<div id="vignette"></div>
+<div id="hdr">
+  <h1>CALIBRE BT-100</h1>
+  <div class="sub">Skeleton Manufacture Movement</div>
+  <div class="rule"></div>
+</div>
+<div id="bar">
+  <button class="btn" id="bExplode">爆炸视图</button>
+  <button class="btn on" id="bRotate">自动旋转</button>
+  <button class="btn" id="bRun">暂停机芯</button>
+  <button class="btn" id="bReset">复位视角</button>
+</div>
+<div id="panel">
+  <h2 id="pTitle"></h2>
+  <div class="tag" id="pTag"></div>
+  <div class="body" id="pBody"></div>
+</div>
+<div id="tip"><div class="in" id="tipTxt"></div></div>
+<div id="hint">拖动 <b>旋转</b> · 滚轮 <b>缩放</b> · 悬停 <b>识别零件</b> · 点击 <b>查看详情</b></div>
+
+<script type="importmap">
+{ "imports": {
+  "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
+  "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/"
+} }
+</script>
+<script type="module">
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';
+import { Reflector } from 'three/addons/objects/Reflector.js';
+
+const TAU = Math.PI * 2;
+
+/* ================= 渲染器 / 场景 ================= */
+const renderer = new THREE.WebGLRenderer({ antialias:true, alpha:true });
+renderer.setPixelRatio(Math.min(devicePixelRatio, 2));
+renderer.setSize(innerWidth, innerHeight);
+renderer.shadowMap.enabled = true;
+renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+renderer.toneMapping = THREE.ACESFilmicToneMapping;
+renderer.toneMappingExposure = 1.15;
+renderer.outputColorSpace = THREE.SRGBColorSpace;
+document.body.appendChild(renderer.domElement);
+
+const scene = new THREE.Scene();
+// 深色影棚背景（屏幕空间渐变，避免透明画布与 transmission 的灰幕伪影）
+{
+  const bgc = document.createElement('canvas'); bgc.width = bgc.height = 1024;
+  const bctx = bgc.getContext('2d');
+  const grd = bctx.createRadialGradient(512, 360, 60, 512, 520, 760);
+  grd.addColorStop(0, '#1d1d26'); grd.addColorStop(0.5, '#0c0c11'); grd.addColorStop(1, '#030304');
+  bctx.fillStyle = grd; bctx.fillRect(0, 0, 1024, 1024);
+  const bgTex = new THREE.CanvasTexture(bgc);
+  bgTex.colorSpace = THREE.SRGBColorSpace;
+  scene.background = bgTex;
+}
+scene.fog = new THREE.FogExp2(0x050507, 0.008);
+const camera = new THREE.PerspectiveCamera(40, innerWidth/innerHeight, 0.1, 400);
+camera.position.set(0, 52, 78);
+
+const controls = new OrbitControls(camera, renderer.domElement);
+controls.enableDamping = true; controls.dampingFactor = 0.06;
+controls.minDistance = 14; controls.maxDistance = 95;
+controls.maxPolarAngle = Math.PI * 0.62;
+controls.autoRotate = true; controls.autoRotateSpeed = 0.9;
+controls.target.set(0, 0.5, 0);
+
+const pmrem = new THREE.PMREMGenerator(renderer);
+scene.environment = pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
+
+/* ================= 灯光 ================= */
+const key = new THREE.DirectionalLight(0xfff1dc, 3.2);
+key.position.set(14, 22, 14);
+key.castShadow = true;
+key.shadow.mapSize.set(2048, 2048);
+key.shadow.camera.left = key.shadow.camera.bottom = -16;
+key.shadow.camera.right = key.shadow.camera.top = 16;
+key.shadow.camera.far = 80; key.shadow.bias = -0.0004; key.shadow.radius = 6;
+scene.add(key);
+const rim = new THREE.DirectionalLight(0x7fa8ff, 1.4); rim.position.set(-18, 8, -16); scene.add(rim);
+const rim2 = new THREE.DirectionalLight(0xd4a45a, 0.9); rim2.position.set(16, -4, -10); scene.add(rim2);
+const fill = new THREE.PointLight(0xffe6c0, 30, 60, 2); fill.position.set(-8, 6, 14); scene.add(fill);
+scene.add(new THREE.AmbientLight(0x1a1c26, 2.2));
+
+/* ================= 地台反射 ================= */
+const FLOOR_Y = -11.5;
+const mirror = new Reflector(new THREE.CircleGeometry(90, 72), {
+  clipBias:0.003, textureWidth:1024, textureHeight:1024, color:0x111116 });
+mirror.rotation.x = -Math.PI/2; mirror.position.y = FLOOR_Y; scene.add(mirror);
+const dim = new THREE.Mesh(new THREE.CircleGeometry(90, 72),
+  new THREE.MeshBasicMaterial({ color:0x050507, transparent:true, opacity:0.72, depthWrite:false }));
+dim.rotation.x = -Math.PI/2; dim.position.y = FLOOR_Y + 0.02; scene.add(dim);
+const shadowCatcher = new THREE.Mesh(new THREE.CircleGeometry(90, 72),
+  new THREE.ShadowMaterial({ opacity:0.42 }));
+shadowCatcher.rotation.x = -Math.PI/2; shadowCatcher.position.y = FLOOR_Y + 0.04;
+shadowCatcher.receiveShadow = true; scene.add(shadowCatcher);
+const halo = new THREE.Mesh(new THREE.RingGeometry(10, 34, 72),
+  new THREE.MeshBasicMaterial({ color:0x2a2418, transparent:true, opacity:0.18, side:THREE.DoubleSide }));
+halo.rotation.x = -Math.PI/2; halo.position.y = FLOOR_Y + 0.06; scene.add(halo);
+
+/* ================= 材质库(基准, 每个零件clone) ================= */
+const mSteel  = new THREE.MeshPhysicalMaterial({ color:0xdfe3e8, metalness:1, roughness:0.22, clearcoat:0.6, clearcoatRoughness:0.25, envMapIntensity:1.3 });
+const mSteelD = new THREE.MeshPhysicalMaterial({ color:0x8f979f, metalness:1, roughness:0.38, envMapIntensity:1.0 });
+const mGold   = new THREE.MeshPhysicalMaterial({ color:0xd9a45f, metalness:1, roughness:0.24, clearcoat:0.5, clearcoatRoughness:0.3, envMapIntensity:1.35 });
+const mRose   = new THREE.MeshPhysicalMaterial({ color:0xc98f6a, metalness:1, roughness:0.28, envMapIntensity:1.25 });
+const mDark   = new THREE.MeshPhysicalMaterial({ color:0x33363d, metalness:0.95, roughness:0.42, envMapIntensity:0.9 });
+const mBlue   = new THREE.MeshPhysicalMaterial({ color:0x2450e8, metalness:0.9, roughness:0.2, clearcoat:1, envMapIntensity:1.6 });
+const mRuby   = new THREE.MeshPhysicalMaterial({ color:0xd8003c, metalness:0.1, roughness:0.05, clearcoat:1, emissive:0x4a0012, envMapIntensity:1.6 });
+const mLume   = new THREE.MeshStandardMaterial({ color:0xbfffe0, emissive:0x5cffa0, emissiveIntensity:1.6, roughness:0.4, metalness:0 });
+const mGlass  = new THREE.MeshPhysicalMaterial({ color:0xbfd4e8, metalness:0, roughness:0.02, transparent:true, opacity:0.13, ior:1.77, clearcoat:1, clearcoatRoughness:0.02, envMapIntensity:1.8, side:THREE.DoubleSide, depthWrite:false });
+
+/* ================= 几何辅助 ================= */
+function ringGeo(outerR, innerR, depth){
+  const s = new THREE.Shape(); s.absarc(0,0,outerR,0,TAU,false);
+  const h = new THREE.Path(); h.absarc(0,0,innerR,0,TAU,true); s.holes.push(h);
+  return new THREE.ExtrudeGeometry(s, { depth, bevelEnabled:false, curveSegments:64 });
+}
+function gearShape(teeth, tipR, rootR, holeR){
+  const s = new THREE.Shape(); const st = TAU/teeth;
+  for(let i=0;i<teeth;i++){
+    const a=i*st;
+    [[rootR,a],[rootR,a+st*0.34],[tipR,a+st*0.44],[tipR,a+st*0.60],[rootR,a+st*0.70]]
+    .forEach(([r,g],j)=>{ const x=Math.cos(g)*r, y=Math.sin(g)*r;
+      (i===0&&j===0)?s.moveTo(x,y):s.lineTo(x,y); });
+  }
+  s.closePath();
+  if(holeR>0){ const h=new THREE.Path(); h.absarc(0,0,holeR,0,TAU,true); s.holes.push(h); }
+  return s;
+}
+function escapeShape(teeth, tipR, rootR){
+  const s = new THREE.Shape(); const st = TAU/teeth;
+  for(let i=0;i<teeth;i++){
+    const a=i*st;
+    [[rootR,a],[tipR,a+st*0.10],[rootR*1.02,a+st*0.42],[rootR,a+st*0.75]]
+    .forEach(([r,g],j)=>{ const x=Math.cos(g)*r, y=Math.sin(g)*r;
+      (i===0&&j===0)?s.moveTo(x,y):s.lineTo(x,y); });
+  }
+  s.closePath();
+  const h=new THREE.Path(); h.absarc(0,0,rootR*0.55,0,TAU,true); s.holes.push(h);
+  return s;
+}
+// 镂空齿轮: 齿圈 + 轮辐 + 轮毂 + 上层小齿轴
+function makeGear({teeth, tipR, th=0.24, spokes=5, mat, pinion=true}){
+  const rootR = tipR*0.88, holeR = tipR*0.60, hubR = Math.max(tipR*0.16, 0.22);
+  const g = new THREE.Group();
+  const rimM = new THREE.Mesh(new THREE.ExtrudeGeometry(gearShape(teeth,tipR,rootR,holeR),
+    { depth:th, bevelEnabled:false, curveSegments:6 }), mat);
+  g.add(rimM);
+  const hub = new THREE.Mesh(new THREE.CylinderGeometry(hubR,hubR,th*1.7,24), mat);
+  hub.rotation.x = Math.PI/2; hub.position.z = th/2; g.add(hub);
+  for(let i=0;i<spokes;i++){
+    const a=i/spokes*TAU, L=holeR-hubR+0.24;
+    const sp = new THREE.Mesh(new THREE.BoxGeometry(L, Math.max(tipR*0.13,0.14), th*0.85), mat);
+    sp.position.set(Math.cos(a)*(hubR+holeR)/2, Math.sin(a)*(hubR+holeR)/2, th/2);
+    sp.rotation.z=a; g.add(sp);
+  }
+  if(pinion){
+    const p = new THREE.Mesh(new THREE.ExtrudeGeometry(gearShape(8, hubR*1.7, hubR*1.25, 0),
+      { depth:th*0.9, bevelEnabled:false, curveSegments:4 }), mat);
+    p.position.z = th*1.1; g.add(p);
+  }
+  return g;
+}
+function makeSpiral(rIn, rOut, coils, tubeR, mat, segs=340){
+  const pts=[];
+  for(let i=0;i<=segs;i++){
+    const t=i/segs, a=t*coils*TAU, r=rIn+(rOut-rIn)*t;
+    pts.push(new THREE.Vector3(Math.cos(a)*r, Math.sin(a)*r, 0));
+  }
+  return new THREE.Mesh(new THREE.TubeGeometry(new THREE.CatmullRomCurve3(pts), segs, tubeR, 6, false), mat);
+}
+// 桥板: 圆垫片折线 + 连接臂
+function makeBridge(pts, w, th, mat){
+  const g = new THREE.Group();
+  pts.forEach(p=>{
+    const pad = new THREE.Mesh(new THREE.CylinderGeometry(w*1.25, w*1.4, th, 32), mat);
+    pad.rotation.x = Math.PI/2; pad.position.set(p[0], p[1], th/2); g.add(pad);
+  });
+  for(let i=0;i<pts.length-1;i++){
+    const [x1,y1]=pts[i],[x2,y2]=pts[i+1];
+    const dx=x2-x1, dy=y2-y1, L=Math.hypot(dx,dy);
+    const bar = new THREE.Mesh(new THREE.BoxGeometry(L, w*1.6, th), mat);
+    bar.position.set((x1+x2)/2,(y1+y2)/2, th/2); bar.rotation.z=Math.atan2(dy,dx); g.add(bar);
+  }
+  return g;
+}
+function addJewel(parent, x, y, z, r=0.3){
+  const j = new THREE.Mesh(new THREE.CylinderGeometry(r, r*0.86, 0.16, 20), mRuby.clone());
+  j.rotation.x = Math.PI/2; j.position.set(x,y,z); parent.add(j);
+  const bez = new THREE.Mesh(new THREE.TorusGeometry(r*1.18, 0.05, 8, 24), mGold.clone());
+  bez.position.set(x,y,z+0.05); parent.add(bez);
+  return j;
+}
+function addScrew(parent, x, y, z, r=0.16){
+  const s = new THREE.Mesh(new THREE.CylinderGeometry(r, r, 0.12, 14), mBlue.clone());
+  s.rotation.x = Math.PI/2; s.position.set(x,y,z); parent.add(s);
+  const slot = new THREE.Mesh(new THREE.BoxGeometry(r*1.7, r*0.36, 0.03), mDark.clone());
+  slot.position.set(x,y,z+0.07); slot.rotation.z = Math.random()*TAU; parent.add(slot);
+}
+
+/* ================= 腕表装配 ================= */
+const tilt  = new THREE.Group(); scene.add(tilt);       // 展示浮动
+const watch = new THREE.Group(); tilt.add(watch);        // 表主体 (XY面, +Z朝观察者)
+watch.rotation.x = -Math.PI/2 + 0.62;                    // 后仰展示角
+watch.position.y = 0.5;
+
+const parts = [];  // 可交互零件
+function reg(grp, id, name, tag, desc, explodeZ){
+  grp.userData.part = { id, name, tag, desc };
+  grp.userData.baseZ = grp.position.z;
+  grp.userData.explodeZ = explodeZ;
+  parts.push(grp); watch.add(grp);
+}
+
+/* ---- 轮系坐标 ---- */
+const B=[-2.7, 3.1], C=[0.2, 0.2], D=[2.85,-0.9], E=[1.6,-2.9], F=[-0.6,-3.6], P=[-2.15,-3.35], G=[-4.0,-2.6];
+
+/* ---- 主夹板 (镂空) ---- */
+const plate = new THREE.Group();
+{
+  const m = mSteelD.clone(); m.color.setHex(0x9aa1a8);
+  plate.add(new THREE.Mesh(ringGeo(7.9, 6.6, 0.5), m));
+  const arms = [[B,C],[C,D],[D,E],[E,F],[C,[6.9,1.6]],[B,[-6.4,4.4]],[G,[-6.2,-4.6]],[C,[0.9,7.0]]];
+  arms.forEach(([p1,p2])=>{
+    const dx=p2[0]-p1[0], dy=p2[1]-p1[1], L=Math.hypot(dx,dy);
+    const bar=new THREE.Mesh(new THREE.BoxGeometry(L+0.6, 0.75, 0.5), m);
+    bar.position.set((p1[0]+p2[0])/2,(p1[1]+p2[1])/2,0.25);
+    bar.rotation.z=Math.atan2(dy,dx); plate.add(bar);
+  });
+  [B,C,D,E,F,P,G].forEach(p=>{
+    const pad=new THREE.Mesh(new THREE.CylinderGeometry(0.62,0.72,0.5,24), m);
+    pad.rotation.x=Math.PI/2; pad.position.set(p[0],p[1],0.25); plate.add(pad);
+    addJewel(plate, p[0], p[1], 0.53, 0.24);
+  });
+}
+reg(plate, 'plate', '镂空主夹板', 'Openworked Main Plate',
+  '经手工镂空、倒角与直纹打磨的铑镀主夹板，是整个机芯的骨架。所有轮系轴承孔均镶嵌人造红宝石以降低摩擦。', -1.2);
+
+/* ---- 发条盒 + 棘轮 ---- */
+const barrel = new THREE.Group(); barrel.position.set(B[0], B[1], 0.62);
+let barrelWheel;
+{
+  const m = mGold.clone();
+  barrelWheel = new THREE.Group();
+  const drum = new THREE.Mesh(ringGeo(2.35, 2.1, 0.95), m); barrelWheel.add(drum);
+  const floor_ = new THREE.Mesh(new THREE.CylinderGeometry(2.32,2.32,0.1,48), m);
+  floor_.rotation.x=Math.PI/2; floor_.position.z=0.05; barrelWheel.add(floor_);
+  const teeth = new THREE.Mesh(new THREE.ExtrudeGeometry(gearShape(84, 2.75, 2.5, 2.36),
+    { depth:0.34, bevelEnabled:false, curveSegments:4 }), m);
+  teeth.position.z = 0.28; barrelWheel.add(teeth);
+  const spring = makeSpiral(0.42, 2.05, 5.2, 0.10, mBlue.clone(), 300);
+  spring.position.z = 0.5; barrelWheel.add(spring);
+  const arbor = new THREE.Mesh(new THREE.CylinderGeometry(0.34,0.34,1.6,20), mSteel.clone());
+  arbor.rotation.x=Math.PI/2; arbor.position.z=0.6; barrelWheel.add(arbor);
+  const ratchet = new THREE.Mesh(new THREE.ExtrudeGeometry(gearShape(40, 1.5, 1.32, 0.5),
+    { depth:0.16, bevelEnabled:false, curveSegments:4 }), mRose.clone());
+  ratchet.position.z = 1.05; barrelWheel.add(ratchet);
+  addScrew(barrelWheel, 0, 0, 1.25, 0.3);
+  barrel.add(barrelWheel);
+}
+reg(barrel, 'barrel', '发条盒与棘轮', 'Mainspring Barrel',
+  '动力之源。手工卷制的蓝钢主发条储存能量，满弦可提供 72 小时动力储备。顶部玫瑰金棘轮经太阳纹打磨，通过表冠上链。', 1.0);
+
+/* ---- 齿轮系 ---- */
+function trainWheel(pos, opts, id, name, tag, desc, ez){
+  const grp = new THREE.Group(); grp.position.set(pos[0], pos[1], 0.72);
+  grp.add(makeGear(opts)); reg(grp, id, name, tag, desc, ez);
+  return grp.children[0];
+}
+const centerW = trainWheel(C, { teeth:64, tipR:2.05, mat:mGold.clone(), spokes:5 },
+  'center', '中心轮（二轮）', 'Center Wheel',
+  '每小时旋转一周，直接驱动分针。金色轮辐经镜面倒角处理，齿形为摆线齿以保证传动效率。', 1.3);
+const thirdW = trainWheel(D, { teeth:56, tipR:1.45, mat:mRose.clone(), spokes:5 },
+  'third', '三轮（过轮）', 'Third Wheel',
+  '连接中心轮与四轮的中间传动轮，将扭矩逐级放大转速。轮辐仅 0.14mm 宽，展现镂空工艺极限。', 1.5);
+const fourthW = trainWheel(E, { teeth:50, tipR:1.15, mat:mGold.clone(), spokes:4 },
+  'fourth', '四轮（秒轮）', 'Fourth Wheel',
+  '每分钟旋转一周，同轴驱动中央秒针，并将动力传递给擒纵轮。', 1.7);
+
+/* ---- 擒纵轮 ---- */
+const escGrp = new THREE.Group(); escGrp.position.set(F[0], F[1], 0.78);
+const escW = new THREE.Group();
+{
+  const m = mSteel.clone(); m.color.setHex(0xf2e6c8); m.roughness = 0.15;
+  const wheel = new THREE.Mesh(new THREE.ExtrudeGeometry(escapeShape(15, 1.05, 0.62),
+    { depth:0.14, bevelEnabled:false, curveSegments:4 }), m);
+  escW.add(wheel);
+  for(let i=0;i<5;i++){
+    const a=i/5*TAU;
+    const sp=new THREE.Mesh(new THREE.BoxGeometry(0.5,0.09,0.12), m);
+    sp.position.set(Math.cos(a)*0.32, Math.sin(a)*0.32, 0.07); sp.rotation.z=a; escW.add(sp);
+  }
+  const hub=new THREE.Mesh(new THREE.CylinderGeometry(0.12,0.12,0.5,12), m);
+  hub.rotation.x=Math.PI/2; hub.position.z=0.1; escW.add(hub);
+  escGrp.add(escW);
+}
+reg(escGrp, 'escape', '擒纵轮', 'Escape Wheel',
+  '轻质合金制成的 15 齿擒纵轮，特殊棘爪齿形。它被擒纵叉周期性锁定与释放，把轮系的连续转动切割为精确节拍——即腕表的"嘀嗒"声。', 1.9);
+
+/* ---- 擒纵叉 ---- */
+const palletGrp = new THREE.Group(); palletGrp.position.set(P[0], P[1], 1.05);
+const palletFork = new THREE.Group();
+{
+  const m = mSteel.clone();
+  const aim = Math.atan2(G[1]-P[1], G[0]-P[0]);
+  const body = new THREE.Mesh(new THREE.BoxGeometry(1.7, 0.2, 0.13), m);
+  body.rotation.z = aim; body.position.set(Math.cos(aim)*0.55, Math.sin(aim)*0.55, 0); palletFork.add(body);
+  const horns = new THREE.Mesh(new THREE.BoxGeometry(0.16, 0.55, 0.13), m);
+  horns.rotation.z = aim; horns.position.set(Math.cos(aim)*1.42, Math.sin(aim)*1.42, 0); palletFork.add(horns);
+  const aimE = Math.atan2(F[1]-P[1], F[0]-P[0]);
+  const armE = new THREE.Mesh(new THREE.BoxGeometry(1.35, 0.62, 0.11), m);
+  armE.rotation.z = aimE; armE.position.set(Math.cos(aimE)*0.6, Math.sin(aimE)*0.6, 0); palletFork.add(armE);
+  [-0.26, 0.26].forEach(off=>{
+    const px = Math.cos(aimE)*1.18 - Math.sin(aimE)*off;
+    const py = Math.sin(aimE)*1.18 + Math.cos(aimE)*off;
+    const stone = new THREE.Mesh(new THREE.BoxGeometry(0.3,0.14,0.16), mRuby.clone());
+    stone.rotation.z = aimE + 0.5*Math.sign(off); stone.position.set(px, py, 0); palletFork.add(stone);
+  });
+  const staff=new THREE.Mesh(new THREE.CylinderGeometry(0.1,0.1,0.6,12), m);
+  staff.rotation.x=Math.PI/2; palletFork.add(staff);
+  palletGrp.add(palletFork);
+}
+reg(palletGrp, 'pallet', '擒纵叉', 'Pallet Fork',
+  '瑞士杠杆式擒纵的核心。两枚人造红宝石叉瓦交替锁定擒纵轮齿，同时通过叉头给予摆轮微小冲量，维持其永不停歇的振荡。', 2.1);
+
+/* ---- 摆轮 + 游丝 + 摆轮夹板 ---- */
+const balanceGrp = new THREE.Group(); balanceGrp.position.set(G[0], G[1], 1.35);
+const balWheel = new THREE.Group();
+let hairspring;
+{
+  const m = mGold.clone(); m.color.setHex(0xe0b06a);
+  const rimT = new THREE.Mesh(new THREE.TorusGeometry(2.0, 0.17, 14, 72), m); balWheel.add(rimT);
+  for(let i=0;i<2;i++){
+    const sp = new THREE.Mesh(new THREE.BoxGeometry(3.9, 0.2, 0.14), m);
+    sp.rotation.z = i*Math.PI/2 + 0.4; balWheel.add(sp);
+  }
+  for(let i=0;i<8;i++){
+    const a=i/8*TAU + 0.2;
+    const sc=new THREE.Mesh(new THREE.CylinderGeometry(0.09,0.09,0.3,10), mRose.clone());
+    sc.position.set(Math.cos(a)*2.22, Math.sin(a)*2.22, 0);
+    sc.rotation.set(0,0,a); sc.rotateX(Math.PI/2); balWheel.add(sc);
+  }
+  const staff = new THREE.Mesh(new THREE.CylinderGeometry(0.11,0.11,1.5,14), mSteel.clone());
+  staff.rotation.x=Math.PI/2; staff.position.z=0.3; balWheel.add(staff);
+  balanceGrp.add(balWheel);
+  hairspring = makeSpiral(0.24, 1.55, 5.5, 0.045, mBlue.clone(), 380);
+  hairspring.position.z = 0.72; balanceGrp.add(hairspring);
+  const collet = new THREE.Mesh(new THREE.CylinderGeometry(0.16,0.16,0.2,12), mBlue.clone());
+  collet.rotation.x=Math.PI/2; collet.position.z=0.72; balanceGrp.add(collet);
+  // 摆轮夹板 (balance cock)
+  const cock = makeBridge([[0,0],[-2.6,-1.7]], 0.55, 0.3, mSteelD.clone());
+  cock.position.z = 1.0; balanceGrp.add(cock);
+  addJewel(balanceGrp, 0, 0, 1.36, 0.3);
+  addScrew(balanceGrp, -2.6, -1.7, 1.36, 0.2);
+  const reg_ = new THREE.Mesh(new THREE.BoxGeometry(0.9,0.14,0.08), mBlue.clone());
+  reg_.position.set(-0.75,-0.5,1.34); reg_.rotation.z=0.6; balanceGrp.add(reg_);
+}
+reg(balanceGrp, 'balance', '摆轮与蓝钢游丝', 'Balance & Hairspring',
+  '机芯的心脏。金质螺丝摆轮以 21,600 次/小时（3Hz）的频率振荡，蓝钢宝玑游丝以同心呼吸控制其节奏。振幅约 280°，走时精度 -2/+4 秒/天。', 2.6);
+
+/* ---- 轮系桥板 ---- */
+const bridges = new THREE.Group(); bridges.position.z = 1.75;
+{
+  const m = mSteelD.clone(); m.color.setHex(0xa8adb4);
+  bridges.add(makeBridge([D, E, F], 0.5, 0.28, m));
+  bridges.add(makeBridge([B, [(B[0]+C[0])/2+0.4,(B[1]+C[1])/2+0.6], C], 0.58, 0.28, m.clone()));
+  bridges.add(makeBridge([P, [P[0]-1.5, P[1]-1.5]], 0.42, 0.28, m.clone()));
+  [D,E,F,C,B,P].forEach(p=>addJewel(bridges, p[0], p[1], 0.32, 0.26));
+  addScrew(bridges, (D[0]+E[0])/2+0.5, (D[1]+E[1])/2, 0.34);
+  addScrew(bridges, B[0]-0.9, B[1]+0.7, 0.34);
+  addScrew(bridges, P[0]-1.5, P[1]-1.5, 0.34, 0.14);
+}
+reg(bridges, 'bridges', '桥板与红宝石轴承', 'Bridges & Jewels',
+  '日内瓦波纹打磨的镂空桥板固定各轮轴上端。全表共镶嵌 27 枚人造红宝石轴承——莫氏硬度 9，将轴摩擦降至最低，配合蓝钢螺丝固定。', 2.2);
+
+/* ---- 时标圈 ---- */
+const chapter = new THREE.Group(); chapter.position.z = 2.5;
+{
+  const m = mDark.clone();
+  chapter.add(new THREE.Mesh(ringGeo(8.05, 6.75, 0.14), m));
+  for(let i=0;i<12;i++){
+    const a=i/12*TAU, r=7.25;
+    if(i===0){
+      [-0.32,0.32].forEach(off=>{
+        const b=new THREE.Mesh(new THREE.BoxGeometry(0.3,1.15,0.2), mLume.clone());
+        b.position.set(Math.sin(a)*r+off, Math.cos(a)*r, 0.2); chapter.add(b);
+      });
+    } else {
+      const b=new THREE.Mesh(new THREE.BoxGeometry(0.4,1.05,0.2), mLume.clone());
+      b.position.set(Math.sin(a)*r, Math.cos(a)*r, 0.2); b.rotation.z=-a; chapter.add(b);
+      const frame=new THREE.Mesh(new THREE.BoxGeometry(0.52,1.17,0.16), mGold.clone());
+      frame.position.set(Math.sin(a)*r, Math.cos(a)*r, 0.17); frame.rotation.z=-a; chapter.add(frame);
+    }
+  }
+  for(let i=0;i<60;i++){
+    if(i%5===0) continue;
+    const a=i/60*TAU;
+    const t=new THREE.Mesh(new THREE.BoxGeometry(0.06,0.34,0.1), mSteel.clone());
+    t.position.set(Math.sin(a)*7.8, Math.cos(a)*7.8, 0.16); t.rotation.z=-a; chapter.add(t);
+  }
+}
+reg(chapter, 'chapter', '时标圈与夜光时标', 'Chapter Ring',
+  '黑色 PVD 时标圈搭配金框立体时标，内部填充 Super-LumiNova® C3 夜光物料，暗处发出冰绿色辉光，可持续 8 小时以上。', 3.4);
+
+/* ---- 指针 ---- */
+function makeHand(len, w, matM, matL, tail){
+  const g = new THREE.Group();
+  const frame = new THREE.Mesh(new THREE.BoxGeometry(w, len+tail, 0.09), matM);
+  frame.position.y = (len-tail)/2; g.add(frame);
+  const lume = new THREE.Mesh(new THREE.BoxGeometry(w*0.52, len*0.5, 0.1), matL);
+  lume.position.set(0, len*0.62, 0.05); g.add(lume);
+  const tip = new THREE.Mesh(new THREE.ConeGeometry(w*0.55, w*1.6, 4), matM);
+  tip.position.y = len + w*0.7; g.add(tip);
+  return g;
+}
+const hands = new THREE.Group(); hands.position.z = 2.95;
+const hourHand = makeHand(4.1, 0.52, mGold.clone(), mLume.clone(), 0.9);
+const minHand  = makeHand(6.1, 0.42, mGold.clone(), mLume.clone(), 1.0); minHand.position.z = 0.22;
+const secHand  = new THREE.Group(); secHand.position.z = 0.44;
+{
+  const m = mBlue.clone();
+  const stem = new THREE.Mesh(new THREE.BoxGeometry(0.1, 8.7, 0.06), m);
+  stem.position.y = 2.55; secHand.add(stem);
+  const cw = new THREE.Mesh(new THREE.TorusGeometry(0.42, 0.09, 8, 24), m);
+  cw.position.y = -1.7; secHand.add(cw);
+  const dot = new THREE.Mesh(new THREE.SphereGeometry(0.16, 12, 10), mLume.clone());
+  dot.position.set(0, 6.6, 0); secHand.add(dot);
+}
+const cap = new THREE.Mesh(new THREE.CylinderGeometry(0.42,0.5,0.75,20), mGold.clone());
+cap.rotation.x=Math.PI/2; cap.position.z=0.28; hands.add(cap);
+hands.add(hourHand, minHand, secHand);
+reg(hands, 'hands', '荧光剑形指针', 'Luminous Hands',
+  '18K 金剑形时分针内嵌 Super-LumiNova® 夜光条，蓝钢中央秒针带环形配重，末端夜光点以 3Hz 节拍平稳扫过表盘。', 4.4);
+
+/* ---- 表壳 ---- */
+const caseGrp = new THREE.Group();
+{
+  const m = mSteel.clone();
+  const band = new THREE.Mesh(ringGeo(9.5, 8.25, 4.3), m); band.position.z = -1.05; caseGrp.add(band);
+  const bezel = new THREE.Mesh(new THREE.TorusGeometry(8.85, 0.68, 18, 96), m);
+  bezel.position.z = 3.15; caseGrp.add(bezel);
+  const backRing = new THREE.Mesh(new THREE.TorusGeometry(8.85, 0.6, 18, 96), m);
+  backRing.position.z = -1.0; caseGrp.add(backRing);
+  // 表耳
+  [[-3.3, 9.35, -0.16],[3.3, 9.35, 0.16],[-3.3,-9.35, 0.16+Math.PI],[3.3,-9.35,-0.16+Math.PI]].forEach(([x,y,rz])=>{
+    const lug = new THREE.Mesh(new THREE.BoxGeometry(1.15, 2.5, 1.2), m);
+    lug.position.set(x, y, 0.7); lug.rotation.z = rz; caseGrp.add(lug);
+  });
+}
+reg(caseGrp, 'case', '精钢表壳', 'Polished Case',
+  '42mm 五级钛+精钢复合表壳，侧面缎面拉丝、棱线镜面抛光。防水 50 米，表耳弧线贴合腕型。', 0);
+
+/* ---- 表冠 ---- */
+const crownGrp = new THREE.Group(); crownGrp.position.set(10.15, 0, 1.05);
+{
+  const m = mSteel.clone();
+  const body = new THREE.Mesh(new THREE.CylinderGeometry(0.95, 0.95, 1.25, 24), m);
+  body.rotation.z = Math.PI/2; crownGrp.add(body);
+  for(let i=0;i<20;i++){
+    const a=i/20*TAU;
+    const k = new THREE.Mesh(new THREE.BoxGeometry(1.15, 0.16, 0.22), m);
+    k.position.set(0, Math.cos(a)*0.95, Math.sin(a)*0.95); k.rotation.x = -a; crownGrp.add(k);
+  }
+  const onion = new THREE.Mesh(new THREE.SphereGeometry(0.75, 20, 14), mGold.clone());
+  onion.scale.set(0.55,1,1); onion.position.x = 0.85; crownGrp.add(onion);
+  const stem = new THREE.Mesh(new THREE.CylinderGeometry(0.3,0.3,1.6,14), m);
+  stem.rotation.z = Math.PI/2; stem.position.x = -1.2; crownGrp.add(stem);
+}
+reg(crownGrp, 'crown', '上链表冠', 'Winding Crown',
+  '滚花防滑表冠，镶嵌 18K 金洋葱头。旋转约 35 圈即可为发条盒完全上链，并可拔出两档调校时间。', 0);
+
+/* ---- 蓝宝石表镜 ---- */
+const crystalGrp = new THREE.Group();
+{
+  const geo = new THREE.SphereGeometry(12, 64, 24, 0, TAU, 0, 0.75);
+  geo.rotateX(Math.PI/2);
+  geo.translate(0, 0, -12*Math.cos(0.75));
+  geo.scale(1, 1, 0.42);
+  const dome = new THREE.Mesh(geo, mGlass.clone());
+  dome.position.z = 3.35; crystalGrp.add(dome);
+}
+reg(crystalGrp, 'crystal', '蓝宝石水晶表镜', 'Sapphire Crystal',
+  '整块合成蓝宝石打磨的盒形表镜，莫氏硬度 9，双面防眩镀膜，折射率 1.77，如无物般通透。', 6.2);
+
+/* ---- 透视底盖 ---- */
+const backGrp = new THREE.Group();
+{
+  const glass = new THREE.Mesh(new THREE.CylinderGeometry(7.7, 7.7, 0.22, 64), mGlass.clone());
+  glass.rotation.x = Math.PI/2; glass.position.z = -1.25; backGrp.add(glass);
+  const rim_ = new THREE.Mesh(ringGeo(8.2, 7.5, 0.3), mGold.clone());
+  rim_.position.z = -1.45; backGrp.add(rim_);
+}
+reg(backGrp, 'back', '蓝宝石透视底盖', 'Exhibition Caseback',
+  '旋入式蓝宝石底盖，翻转腕表即可欣赏机芯背面的日内瓦波纹与鱼鳞纹打磨。', -3.6);
+
+/* ---- 阴影/材质设置 ---- */
+watch.traverse(o=>{
+  if(o.isMesh){
+    o.castShadow = true;
+    if(o.material !== undefined && o.material.transparent) o.castShadow = false;
+    o.receiveShadow = true;
+  }
+});
+
+/* ================= 信息面板 ================= */
+const pTitle = document.getElementById('pTitle');
+const pTag = document.getElementById('pTag');
+const pBody = document.getElementById('pBody');
+const DEFAULT_INFO = {
+  name:'Calibre BT-100', tag:'Movement Specifications',
+  desc:`<table>
+  <tr><td>机芯类型</td><td>手动上链 · 全镂空</td></tr>
+  <tr><td>振动频率</td><td>21,600 次/小时（3 Hz）</td></tr>
+  <tr><td>宝石数</td><td>27 枚人造红宝石</td></tr>
+  <tr><td>动力储备</td><td>72 小时</td></tr>
+  <tr><td>擒纵系统</td><td>瑞士杠杆式擒纵</td></tr>
+  <tr><td>游丝</td><td>蓝钢宝珑上绕游丝</td></tr>
+  <tr><td>零件数</td><td>168 枚</td></tr>
+  <tr><td>打磨工艺</td><td>日内瓦波纹 · 手工倒角<br>镜面抛光 · 鱼鳞纹</td></tr>
+  <tr><td>走时精度</td><td>-2 / +4 秒 · 天</td></tr>
+  </table>
+  <div style="margin-top:12px;font-size:11.5px;color:#7d7666;">悬停机芯零件可识别其名称，点击可查看详细介绍。</div>`
+};
+function showInfo(info, showBack){
+  pTitle.textContent = info.name;
+  pTag.textContent = info.tag;
+  pBody.innerHTML = info.desc + (showBack ? '<span class="back" id="backLink">← 返回机芯规格</span>' : '');
+  const bk = document.getElementById('backLink');
+  if(bk) bk.onclick = ()=>showInfo(DEFAULT_INFO, false);
+}
+showInfo(DEFAULT_INFO, false);
+
+/* ================= 交互: 悬停 / 点击 ================= */
+const raycaster = new THREE.Raycaster();
+const mouse = new THREE.Vector2(-10,-10);
+const tip = document.getElementById('tip');
+const tipTxt = document.getElementById('tipTxt');
+let hovered = null, mouseSX = 0, mouseSY = 0;
+
+function findPart(obj){
+  while(obj){ if(obj.userData && obj.userData.part) return obj; obj = obj.parent; }
+  return null;
+}
+function setHi(grp, on){
+  grp.traverse(o=>{
+    if(o.isMesh && o.material && o.material.emissive){
+      if(!o.userData.e0){ o.userData.e0 = o.material.emissive.clone();
+        o.userData.ei0 = o.material.emissiveIntensity ?? 1; }
+      if(on){ o.material.emissive.setHex(0xb5852f); o.material.emissiveIntensity = 0.55; }
+      else { o.material.emissive.copy(o.userData.e0); o.material.emissiveIntensity = o.userData.ei0; }
+    }
+  });
+}
+addEventListener('pointermove', e=>{
+  mouse.x = (e.clientX/innerWidth)*2-1;
+  mouse.y = -(e.clientY/innerHeight)*2+1;
+  mouseSX = e.clientX; mouseSY = e.clientY;
+});
+let downX = 0, downY = 0;
+addEventListener('pointerdown', e=>{ downX = e.clientX; downY = e.clientY; });
+addEventListener('click', e=>{
+  if(e.target instanceof Element && (e.target.closest('#bar') || e.target.closest('#panel'))) return;
+  if(Math.hypot(e.clientX-downX, e.clientY-downY) > 6) return; // 拖拽不触发
+  if(hovered) showInfo(hovered.userData.part, true);
+  else showInfo(DEFAULT_INFO, false);
+});
+function updateHover(){
+  raycaster.setFromCamera(mouse, camera);
+  const hits = raycaster.intersectObjects(watch.children, true);
+  let target = null, glassTarget = null;
+  for(const h of hits){
+    const p = findPart(h.object);
+    if(!p) continue;
+    const id = p.userData.part.id;
+    if(id === 'crystal' || id === 'back'){ if(!glassTarget) glassTarget = p; continue; } // 玻璃不遮挡内部零件拾取
+    target = p; break;
+  }
+  if(!target) target = glassTarget;
+  if(target !== hovered){
+    if(hovered) setHi(hovered, false);
+    hovered = target;
+    if(hovered){ setHi(hovered, true);
+      tipTxt.textContent = hovered.userData.part.name;
+      tip.style.opacity = 1;
+      document.body.style.cursor = 'pointer';
+    } else { tip.style.opacity = 0; document.body.style.cursor = 'default'; }
+  }
+  if(hovered){ tip.style.left = mouseSX+'px'; tip.style.top = mouseSY+'px'; }
+}
+
+/* ================= UI 按钮 ================= */
+let explodeT = 0, explodeTarget = 0, running = true;
+const bExplode = document.getElementById('bExplode');
+const bRotate = document.getElementById('bRotate');
+const bRun = document.getElementById('bRun');
+bExplode.onclick = ()=>{
+  explodeTarget = explodeTarget ? 0 : 1;
+  bExplode.classList.toggle('on', explodeTarget===1);
+};
+bRotate.onclick = ()=>{
+  controls.autoRotate = !controls.autoRotate;
+  bRotate.classList.toggle('on', controls.autoRotate);
+};
+bRun.onclick = ()=>{
+  running = !running;
+  bRun.textContent = running ? '暂停机芯' : '启动机芯';
+  bRun.classList.toggle('on', !running);
+};
+document.getElementById('bReset').onclick = ()=>{
+  introT = 0; introFrom.copy(camera.position); introActive = true;
+  controls.target.set(0, 0.5, 0);
+};
+
+/* ================= 动画主循环 ================= */
+const clock = new THREE.Clock();
+let T = 0;                       // 机芯运转时间
+const BEAT = 3;                  // 3 Hz 摆频
+let introActive = true, introT = 0;
+const introFrom = new THREE.Vector3(0, 52, 78);
+const introTo = new THREE.Vector3(3.5, 24.5, 29);
+controls.addEventListener('start', ()=>{ introActive = false; });
+
+function animate(){
+  requestAnimationFrame(animate);
+  const dt = Math.min(clock.getDelta(), 0.05);
+  const t = clock.elapsedTime;
+
+  // 入场镜头
+  if(introActive){
+    introT = Math.min(introT + dt/2.6, 1);
+    const k = 1 - Math.pow(1-introT, 3);
+    camera.position.lerpVectors(introFrom, introTo, k);
+    if(introT >= 1) introActive = false;
+  }
+
+  // 悬浮呼吸
+  tilt.position.y = Math.sin(t*0.55)*0.28;
+  tilt.rotation.z = Math.sin(t*0.22)*0.03;
+
+  // 机芯运转
+  if(running){
+    T += dt;
+    const w = TAU*BEAT;
+    balWheel.rotation.z = 2.4*Math.sin(w*T);                         // 摆轮振荡 ±140°
+    hairspring.scale.setScalar(1 + 0.05*Math.sin(w*T));              // 游丝呼吸
+    palletFork.rotation.z = 0.24*Math.tanh(5*Math.sin(w*T + 0.4));   // 擒纵叉摆动
+    const halfBeats = Math.floor(w*T/Math.PI);                       // 擒纵轮逐齿步进
+    const targetEsc = -halfBeats*(TAU/15)/2;
+    escW.rotation.z += (targetEsc - escW.rotation.z)*Math.min(1, dt*26);
+    fourthW.rotation.z += dt*0.21;                                   // 轮系按传动比缓转
+    thirdW.rotation.z  -= dt*0.062;
+    centerW.rotation.z += dt*0.0175;
+    barrelWheel.rotation.z -= dt*0.006;
+  }
+
+  // 指针（真实时间）
+  const d = new Date();
+  const s = d.getSeconds() + d.getMilliseconds()/1000;
+  const mi = d.getMinutes() + s/60;
+  const h = (d.getHours()%12) + mi/60;
+  secHand.rotation.z  = -s/60*TAU;
+  minHand.rotation.z  = -mi/60*TAU;
+  hourHand.rotation.z = -h/12*TAU;
+
+  // 爆炸视图缓动
+  explodeT += (explodeTarget - explodeT)*Math.min(1, dt*3.2);
+  const e = explodeT*explodeT*(3-2*explodeT);
+  for(const p of parts) p.position.z = p.userData.baseZ + e*p.userData.explodeZ;
+
+  updateHover();
+  controls.update();
+  renderer.render(scene, camera);
+}
+animate();
+document.getElementById('loading').classList.add('done');
+
+addEventListener('resize', ()=>{
+  camera.aspect = innerWidth/innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(innerWidth, innerHeight);
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 产出说明 / Run info

- 模型 / Model: Qoder Ultimate
- 厂商 / Vendor: Alibaba
- 运行环境 / Harness: Qoder
- 思考配额 / Thinking effort: Max
- 是否一次生成 / One-shot?: 是。两次独立会话各一次生成（同一 Agent 的两次 take，以 runs.skeleton-watch 数组登记于新条目 models/qoder-ultimate-max.json，与已有 Default 档条目分立）。仅按匿名化规则替换了产物中暗示身份的品牌与机芯型号：QODER · HAUTE HORLOGERIE→BOREAL · HAUTE HORLOGERIE、QDR-88→BT-100；MAISON QODER→MAISON FASHION、QD-88→MF-500。已在两条 note 中逐一说明，其余未改。

## 生成凭证截图 / Proof screenshot **(required)**

<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/67170d5d-413d-4fa3-bfdc-21ed8a69ccb3" />

<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/fda24c79-e10e-4916-89a1-65feba95a963" />

## 自查 / Checklist

- [x] 只改了两类文件：`outputs/<artifactDir>/<case-id>.<ext>` + `models/<model-id>.json` / only the artifact + its JSON
- [x] **没有**手改 `README.md` / `README.en.md`（注册表合并后由 CI 自动同步）/ did **not** hand-edit the README registry (auto-synced after merge)
- [x] 模型 id 用短横线、以**模型**命名（非 harness），如 `deepseek-v4-flash-reasonix` / dash-case id named after the model, not the harness
- [x] `harness` 与 `effort` 如实填写（站点据此生成 metadata 与品牌 icon）/ `harness` and `effort` are accurate
- [x] 用 harness **默认形态**生成，未额外加载自带以外的 skill / 插件 / MCP / 自定义系统提示 / ran the harness as it ships — no extra skills / plugins / MCP / custom prompts
- [x] 每条 run 的 `note` 双语（zh + en，zh 先，无 emoji）填了来历 / bilingual `note`, zh first, no emojis
- [x] 同一模型换 Harness 或思考配额是**新建一个 JSON 条目** / a different harness or effort = a NEW json entry
- [x] `contributor` 是我的 GitHub 用户名 / `contributor` is my GitHub username
- [x] 已贴生成凭证截图 / attached the proof screenshot above
- [x] 本地 `bun scripts/validate-data.ts` 通过 / `bun scripts/validate-data.ts` passes locally