### PR TITLE
feat: add DeepSeek V4 Flash 0731 (Claude Code, Max) — 4 runs

### DIFF
--- a/models/deepseek-v4-flash-0731-cc.json
+++ b/models/deepseek-v4-flash-0731-cc.json
@@ -1,0 +1,38 @@
+{
+  "label": "DeepSeek V4 Flash 0731",
+  "vendor": "DeepSeek",
+  "harness": "Claude Code",
+  "effort": "Max",
+  "artifactDir": "deepseek-v4-flash-0731/claude-code-max",
+  "order": 50,
+  "runs": {
+    "mythos-craft": {
+      "note": {
+        "zh": "在 Claude Code 中以 DeepSeek-V4-Flash-0731（Max）使用仓库标准中文提示词一次生成，未修改。自实现分形柏林噪声的无限区块化地形，第一人称 WASD 移动与鼠标环视，16 种程序化纹理方块，左键挖掘右键放置，内置龙辉堡、远古神庙、世界之树、水晶尖塔、浮空岛、龙之巢穴、先民石阵七大神话遗迹，昼夜循环与群系系统。",
+        "en": "One-shot by DeepSeek-V4-Flash-0731 (Max effort) in Claude Code from the canonical prompt, unmodified. Features fractal Perlin-noise infinite chunked terrain, first-person WASD + mouse-look, 16 procedurally textured block types with left-click break / right-click place, seven mythic ruins (Dragonkeep, Ancient Temple, World Tree, Crystal Spire, Sky Island, Dragon's Lair, Standing Stones), day-night cycle and biomes."
+      },
+      "contributor": "wuguohan0816-glitch"
+    },
+    "skeleton-watch": {
+      "note": {
+        "zh": "在 Claude Code 中以 DeepSeek-V4-Flash-0731（Max）使用仓库标准中文提示词一次生成，未修改。Three.js (CDN) 构建的完整 3D 镂空机械表：18 个可交互机芯零件（发条盒、齿轮系、游丝摆轮、擒纵机构、夹板、红宝石轴承等），支持旋转、爆炸视图、CSS2D 零件标签与信息面板，摆轮振荡与齿轮传动动画。",
+        "en": "One-shot by DeepSeek-V4-Flash-0731 (Max effort) in Claude Code from the canonical prompt, unmodified. A complete interactive 3D skeleton mechanical watch built with Three.js (CDN): 18 interactive movement parts (mainspring barrel, gear train, hairspring balance wheel, escapement, bridges, ruby jewels), orbit/exploded view, CSS2D part labels and info panel, oscillating balance and gear animations."
+      },
+      "contributor": "wuguohan0816-glitch"
+    },
+    "pelican-cycling": {
+      "note": {
+        "zh": "在 Claude Code 中以 DeepSeek-V4-Flash-0731（Max）使用仓库标准中文提示词一次生成，未修改。手绘矢量海边场景：骑自行车的鹈鹕、海浪、沙滩、云朵与太阳，全部以 SMIL 动画实现车轮旋转、蹬踏、翅扇、浪涌等 10 组动画。",
+        "en": "One-shot by DeepSeek-V4-Flash-0731 (Max effort) in Claude Code from the canonical prompt, unmodified. Hand-drawn vector seaside scene: a pelican riding a bicycle, waves, beach, clouds and sun, with 10 SMIL animations (wheel spin, pedaling, wing flaps, wave motion)."
+      },
+      "contributor": "wuguohan0816-glitch"
+    },
+    "cs-dust2": {
+      "note": {
+        "zh": "在 Claude Code 中以 DeepSeek-V4-Flash-0731（Max）使用仓库标准中文提示词一次生成的完整 Vite + React 18 + TypeScript + Three.js 工程，源码未经人工修改，站点部署时从源码重新构建。覆盖 Dust2 全部核心区域（T/CT 出生点、A大、A点、中门、猫道、B洞、B点），程序化类人角色、7 种武器、Hitbox 分区伤害、C4 下包/拆包/爆炸回合结算、5v5 AI（BFS 寻路、视野索敌、参与下包拆包）、小地图与程序化合成音效；本地 tsc 与 vite build 通过，并附带无头模拟对局验证。",
+        "en": "A complete Vite + React 18 + TypeScript + Three.js project generated in one shot by DeepSeek-V4-Flash-0731 (Max effort) in Claude Code from the canonical prompt, with no human edits to the source; the site rebuilds it from source during deployment. Covers all core Dust2 areas (T/CT spawns, A Long, A Site, Mid with door, Catwalk, B Tunnels, B Site), procedural humanoid characters, 7 weapons, hitbox-part damage, C4 plant/defuse/explode round resolution, 5v5 AI (BFS pathfinding, line-of-sight detection, plant/defuse participation), minimap and procedurally synthesized audio; local tsc and vite build passed, plus headless simulated matches as verification."
+      },
+      "contributor": "wuguohan0816-glitch"
+    }
+  }
+}

--- a/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/index.html
+++ b/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dust2 FPS</title>
+    <style>
+      html, body, #root { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; background: #000; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/package-lock.json
+++ b/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/package-lock.json
@@ -1,0 +1,1836 @@
+{
+  "name": "dust2-fps-prototype",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dust2-fps-prototype",
+      "version": "1.0.0",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "three": "^0.170.0"
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
+        "@types/three": "^0.170.0",
+        "@vitejs/plugin-react": "^4.3.4",
+        "typescript": "^5.6.3",
+        "vite": "^5.4.11"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
+      "integrity": "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz",
+      "integrity": "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz",
+      "integrity": "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz",
+      "integrity": "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz",
+      "integrity": "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz",
+      "integrity": "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz",
+      "integrity": "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz",
+      "integrity": "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz",
+      "integrity": "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz",
+      "integrity": "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz",
+      "integrity": "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz",
+      "integrity": "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz",
+      "integrity": "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz",
+      "integrity": "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz",
+      "integrity": "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz",
+      "integrity": "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz",
+      "integrity": "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
+      "integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz",
+      "integrity": "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz",
+      "integrity": "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz",
+      "integrity": "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz",
+      "integrity": "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
+      "integrity": "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-CUm2uckq+zkCY7ZbFpviRttY+6f9fvwm6YqSqPfA5K22s9w7R4VnA3rzJse8kHVvuzLcTx+CjNCs2NYe0QFAyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.18.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.71",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.71.tgz",
+      "integrity": "sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.8.tgz",
+      "integrity": "sha512-zAgkquC2WYF0PIc6XbNYkA2uuxxFavzgmX61R+dHDUa558V8Ejf8ozTZFR6QzM24RWu4kBcRkhJ5kpz77j9fnQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.399",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.399.tgz",
+      "integrity": "sha512-lEcqhErbHjXRvd41rnWLpzbyU/IXfIYo7QwaFWmxGeLiLyY2TBCdHnWY88vB+p3ubnihRypDm66panXl7TylLA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
+      "integrity": "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.3",
+        "@rollup/rollup-android-arm64": "4.62.3",
+        "@rollup/rollup-darwin-arm64": "4.62.3",
+        "@rollup/rollup-darwin-x64": "4.62.3",
+        "@rollup/rollup-freebsd-arm64": "4.62.3",
+        "@rollup/rollup-freebsd-x64": "4.62.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.3",
+        "@rollup/rollup-linux-arm64-musl": "4.62.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.3",
+        "@rollup/rollup-linux-loong64-musl": "4.62.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-musl": "4.62.3",
+        "@rollup/rollup-openbsd-x64": "4.62.3",
+        "@rollup/rollup-openharmony-arm64": "4.62.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.3",
+        "@rollup/rollup-win32-x64-gnu": "4.62.3",
+        "@rollup/rollup-win32-x64-msvc": "4.62.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/package.json
+++ b/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "dust2-fps-prototype",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "three": "^0.170.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@types/three": "^0.170.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.11"
+  }
+}

--- a/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/game/ai.ts
+++ b/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/game/ai.ts
@@ -1,0 +1,329 @@
+// AI 控制器：寻路、巡逻、索敌开火、下包 / 拆包决策
+
+import { NAV, NAV_EDGES, SITES, navNode } from './map';
+import { EYE_HEIGHT, TEAM_CT, TEAM_T } from './types';
+import { PlayerEntity } from './entity';
+import type { GameEngine } from './engine';
+
+function normAngle(a: number): number {
+  while (a > Math.PI) a -= Math.PI * 2;
+  while (a < -Math.PI) a += Math.PI * 2;
+  return a;
+}
+
+export class AIController {
+  role = 'defA'; // carrier / carrierM8 / attackA / attackB / midLurk / defA / defB / midDef / roam
+  siteTarget: 'A' | 'B' = 'A'; // 进攻方主攻包点
+  path: number[] = [];
+  goalNode = -1;
+  state: 'move' | 'hold' | 'combat' = 'move';
+  targetEnemy = -1;
+  fireDelay = 0;
+  stuckT = 0;
+  lastX = 0;
+  lastZ = 0;
+  holdT = 0;
+  scanT = 0;
+
+  reset(): void {
+    this.path = [];
+    this.state = 'move';
+    this.targetEnemy = -1;
+    this.fireDelay = 0;
+    this.stuckT = 0;
+    this.holdT = 0;
+    this.scanT = 0;
+  }
+
+  /** 回合开始时的职责分配 */
+  static assignRoles(eng: GameEngine): void {
+    const ts = eng.players.filter((p) => p.team === TEAM_T);
+    const cs = eng.players.filter((p) => p.team === TEAM_CT);
+    const site: 'A' | 'B' = Math.random() < 0.5 ? 'A' : 'B';
+    const other: 'A' | 'B' = site === 'A' ? 'B' : 'A';
+    for (const p of ts) {
+      const c = eng.aiControllers[p.index];
+      c.siteTarget = site;
+      c.role = p.index === eng.bombCarrier ? 'carrier' : (Math.random() < 0.5 ? `attack${site}` : `attack${other}`);
+    }
+    const others = ts.filter((p) => p.index !== eng.bombCarrier);
+    if (others.length >= 2) {
+      eng.aiControllers[others[0].index].role = `attack${site}`;
+      eng.aiControllers[others[1].index].role = `attack${other}`;
+    }
+    if (others.length >= 3) eng.aiControllers[others[2].index].role = 'midLurk';
+    if (others.length >= 4) eng.aiControllers[others[3].index].role = `attack${other}`;
+
+    const defs: ('defA' | 'defB' | 'midDef' | 'roam')[] = ['defA', 'defB', 'midDef', 'roam', 'roam'];
+    cs.forEach((p, i) => {
+      eng.aiControllers[p.index].role = defs[i];
+    });
+    // 切换默认主武器
+    for (const p of eng.players) {
+      if (p.team === TEAM_T && p.hasWeapon('ak47')) p.switchWeapon('primary');
+      else if (p.team === TEAM_CT && p.hasWeapon('m4a4')) p.switchWeapon('primary');
+    }
+  }
+
+  private nearestNode(x: number, z: number): number {
+    let best = 0;
+    let bestD = Infinity;
+    for (const n of NAV) {
+      const d = (n.x - x) * (n.x - x) + (n.z - z) * (n.z - z);
+      if (d < bestD) { bestD = d; best = n.id; }
+    }
+    return best;
+  }
+
+  /** BFS 寻路（waypoint 图） */
+  private computePath(fromX: number, fromZ: number, toNode: number): number[] {
+    const start = this.nearestNode(fromX, fromZ);
+    if (start === toNode) return [];
+    const prev = new Map<number, number>();
+    const visited = new Set<number>([start]);
+    const queue: number[] = [start];
+    let found = false;
+    while (queue.length > 0 && !found) {
+      const cur = queue.shift()!;
+      for (const [a, b] of NAV_EDGES) {
+        const nxt = a === cur ? b : b === cur ? a : -1;
+        if (nxt < 0 || visited.has(nxt)) continue;
+        visited.add(nxt);
+        prev.set(nxt, cur);
+        if (nxt === toNode) { found = true; break; }
+        queue.push(nxt);
+      }
+    }
+    if (!found) return [];
+    const path: number[] = [];
+    let cur = toNode;
+    while (cur !== start) {
+      path.unshift(cur);
+      cur = prev.get(cur) ?? start;
+    }
+    return path;
+  }
+
+  /** 当前角色目标节点 */
+  private goalFor(eng: GameEngine, bot: PlayerEntity): number {
+    const planted = eng.bombPlanted;
+    const bomb = { x: eng.bombX, z: eng.bombZ };
+    if (bot.team === TEAM_T) {
+      if (planted) {
+        // 防守炸弹：围绕炸弹的固定偏移（确定性，避免每帧换目标）
+        const ox = bomb.x + ((bot.index * 13) % 15) - 7;
+        const oz = bomb.z + ((bot.index * 7) % 11) - 5;
+        return this.nearestNode(ox, oz);
+      }
+      // 炸弹掉落时去捡
+      if (eng.bombDropped && !bot.hasBomb) {
+        return this.nearestNode(bomb.x, bomb.z);
+      }
+      switch (this.role) {
+        case 'carrier':
+        case 'carrierM8': return this.siteTarget === 'A' ? 29 : 9;
+        case 'attackA': return 29;
+        case 'attackB': return 9;
+        case 'midLurk': return 19;
+        default: return this.siteTarget === 'A' ? 29 : 9;
+      }
+    } else {
+      if (planted) return this.nearestNode(bomb.x, bomb.z);
+      switch (this.role) {
+        case 'defA': return 29;
+        case 'defB': return 9;
+        case 'midDef': return 19;
+        default: return 24; // roam 猫道 / CT 通道
+      }
+    }
+  }
+
+  think(eng: GameEngine, bot: PlayerEntity): void {
+    bot.aiFire = false;
+    bot.aiInteract = false;
+    const dt = 0.12;
+
+    // ---- 目标动作优先：捡包 / 下包 / 拆包（挨打也要继续执行） ----
+    if (bot.team === TEAM_T && eng.bombDropped && !eng.bombPlanted && !bot.hasBomb) {
+      if (Math.hypot(eng.bombX - bot.x, eng.bombZ - bot.z) < 1.1) {
+        bot.aiInteract = true;
+        bot.aiMoveX = 0;
+        bot.aiMoveZ = 0;
+        return;
+      }
+    }
+    if (bot.team === TEAM_T && bot.hasBomb && !eng.bombPlanted) {
+      const site = this.siteTarget === 'A' ? SITES[0] : SITES[1];
+      const d = Math.hypot(bot.x - site.x, bot.z - site.z);
+      if (d < site.radius * 0.5) {
+        bot.aiInteract = true;
+        bot.aiMoveX = 0;
+        bot.aiMoveZ = 0;
+        bot.yaw = Math.atan2(site.z - bot.z, site.x - bot.x);
+        return;
+      }
+    }
+    // ---- 拆包（已开始则坚持拆完；其余 CT 先清场再拆） ----
+    if (bot.team === TEAM_CT && eng.bombPlanted) {
+      const d = Math.hypot(bot.x - eng.bombX, bot.z - eng.bombZ);
+      if (eng.defusingEntity === bot.index) {
+        bot.aiInteract = true; // 已分配拆包：继续执行
+        bot.aiMoveX = 0;
+        bot.aiMoveZ = 0;
+        return;
+      }
+      if (d < 1.15 && eng.defusingEntity === -1) {
+        bot.aiInteract = true;
+        bot.aiMoveX = 0;
+        bot.aiMoveZ = 0;
+        bot.yaw = Math.atan2(eng.bombZ - bot.z, eng.bombX - bot.x);
+        return;
+      }
+    }
+
+    // ---- 索敌（30m 内；优先反击最近伤害来源，避免被远距离目标带离路线） ----
+    let visible: PlayerEntity | null = null;
+    let bestScore = Infinity;
+    for (const e of eng.players) {
+      if (e.team === bot.team || !e.alive) continue;
+      const d = Math.hypot(e.x - bot.x, e.z - bot.z);
+      if (d > 30) continue;
+      const ang = Math.atan2(e.z - bot.z, e.x - bot.x);
+      if (Math.abs(normAngle(ang - bot.yaw)) > 2.1) continue;
+      if (PlayerEntity.lineBlocked(bot.x, bot.z, e.x, e.z)) continue;
+      const isDamager = e.index === bot.lastDamager && eng.simTime - bot.lastDamagerT < 3;
+      const score = d - (isDamager ? 100 : 0);
+      if (score < bestScore) {
+        visible = e;
+        bestScore = score;
+      }
+    }
+
+    if (visible) {
+      const newTarget = this.targetEnemy !== visible.index;
+      this.state = 'combat';
+      this.targetEnemy = visible.index;
+      if (newTarget) {
+        // CT 反应更快（回防拆包有利）
+        this.fireDelay = bot.team === TEAM_CT ? 0.12 + Math.random() * 0.28 : 0.3 + Math.random() * 0.5;
+      }
+      this.fireDelay = Math.max(0, this.fireDelay - dt);
+      const dist = Math.hypot(visible.x - bot.x, visible.z - bot.z);
+      const desired = Math.atan2(visible.z - bot.z, visible.x - bot.x);
+      const diff = normAngle(desired - bot.yaw);
+      bot.yaw += Math.max(-6, Math.min(6, diff)) * dt;
+      bot.pitch = Math.max(-1.4, Math.min(1.4, Math.atan2(EYE_HEIGHT - 0.35 - EYE_HEIGHT, dist)));
+      if (Math.abs(diff) < 0.3 && dist < 36 && this.fireDelay <= 0) {
+        bot.aiFire = true;
+      }
+      // 拆包优先：CT 在炸弹附近或时间紧迫时不停下缠斗
+      const defuseUrgent =
+        bot.team === TEAM_CT && eng.bombPlanted &&
+        (Math.hypot(bot.x - eng.bombX, bot.z - eng.bombZ) < 35 || eng.bombTime < 25);
+      if (dist <= 22 && !defuseUrgent) {
+        bot.aiMoveX = 0;
+        bot.aiMoveZ = 0;
+        return;
+      }
+      if (defuseUrgent) {
+        // 边打边冲向炸弹
+        const bd = Math.atan2(eng.bombZ - bot.z, eng.bombX - bot.x);
+        const bdiff = normAngle(bd - bot.yaw);
+        bot.aiMoveX = Math.sin(bdiff);
+        bot.aiMoveZ = Math.cos(bdiff);
+        return;
+      }
+      // 远距离：向敌人推进（边走边打），避免远距离站桩对峙
+      const pushDiff = normAngle(desired - bot.yaw);
+      bot.aiMoveX = Math.sin(pushDiff) * 0.7;
+      bot.aiMoveZ = Math.cos(pushDiff) * 0.7;
+      return;
+    }
+    if (this.state === 'combat') {
+      this.state = 'move';
+      this.targetEnemy = -1;
+    }
+
+    // ---- 移动寻路 ----
+    const goalNode = this.goalFor(eng, bot);
+    if (this.goalNode !== goalNode || this.path.length === 0) {
+      this.goalNode = goalNode;
+      this.path = this.computePath(bot.x, bot.z, goalNode);
+      this.stuckT = 0;
+      this.lastX = bot.x;
+      this.lastZ = bot.z;
+    }
+
+    const target = this.path.length > 0 ? navNode(this.path[0]) : navNode(goalNode);
+    let tx = target.x, tz = target.z;
+    // CT 拆包冲刺：路径走完后直奔炸弹精确位置
+    const rushDefuse = bot.team === TEAM_CT && eng.bombPlanted && this.path.length === 0;
+    if (rushDefuse) {
+      tx = eng.bombX;
+      tz = eng.bombZ;
+    }
+    const dGoal = Math.hypot(tx - bot.x, tz - bot.z);
+    if (dGoal < 1.4) {
+      if (this.path.length > 0) this.path.shift();
+      else if (!rushDefuse) {
+        this.state = 'hold';
+        this.holdT = 2 + Math.random() * 5;
+      }
+    }
+
+    // 卡住检测
+    const moved = Math.hypot(bot.x - this.lastX, bot.z - this.lastZ);
+    this.stuckT += moved < 0.05 ? dt : 0;
+    this.lastX = bot.x;
+    this.lastZ = bot.z;
+    if (this.stuckT > 1.2) {
+      this.stuckT = 0;
+      if (this.path.length > 1) this.path.shift();
+      else this.path = [];
+    }
+
+    if (this.state === 'hold') {
+      this.holdT -= dt;
+      // 驻守：缓慢转动扫描
+      this.scanT += dt;
+      const cur = navNode(this.nearestNode(bot.x, bot.z));
+      const ang = Math.atan2(cur.z - bot.z, cur.x - bot.x);
+      bot.yaw += normAngle(ang + Math.sin(this.scanT * 1.2 + bot.index) * 0.8 - bot.yaw) * 0.04;
+      bot.aiMoveX = 0;
+      bot.aiMoveZ = 0;
+      if (this.holdT <= 0) {
+        this.state = 'move';
+        // 巡逻到相邻节点
+        const neighbors: number[] = [];
+        for (const [a, b] of NAV_EDGES) {
+          if (a === this.goalNode) neighbors.push(b);
+          if (b === this.goalNode) neighbors.push(a);
+        }
+        if (neighbors.length > 0) {
+          const pick = neighbors[Math.floor(Math.random() * neighbors.length)];
+          this.goalNode = pick;
+          this.path = [pick];
+        }
+      }
+      return;
+    }
+
+    // 朝目标移动（本地输入：mx 横向 / mz 纵向）
+    const desiredYaw = Math.atan2(tz - bot.z, tx - bot.x);
+    const diff = normAngle(desiredYaw - bot.yaw);
+    bot.yaw += Math.max(-5.5, Math.min(5.5, diff)) * dt;
+    let repX = 0, repZ = 0;
+    for (const mate of eng.players) {
+      if (mate === bot || !mate.alive || mate.team !== bot.team) continue;
+      const dx = bot.x - mate.x, dz = bot.z - mate.z;
+      const d = Math.hypot(dx, dz);
+      if (d < 1.3 && d > 0.01) {
+        repX += (dx / d) * (1.3 - d) * 2;
+        repZ += (dz / d) * (1.3 - d) * 2;
+      }
+    }
+    const fdiff = normAngle(Math.atan2(tz + repZ - bot.z, tx + repX - bot.x) - bot.yaw);
+    bot.aiMoveX = Math.sin(fdiff);
+    bot.aiMoveZ = Math.cos(fdiff);
+  }
+}

--- a/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/game/audio.ts
+++ b/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/game/audio.ts
@@ -1,0 +1,181 @@
+// Web Audio 程序化合成音效（无外部音频文件）
+
+export type SoundName =
+  | 'ak47' | 'm4a4' | 'awp' | 'glock' | 'usp' | 'deagle' | 'knife'
+  | 'reload' | 'step' | 'zoom' | 'hit' | 'kill' | 'headshot'
+  | 'plant' | 'defuse' | 'explode' | 'beep' | 'roundStart' | 'roundEnd'
+  | 'jump' | 'dryfire' | 'armorHit' | 'buy' | 'death' | 'pickup';
+
+export class SoundManager {
+  private ctx: AudioContext | null = null;
+  private master: GainNode | null = null;
+  private noiseBuf: AudioBuffer | null = null;
+  muted = false;
+
+  /** 必须在用户手势中调用一次 */
+  ensure(): void {
+    if (!this.ctx) {
+      const AC = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+      this.ctx = new AC();
+      this.master = this.ctx.createGain();
+      this.master.gain.value = 0.5;
+      this.master.connect(this.ctx.destination);
+      // 预生成噪声缓冲
+      const len = this.ctx.sampleRate * 1.0;
+      this.noiseBuf = this.ctx.createBuffer(1, len, this.ctx.sampleRate);
+      const data = this.noiseBuf.getChannelData(0);
+      for (let i = 0; i < len; i++) data[i] = Math.random() * 2 - 1;
+    }
+    if (this.ctx.state === 'suspended') void this.ctx.resume();
+  }
+
+  resume(): void {
+    this.ensure();
+  }
+
+  private noise(dur: number, filterFreq: number, filterType: BiquadFilterType, gain: number, decay = true): void {
+    if (!this.ctx || !this.master || !this.noiseBuf || this.muted) return;
+    const t = this.ctx.currentTime;
+    const src = this.ctx.createBufferSource();
+    src.buffer = this.noiseBuf;
+    src.playbackRate.value = 0.7 + Math.random() * 0.6;
+    const filt = this.ctx.createBiquadFilter();
+    filt.type = filterType;
+    filt.frequency.value = filterFreq;
+    filt.Q.value = 0.8;
+    const g = this.ctx.createGain();
+    const v = gain * (0.75 + Math.random() * 0.5);
+    g.gain.setValueAtTime(v, t);
+    if (decay) g.gain.exponentialRampToValueAtTime(0.0001, t + dur);
+    src.connect(filt).connect(g).connect(this.master);
+    src.start(t);
+    src.stop(t + dur + 0.05);
+  }
+
+  private tone(
+    freq: number, endFreq: number, dur: number, gain: number,
+    type: OscillatorType = 'sine', delay = 0,
+  ): void {
+    if (!this.ctx || !this.master || this.muted) return;
+    const t = this.ctx.currentTime + delay;
+    const osc = this.ctx.createOscillator();
+    osc.type = type;
+    osc.frequency.setValueAtTime(freq, t);
+    osc.frequency.exponentialRampToValueAtTime(Math.max(20, endFreq), t + dur);
+    const g = this.ctx.createGain();
+    g.gain.setValueAtTime(gain, t);
+    g.gain.exponentialRampToValueAtTime(0.0001, t + dur);
+    osc.connect(g).connect(this.master);
+    osc.start(t);
+    osc.stop(t + dur + 0.05);
+  }
+
+  play(name: SoundName): void {
+    this.ensure();
+    if (!this.ctx || this.muted) return;
+    switch (name) {
+      case 'ak47': // 低沉爆响 + 机械音
+        this.noise(0.12, 700, 'lowpass', 0.9);
+        this.noise(0.06, 2400, 'highpass', 0.5);
+        this.tone(160, 55, 0.11, 0.7, 'square');
+        break;
+      case 'm4a4': // 清脆短促
+        this.noise(0.08, 1500, 'lowpass', 0.75);
+        this.noise(0.05, 3500, 'highpass', 0.4);
+        this.tone(220, 90, 0.07, 0.5, 'square');
+        break;
+      case 'awp': // 巨响 + 弹壳
+        this.noise(0.35, 500, 'lowpass', 1.6);
+        this.noise(0.15, 3000, 'highpass', 0.8);
+        this.tone(120, 40, 0.3, 1.0, 'sawtooth');
+        this.tone(800, 300, 0.05, 0.3, 'triangle', 0.1);
+        break;
+      case 'glock':
+        this.noise(0.07, 1800, 'lowpass', 0.55);
+        this.tone(300, 120, 0.05, 0.35, 'square');
+        break;
+      case 'usp':
+        this.noise(0.08, 1600, 'lowpass', 0.6);
+        this.tone(260, 100, 0.06, 0.4, 'square');
+        break;
+      case 'deagle': // 威力大
+        this.noise(0.14, 900, 'lowpass', 1.0);
+        this.tone(180, 60, 0.12, 0.8, 'square');
+        break;
+      case 'knife':
+        this.noise(0.09, 2500, 'bandpass', 0.5);
+        this.tone(900, 200, 0.08, 0.4, 'sawtooth');
+        break;
+      case 'dryfire':
+        this.noise(0.02, 2000, 'highpass', 0.2);
+        break;
+      case 'reload': // 拉栓 / 上弹咔哒
+        this.tone(700, 500, 0.03, 0.25, 'square');
+        this.tone(500, 350, 0.03, 0.25, 'square', 0.15);
+        this.tone(900, 600, 0.04, 0.3, 'square', 0.5);
+        break;
+      case 'step':
+        this.noise(0.06, 400, 'lowpass', 0.22);
+        break;
+      case 'jump':
+        this.noise(0.05, 300, 'lowpass', 0.15);
+        break;
+      case 'zoom':
+        this.tone(1200, 900, 0.05, 0.2, 'sine');
+        this.tone(1500, 1100, 0.04, 0.15, 'sine', 0.06);
+        break;
+      case 'hit':
+        this.tone(500, 200, 0.06, 0.35, 'triangle');
+        break;
+      case 'armorHit':
+        this.tone(900, 400, 0.05, 0.3, 'square');
+        break;
+      case 'headshot':
+        this.tone(1200, 500, 0.08, 0.5, 'triangle');
+        break;
+      case 'kill': // 击杀提示
+        this.tone(880, 880, 0.09, 0.3, 'sine');
+        this.tone(1174, 1174, 0.12, 0.3, 'sine', 0.1);
+        break;
+      case 'death':
+        this.tone(400, 120, 0.4, 0.4, 'sawtooth');
+        break;
+      case 'plant': // 嘀-嘀-嘀
+        for (let i = 0; i < 4; i++) this.tone(900, 900, 0.08, 0.35, 'square', i * 0.3);
+        this.tone(600, 300, 0.4, 0.4, 'square', 1.3);
+        break;
+      case 'defuse':
+        this.tone(500, 800, 0.1, 0.3, 'square');
+        this.tone(650, 1000, 0.12, 0.3, 'square', 0.2);
+        break;
+      case 'beep': // C4 倒计时
+        this.tone(1000, 1000, 0.05, 0.3, 'square');
+        break;
+      case 'explode':
+        this.noise(1.8, 200, 'lowpass', 2.2);
+        this.tone(90, 25, 1.4, 1.2, 'sine');
+        this.noise(0.6, 800, 'bandpass', 1.0);
+        break;
+      case 'roundStart':
+        this.tone(520, 520, 0.1, 0.25, 'sine');
+        this.tone(660, 660, 0.1, 0.25, 'sine', 0.12);
+        this.tone(880, 880, 0.18, 0.3, 'sine', 0.24);
+        break;
+      case 'roundEnd':
+        this.tone(440, 300, 0.35, 0.3, 'sawtooth');
+        break;
+      case 'pickup':
+        this.tone(750, 950, 0.07, 0.3, 'triangle');
+        break;
+      default:
+        break;
+    }
+  }
+
+  setMuted(m: boolean): void {
+    this.muted = m;
+    if (this.master && this.ctx) {
+      this.master.gain.linearRampToValueAtTime(m ? 0 : 0.5, this.ctx.currentTime + 0.1);
+    }
+  }
+}

--- a/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/game/engine.ts
+++ b/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/game/engine.ts
@@ -1,0 +1,742 @@
+// 游戏引擎：回合状态机、战斗、C4、事件、快照
+
+import { PlayerEntity } from './entity';
+import { WEAPONS } from './weapons';
+import { T_SPAWNS, CT_SPAWNS, isInSite, OBSTACLES } from './map';
+import { SoundManager } from './audio';
+import { AIController } from './ai';
+import {
+  TEAM_CT, TEAM_T, EYE_HEIGHT, PLANT_TIME, DEFUSE_TIME, BOMB_FUSE,
+  ROUND_TIME, type Team, type WeaponId, type GameEvent, type HudState,
+  type MinimapData, type Slot,
+} from './types';
+
+export interface InputState {
+  mx: number; // 鼠标横向增量（每帧直接累加）
+  mz: number; // 鼠标纵向增量
+  moveX: number; // -1..1 左右移动
+  moveZ: number; // -1..1 前后移动
+  run: boolean;
+  fire: boolean;
+  zoom: boolean;
+  reload: boolean;
+  jump: boolean;
+  interact: boolean;
+  cycleSlot: 0 | 1 | -1;
+  slotSelect: Slot | null;
+}
+
+export interface RoundResult {
+  winner: Team;
+  reason: string;
+}
+
+const EMPTY_INPUT: InputState = {
+  mx: 0, mz: 0, moveX: 0, moveZ: 0, run: false, fire: false, zoom: false,
+  reload: false, jump: false, interact: false, cycleSlot: 0, slotSelect: null,
+};
+
+export class GameEngine {
+  players: PlayerEntity[] = [];
+  audio: SoundManager;
+  onEvent: (e: GameEvent) => void;
+
+  phase: 'freeze' | 'live' | 'over' = 'freeze';
+  phaseT = 3.5;
+  roundTime = ROUND_TIME;
+  roundNum = 1;
+  scoreCT = 0;
+  scoreT = 0;
+  lastWinner: Team | -1 = -1;
+  lastReason = '';
+  gameOver = false;
+
+  // C4
+  bombCarrier = -1;
+  bombPlanted = false;
+  bombDropped = false;
+  bombX = 0; bombZ = 0;
+  bombTime = BOMB_FUSE;
+  plantProgress = 0;
+  defuseProgress = 0;
+  plantingEntity = -1;
+  defusingEntity = -1;
+  private beepTimer = 0;
+
+  input: InputState = { ...EMPTY_INPUT };
+  simTime = 0; // 全局模拟时间（秒）
+  camIndex = 0; // 视角实体（玩家或接管的队友）
+  playerAlive = true;
+  playerZoom = false;
+  private snapT = 0;
+  private aiLoopT = 0;
+  seenByTeam = new Set<number>(); // 被 CT 或 T 看到的敌人
+  aiControllers: AIController[] = [];
+  private meleeCool = new Map<number, number>();
+  private overT = 0;
+
+  constructor(audio: SoundManager, onEvent: (e: GameEvent) => void) {
+    this.audio = audio;
+    this.onEvent = onEvent;
+    for (let i = 0; i < 5; i++) {
+      const p = new PlayerEntity(i, TEAM_CT);
+      this.players.push(p);
+    }
+    for (let i = 5; i < 10; i++) {
+      const p = new PlayerEntity(i, TEAM_T);
+      this.players.push(p);
+    }
+    this.players[0].isPlayer = true;
+    for (let i = 0; i < 10; i++) {
+      this.aiControllers.push(new AIController());
+    }
+    this.startRound(true);
+  }
+
+  // ---------------- 回合管理 ----------------
+  startRound(pistol: boolean): void {
+    this.phase = 'freeze';
+    this.phaseT = 3.5;
+    this.roundTime = ROUND_TIME;
+    this.bombPlanted = false;
+    this.bombDropped = false;
+    this.bombTime = BOMB_FUSE;
+    this.plantProgress = 0;
+    this.defuseProgress = 0;
+    this.plantingEntity = -1;
+    this.defusingEntity = -1;
+    this.seenByTeam.clear();
+    this.playerZoom = false;
+    this.input.mx = 0;
+    this.input.mz = 0;
+
+    const spawns = this.players.map((p) => (p.team === TEAM_T ? T_SPAWNS : CT_SPAWNS));
+    for (let i = 0; i < 10; i++) {
+      const p = this.players[i];
+      const s = spawns[i][i % 5];
+      p.x = s.x; p.z = s.z; p.y = 0;
+      p.vx = 0; p.vy = 0; p.vz = 0;
+      p.yaw = s.yaw + (Math.random() - 0.5) * 0.4;
+      p.pitch = 0;
+      p.alive = true;
+      p.hasBomb = false;
+      p.hitFlash = 0;
+      p.recoilKick = 0;
+      p.spread = 0;
+      p.reloading = false;
+      p.fireCooldown = 0;
+      p.setupLoadout(pistol);
+      this.aiControllers[i].reset();
+    }
+    // C4 交给随机 T
+    const ts = this.players.filter((p) => p.team === TEAM_T);
+    const carrier = ts[Math.floor(Math.random() * ts.length)];
+    carrier.hasBomb = true;
+    this.bombCarrier = carrier.index;
+
+    // AI 职责分配与主武器切换
+    AIController.assignRoles(this);
+
+    this.camIndex = 0;
+    this.players[0].isPlayer = true;
+    this.playerAlive = true;
+    for (const p of this.players) p.isPlayer = p.index === 0;
+
+    this.audio.play('roundStart');
+    this.onEvent({ type: 'roundStart', roundNum: this.roundNum, pistol });
+  }
+
+  resetGame(): void {
+    this.roundNum = 1;
+    this.scoreCT = 0;
+    this.scoreT = 0;
+    this.gameOver = false;
+    this.startRound(true);
+  }
+
+  private endRound(winner: Team, reason: string): void {
+    if (this.phase === 'over') return;
+    this.phase = 'over';
+    this.overT = 2.8;
+    this.lastWinner = winner;
+    this.lastReason = reason;
+    if (winner === TEAM_CT) this.scoreCT++; else this.scoreT++;
+    if (this.scoreCT >= 8 || this.scoreT >= 8) this.gameOver = true;
+    this.audio.play('roundEnd');
+    this.onEvent({ type: 'roundEnd', winner, reason });
+  }
+
+  private checkRoundEnd(): void {
+    const aliveCT = this.players.filter((p) => p.team === TEAM_CT && p.alive);
+    const aliveT = this.players.filter((p) => p.team === TEAM_T && p.alive);
+    if (aliveCT.length === 0) {
+      this.endRound(TEAM_T, 'CT 全灭');
+      return;
+    }
+    if (aliveT.length === 0 && !this.bombPlanted) {
+      this.endRound(TEAM_CT, 'T 全灭');
+      return;
+    }
+    // T 全灭但已下包：等待拆包或爆炸
+  }
+
+  // ---------------- 主更新 ----------------
+  update(dt: number): void {
+    this.simTime += dt;
+    this.phaseT -= dt;
+    if (this.phase === 'freeze' && this.phaseT <= 0) {
+      this.phase = 'live';
+      this.audio.play('roundStart');
+    }
+    if (this.phase === 'over') {
+      this.overT -= dt;
+      if (this.overT <= 0 && !this.gameOver) {
+        this.roundNum++;
+        this.startRound(this.roundNum === 1); // 只有第 1 回合是手枪局
+      } else if (this.overT <= 0) {
+        // 游戏结束，等待 UI 重置
+      }
+      // over 阶段仍更新动画
+      for (const p of this.players) this.updateEntityFx(p, dt);
+      return;
+    }
+
+    if (this.phase === 'live') {
+      this.roundTime -= dt;
+      if (this.roundTime <= 0) {
+        if (this.bombPlanted) this.endRound(TEAM_T, '时间耗尽（炸弹已安放）');
+        else this.endRound(TEAM_CT, '时间耗尽');
+      }
+    }
+
+    // 玩家输入 → 受控实体
+    const cam = this.players[this.camIndex];
+    if (cam.alive && this.phase === 'live') {
+      this.applyPlayerInput(cam, dt);
+    } else if (cam.alive && this.phase !== 'live') {
+      // 冻结期可以转身
+      cam.yaw += this.input.mx;
+      cam.pitch = Math.max(-1.4, Math.min(1.4, cam.pitch - this.input.mz));
+      this.input.mx = 0;
+      this.input.mz = 0;
+    }
+
+    // AI 思考（节流）
+    this.aiLoopT -= dt;
+    if (this.aiLoopT <= 0) {
+      this.aiLoopT = 0.12;
+      for (let i = 0; i < 10; i++) {
+        const p = this.players[i];
+        if (!p.alive || p.isPlayer) continue;
+        if (this.phase !== 'live') continue;
+        this.aiControllers[i].think(this, p);
+      }
+    }
+
+    // 物理与动画
+    for (const p of this.players) {
+      if (!p.alive) continue;
+      this.updateEntityFx(p, dt);
+      if (p.isPlayer) continue; // 玩家物理由 applyPlayerInput 驱动
+      if (this.phase !== 'live') { p.updatePhysics(dt, 0, 0, false, 1); continue; }
+      const def = WEAPONS[p.activeWeapon];
+      p.updatePhysics(dt, p.aiMoveX, p.aiMoveZ, true, def.moveSpeedMult);
+      if (p.aiFire && p.canFire()) this.tryFire(p);
+      if (p.aiInteract) p.aiInteractLock = 0.15; // 保持互动意图
+      p.aiInteractLock = Math.max(0, p.aiInteractLock - dt);
+      if (p.aiInteractLock > 0) this.tryInteract(p);
+    }
+
+    // 安放 / 拆除进度（按 dt 累积）
+    this.updateActions(dt);
+
+    // C4 逻辑
+    this.updateBomb(dt);
+
+    // 回合结束检查
+    this.checkRoundEnd();
+
+    // 可见敌人（供小地图）
+    this.updateVision();
+  }
+
+  private updateEntityFx(p: PlayerEntity, dt: number): void {
+    p.fireCooldown -= dt;
+    p.firingAnim = Math.max(0, p.firingAnim - dt * 4);
+    p.hitFlash = Math.max(0, p.hitFlash - dt * 3);
+    p.recoilKick = Math.max(0, p.recoilKick - dt * 3.2);
+    p.updateReload(dt);
+    if (p.mag <= 0 && !p.reloading && p.alive) p.startReload();
+  }
+
+  // 玩家（含接管 bot）输入应用
+  private applyPlayerInput(p: PlayerEntity, dt: number): void {
+    const inp = this.input;
+    const def = WEAPONS[p.activeWeapon];
+    // 转身
+    p.yaw += inp.mx;
+    p.pitch = Math.max(-1.45, Math.min(1.45, p.pitch - inp.mz));
+    inp.mx = 0;
+    inp.mz = 0;
+    // 武器切换
+    if (inp.cycleSlot !== 0) {
+      p.cycleSlot(inp.cycleSlot);
+      inp.cycleSlot = 0;
+    }
+    if (inp.slotSelect) {
+      p.switchWeapon(inp.slotSelect);
+      inp.slotSelect = null;
+    }
+    // 换弹
+    if (inp.reload) { p.startReload(); inp.reload = false; }
+    // 跳跃
+    if (inp.jump) { p.jump(); inp.jump = false; }
+    // 移动（植物/拆包时不可移动）
+    const doingAction = this.plantingEntity === p.index || this.defusingEntity === p.index;
+    const zoomed = this.playerZoom;
+    const speedMult = def.moveSpeedMult * (zoomed ? 0.55 : 1);
+    if (!doingAction && this.phase === 'live') {
+      p.updatePhysics(dt, inp.moveX, inp.moveZ, inp.run, speedMult);
+    }
+    // 开火
+    if (inp.fire && this.phase === 'live') {
+      this.tryFire(p);
+    }
+    // 互动（E）
+    if (inp.interact && this.phase === 'live') {
+      this.tryInteract(p);
+    }
+  }
+
+  // ---------------- 战斗 ----------------
+  tryFire(p: PlayerEntity): void {
+    const def = WEAPONS[p.activeWeapon];
+    if (!p.canFire()) {
+      if (def.slot !== 'melee' && p.mag <= 0 && !p.reloading) this.audio.play('dryfire');
+      return;
+    }
+    p.fireCooldown = def.fireInterval;
+
+    if (def.slot === 'melee') {
+      this.meleeAttack(p);
+      return;
+    }
+
+    // 消耗弹药
+    p.mag--;
+    p.spread = Math.min(p.spread + def.spreadPerShot, def.spreadMax);
+    p.recoilKick = Math.min(p.recoilKick + def.recoilPitch, 0.5);
+    p.firingAnim = 1;
+    // 射击音效
+    this.audio.play(p.activeWeapon);
+
+    // 弹道方向（含散布）
+    const sp = p.spread;
+    const yaw = p.yaw + (Math.random() - 0.5) * 2 * sp;
+    const pitch = p.pitch + (Math.random() - 0.5) * 2 * sp * 0.8 - p.recoilKick * 0.5;
+    const dx = Math.cos(yaw) * Math.cos(pitch);
+    const dy = Math.sin(pitch);
+    const dz = Math.sin(yaw) * Math.cos(pitch);
+    const hit = this.rayTrace(p, dx, dy, dz, def.range);
+    if (hit) {
+      this.applyDamage(p, hit, def);
+    }
+    // AWP 开火后自动关镜
+    if (def.scope && this.playerZoom) {
+      this.playerZoom = false;
+      this.audio.play('zoom');
+    }
+    // 子弹示踪（渲染用）
+    p.emit = { dx, dy, dz };
+  }
+
+  private meleeAttack(p: PlayerEntity): void {
+    p.firingAnim = 1;
+    this.audio.play('knife');
+    let best: PlayerEntity | null = null;
+    let bestD = Infinity;
+    for (const e of this.players) {
+      if (e.team === p.team || !e.alive) continue;
+      const dx = e.x - p.x, dz = e.z - p.z;
+      const d = Math.hypot(dx, dz);
+      if (d > 1.9) continue;
+      const ang = Math.atan2(dz, dx) - p.yaw;
+      const a = Math.atan2(Math.sin(ang), Math.cos(ang));
+      if (Math.abs(a) > 1.1) continue;
+      if (d < bestD) { bestD = d; best = e; }
+    }
+    if (best) {
+      const dmg = 55;
+      this.dealDamage(p, best, dmg, 'chest', false);
+    }
+  }
+
+  /** 射线检测：返回命中的敌人与部位 */
+  private rayTrace(attacker: PlayerEntity, dx: number, dy: number, dz: number, range: number): { target: PlayerEntity; zone: string; mult: number } | null {
+    const ox = attacker.x, oy = EYE_HEIGHT, oz = attacker.z;
+    // 最近墙体
+    const wallT = this.rayWallDistance(ox, oz, dx, dz, range);
+    let best: { target: PlayerEntity; zone: string; mult: number; t: number } | null = null;
+    for (const e of this.players) {
+      if (e.team === attacker.team || !e.alive) continue;
+      const ex = e.x - ox, ez = e.z - oz;
+      const hLen2 = dx * dx + dz * dz;
+      if (hLen2 < 1e-9) continue;
+      let t = (ex * dx + ez * dz) / hLen2;
+      if (t < 0) t = 0;
+      if (t > range || t > wallT) continue;
+      const hx = ox + dx * t - e.x;
+      const hz = oz + dz * t - e.z;
+      const hDist = Math.hypot(hx, hz);
+      if (hDist > 0.42) continue;
+      const py = oy + dy * t;
+      if (py < 0.05 || py > 1.85) continue;
+      const zr = PlayerEntity.hitZoneFor(py, hDist);
+      if (!best || t < best.t) best = { target: e, zone: zr.zone, mult: zr.mult, t };
+    }
+    if (!best) return null;
+    return { target: best.target, zone: best.zone, mult: best.mult };
+  }
+
+  private rayWallDistance(ox: number, oz: number, dx: number, dz: number, maxT: number): number {
+    let best = Infinity;
+    for (let i = 0; i < OBSTACLES.length; i++) {
+      const o = OBSTACLES[i];
+      let tMin = 0, tMax = 1;
+      let ok = true;
+      if (Math.abs(dx) < 1e-9) { if (ox < o.x0 || ox > o.x1) ok = false; }
+      else {
+        let t1 = (o.x0 - ox) / dx, t2 = (o.x1 - ox) / dx;
+        if (t1 > t2) { const t = t1; t1 = t2; t2 = t; }
+        tMin = Math.max(tMin, t1); tMax = Math.min(tMax, t2);
+        if (tMin > tMax) ok = false;
+      }
+      if (!ok) continue;
+      if (Math.abs(dz) < 1e-9) { if (oz < o.z0 || oz > o.z1) ok = false; }
+      else {
+        let t1 = (o.z0 - oz) / dz, t2 = (o.z1 - oz) / dz;
+        if (t1 > t2) { const t = t1; t1 = t2; t2 = t; }
+        tMin = Math.max(tMin, t1); tMax = Math.min(tMax, t2);
+        if (tMin > tMax) ok = false;
+      }
+      if (ok && tMin > 0.02 && tMin < best && tMin <= maxT) best = tMin;
+    }
+    return Math.min(best, maxT);
+  }
+
+  private applyDamage(attacker: PlayerEntity, hit: { target: PlayerEntity; zone: string; mult: number }, def: { damage: number; headMult: number; pen: number }): void {
+    const t = hit.target;
+    const zone = hit.zone;
+    const head = zone === 'head';
+    const mult = head ? def.headMult : hit.mult;
+    let dmg = def.damage * mult;
+    const armoredZone = zone !== 'legs';
+    let absorbed = 0;
+    if (armoredZone && t.armor > 0) {
+      absorbed = dmg * (1 - def.pen) * 0.85;
+      dmg -= absorbed;
+      t.armor = Math.max(0, t.armor - absorbed);
+    }
+    this.dealDamage(attacker, t, Math.max(1, Math.round(dmg)), zone, head);
+  }
+
+  private dealDamage(attacker: PlayerEntity, victim: PlayerEntity, dmg: number, zone: string, head: boolean): void {
+    victim.hp -= dmg;
+    victim.hitFlash = 1;
+    victim.lastDamager = attacker.index;
+    victim.lastDamagerT = this.simTime;
+    // 音效反馈
+    if (victim.isPlayer) {
+      this.audio.play(zone === 'head' ? 'headshot' : victim.armor > 0 ? 'armorHit' : 'hit');
+    }
+    if (attacker.isPlayer) {
+      this.audio.play('hit');
+      this.onEvent({ type: 'hit', fatal: victim.hp <= 0, headshot: head });
+    }
+    if (victim.hp <= 0) {
+      victim.hp = 0;
+      victim.alive = false;
+      this.onKill(attacker, victim, attacker.activeWeapon, head);
+    }
+  }
+
+  private onKill(killer: PlayerEntity, victim: PlayerEntity, weapon: WeaponId, head: boolean): void {
+    this.audio.play('kill');
+    if (victim.isPlayer) {
+      this.audio.play('death');
+      this.playerZoom = false;
+    }
+    // 掉落 C4
+    if (victim.hasBomb) {
+      victim.hasBomb = false;
+      this.bombCarrier = -1;
+      this.bombDropped = true;
+      this.bombX = victim.x + (Math.random() - 0.5);
+      this.bombZ = victim.z + (Math.random() - 0.5);
+      this.onEvent({ type: 'bombDropped' });
+      this.audio.play('pickup');
+    }
+    this.onEvent({ type: 'kill', killer: killer.index, victim: victim.index, weapon, headshot: head });
+    // 玩家阵亡 → 切换视角到存活队友
+    if (victim.isPlayer) {
+      this.playerAlive = false;
+      this.assignSpectate();
+    }
+    this.checkRoundEnd();
+  }
+
+  private assignSpectate(): void {
+    const prev = this.players[this.camIndex];
+    if (prev) prev.isPlayer = false;
+    const aliveCT = this.players.filter((p) => p.team === TEAM_CT && p.alive);
+    if (aliveCT.length > 0) {
+      // 优先选择当前 camIndex 的下一个
+      const idxs = aliveCT.map((p) => p.index);
+      let pick = idxs[0];
+      for (const i of idxs) {
+        if (i > this.camIndex) { pick = i; break; }
+      }
+      this.camIndex = pick;
+      this.players[pick].isPlayer = true;
+      this.onEvent({ type: 'playerTakeover', index: pick });
+    }
+  }
+
+  cycleSpectate(): void {
+    if (this.players[0].alive) return;
+    const aliveCT = this.players.filter((p) => p.team === TEAM_CT && p.alive);
+    if (aliveCT.length === 0) return;
+    const idxs = aliveCT.map((p) => p.index);
+    const cur = idxs.indexOf(this.camIndex);
+    this.players[this.camIndex].isPlayer = false;
+    this.camIndex = idxs[(cur + 1) % idxs.length];
+    this.players[this.camIndex].isPlayer = true;
+    this.onEvent({ type: 'playerTakeover', index: this.camIndex });
+  }
+
+  // ---------------- 互动：安放 / 拆除 / 捡包 ----------------
+  /** 发起互动（每帧按住时调用；进度累积在 updateActions） */
+  tryInteract(p: PlayerEntity): void {
+    // 捡包（T）
+    if (!p.hasBomb && p.team === TEAM_T && this.bombDropped && !this.bombPlanted) {
+      const d = Math.hypot(p.x - this.bombX, p.z - this.bombZ);
+      if (d < 1.0) {
+        p.hasBomb = true;
+        this.bombCarrier = p.index;
+        this.bombDropped = false;
+        this.audio.play('pickup');
+        this.onEvent({ type: 'bombPicked' });
+        return;
+      }
+    }
+    // 下包（T）
+    if (p.hasBomb && !this.bombPlanted && this.phase === 'live') {
+      const site = isInSite(p.x, p.z);
+      if (site && this.plantingEntity === -1) {
+        this.plantingEntity = p.index;
+        this.plantProgress = 0;
+        return;
+      }
+    }
+    // 拆包（CT）
+    if (p.team === TEAM_CT && this.bombPlanted && this.defusingEntity === -1) {
+      const d = Math.hypot(p.x - this.bombX, p.z - this.bombZ);
+      if (d < 1.3) {
+        this.defusingEntity = p.index;
+        this.defuseProgress = 0;
+      }
+    }
+  }
+
+  /** 安放 / 拆除进度累积（dt 驱动） */
+  private updateActions(dt: number): void {
+    // 安放
+    if (this.plantingEntity >= 0) {
+      const p = this.players[this.plantingEntity];
+      const holding = p.isPlayer ? this.input.interact : p.aiInteractLock > 0;
+      const valid = p.alive && p.hasBomb && !this.bombPlanted && this.phase === 'live'
+        && !!isInSite(p.x, p.z) && holding;
+      if (!valid) {
+        this.plantingEntity = -1;
+        this.plantProgress = 0;
+      } else {
+        this.plantProgress += dt / PLANT_TIME;
+        if (this.plantProgress >= 1) {
+          this.plantingEntity = -1;
+          this.plantProgress = 0;
+          p.hasBomb = false;
+          this.bombPlanted = true;
+          this.bombCarrier = -1;
+          this.bombX = p.x; this.bombZ = p.z;
+          this.bombTime = BOMB_FUSE;
+          this.audio.play('plant');
+          this.onEvent({ type: 'plant' });
+        }
+      }
+    }
+    // 拆除
+    if (this.defusingEntity >= 0) {
+      const p = this.players[this.defusingEntity];
+      const holding = p.isPlayer ? this.input.interact : p.aiInteractLock > 0;
+      const d = Math.hypot(p.x - this.bombX, p.z - this.bombZ);
+      const valid = p.alive && p.team === TEAM_CT && this.bombPlanted && d < 1.3 && holding;
+      if (!valid) {
+        this.defusingEntity = -1;
+        this.defuseProgress = 0;
+      } else {
+        this.defuseProgress += dt / DEFUSE_TIME;
+        if (this.defuseProgress >= 1) {
+          this.defusingEntity = -1;
+          this.defuseProgress = 0;
+          this.bombPlanted = false;
+          this.audio.play('defuse');
+          this.onEvent({ type: 'defuse' });
+          this.endRound(TEAM_CT, '成功拆包');
+        }
+      }
+    }
+  }
+
+  private updateBomb(dt: number): void {
+    // 玩家自动捡包
+    const cam = this.players[this.camIndex];
+    if (cam.alive && !cam.hasBomb && cam.team === TEAM_T && this.bombDropped && !this.bombPlanted) {
+      const d = Math.hypot(cam.x - this.bombX, cam.z - this.bombZ);
+      if (d < 0.7) {
+        cam.hasBomb = true;
+        this.bombCarrier = cam.index;
+        this.bombDropped = false;
+        this.audio.play('pickup');
+        this.onEvent({ type: 'bombPicked' });
+      }
+    }
+    if (!this.bombPlanted) return;
+    this.bombTime -= dt;
+    // 倒计时提示音（越来越快）
+    this.beepTimer -= dt;
+    const interval = Math.max(0.15, this.bombTime / 12);
+    if (this.beepTimer <= 0 && this.bombTime > 0) {
+      this.beepTimer = interval;
+      this.audio.play('beep');
+    }
+    if (this.bombTime <= 0) {
+      this.bombTime = 0;
+      this.bombPlanted = false;
+      this.audio.play('explode');
+      this.onEvent({ type: 'explode' });
+      // 爆炸伤害：范围内全部死亡
+      for (const p of this.players) {
+        if (!p.alive) continue;
+        const d = Math.hypot(p.x - this.bombX, p.z - this.bombZ);
+        if (d < 16) {
+          p.hp = 0;
+          p.alive = false;
+          if (p.isPlayer) {
+            this.playerAlive = false;
+            this.assignSpectate();
+          }
+        }
+      }
+      this.endRound(TEAM_T, '炸弹爆炸');
+    }
+  }
+
+  /** 开镜切换（玩家） */
+  setZoom(on: boolean): void {
+    const cam = this.players[this.camIndex];
+    if (!cam.alive) return;
+    const def = WEAPONS[cam.activeWeapon];
+    if (!def.scope) return;
+    if (this.playerZoom !== on) this.audio.play('zoom');
+    this.playerZoom = on;
+  }
+
+  // ---------------- 视野（小地图） ----------------
+  private updateVision(): void {
+    for (const p of this.players) {
+      if (!p.alive) continue;
+      for (const e of this.players) {
+        if (e.team === p.team || !e.alive) continue;
+        const d = Math.hypot(e.x - p.x, e.z - p.z);
+        if (d > 45) continue;
+        if (!PlayerEntity.lineBlocked(p.x, p.z, e.x, e.z)) {
+          this.seenByTeam.add(e.index);
+        }
+      }
+    }
+  }
+
+  // 供 AI 使用的视野查询
+  canSee(from: PlayerEntity, target: PlayerEntity, maxDist = 45): boolean {
+    if (!target.alive) return false;
+    const dx = target.x - from.x, dz = target.z - from.z;
+    const d = Math.hypot(dx, dz);
+    if (d > maxDist || d < 0.01) return false;
+    if (PlayerEntity.lineBlocked(from.x, from.z, target.x, target.z)) return false;
+    return true;
+  }
+
+  // ---------------- 快照 ----------------
+  buildSnapshot(): HudState {
+    const cam = this.players[this.camIndex];
+    const minData: MinimapData = {
+      self: { x: cam.x, z: cam.z, yaw: cam.yaw, alive: cam.alive },
+      allies: [],
+      enemies: [],
+      bomb: this.bombPlanted
+        ? { x: this.bombX, z: this.bombZ, state: 'planted' }
+        : this.bombDropped
+          ? { x: this.bombX, z: this.bombZ, state: 'dropped' }
+          : this.bombCarrier >= 0
+            ? { x: this.players[this.bombCarrier].x, z: this.players[this.bombCarrier].z, state: 'carried' }
+            : null,
+    };
+    for (const p of this.players) {
+      if (p.index === this.camIndex) continue;
+      if (p.team === cam.team) {
+        minData.allies.push({ x: p.x, z: p.z, alive: p.alive });
+      } else if (p.alive && this.seenByTeam.has(p.index)) {
+        minData.enemies.push({ x: p.x, z: p.z, alive: true });
+      }
+    }
+    const actionLabel =
+      this.plantingEntity >= 0 ? '正在安放炸弹...' :
+      this.defusingEntity >= 0 ? '正在拆除炸弹...' : '';
+    return {
+      phase: this.phase,
+      roundNum: this.roundNum,
+      roundTime: Math.max(0, Math.ceil(this.roundTime)),
+      roundTimeMax: ROUND_TIME,
+      freezeTime: this.phase === 'freeze' ? Math.max(0, Math.ceil(this.phaseT)) : 0,
+      scoreCT: this.scoreCT,
+      scoreT: this.scoreT,
+      lastRoundWinner: this.lastWinner,
+      lastRoundReason: this.lastReason,
+      camIndex: this.camIndex,
+      spectating: this.camIndex !== 0 || !this.playerAlive,
+      aliveCT: this.players.filter((p) => p.team === TEAM_CT && p.alive).length,
+      aliveT: this.players.filter((p) => p.team === TEAM_T && p.alive).length,
+      playerAlive: this.playerAlive,
+      hp: Math.max(0, Math.round(cam.hp)),
+      armor: Math.round(cam.armor),
+      slot: cam.activeSlot,
+      weapons: cam.weaponList().map((w) => ({ id: w, name: WEAPONS[w].name, slot: WEAPONS[w].slot })),
+      ammoMag: Math.min(cam.mag, WEAPONS[cam.activeWeapon].magSize),
+      ammoReserve: cam.reserve,
+      reloading: cam.reloading,
+      spread: cam.spread,
+      zooming: this.playerZoom && cam.alive && WEAPONS[cam.activeWeapon].scope,
+      hasBomb: cam.hasBomb,
+      bombPlanted: this.bombPlanted,
+      bombTime: Math.max(0, Math.ceil(this.bombTime)),
+      plantProgress: this.plantingEntity === cam.index ? this.plantProgress : -1,
+      defuseProgress: this.defusingEntity === cam.index ? this.defuseProgress : -1,
+      actionLabel,
+      weaponName: WEAPONS[cam.activeWeapon].name,
+      killfeed: [],
+      hitmark: 0,
+      damageFlash: 0,
+      minimap: minData,
+    };
+  }
+}

--- a/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/game/entity.ts
+++ b/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/game/entity.ts
@@ -1,0 +1,274 @@
+// 玩家实体：物理、碰撞、武器状态、受击判定
+
+import { WEAPONS } from './weapons';
+import { OBSTACLES, WORLD_MIN_X, WORLD_MAX_X, WORLD_MIN_Z, WORLD_MAX_Z } from './map';
+import {
+  PLAYER_RADIUS, GRAVITY, JUMP_SPEED,
+  RUN_SPEED, EYE_HEIGHT,
+  type Team, type WeaponId, type Slot, type WeaponDef,
+} from './types';
+
+export interface HitZoneResult {
+  zone: string;
+  mult: number;
+}
+
+export class PlayerEntity {
+  index = 0;
+  team: Team = 0;
+  x = 0; z = 0; y = 0;
+  vx = 0; vy = 0; vz = 0;
+  yaw = 0; pitch = 0;
+  onGround = true;
+
+  alive = true;
+  hp = 100;
+  armor = 0;
+  isPlayer = false; // 玩家本人（含接管模式）
+
+  weapons: WeaponId[] = [];
+  activeSlot: Slot = 'secondary';
+  activeWeapon: WeaponId = 'glock';
+  mag = 0;
+  reserve = 0;
+  reloading = false;
+  reloadT = 0;
+  fireCooldown = 0;
+  spread = 0;
+  recoilKick = 0; // 视角上扬（玩家输入用）
+  switchT = 0;
+
+  hasBomb = false;
+
+  // 动画
+  walkPhase = 0;
+  moveAmount = 0;
+  firingAnim = 0; // 开火后坐动画（渲染用）
+
+  // AI
+  aiMode = false;
+  aiThink = 0;
+
+  // 受击闪红
+  hitFlash = 0;
+
+  // 最近伤害来源（AI 反击目标选择）
+  lastDamager = -1;
+  lastDamagerT = 0;
+
+  // AI 驱动（本地移动输入 + 意图）
+  aiMoveX = 0;
+  aiMoveZ = 0;
+  aiFire = false;
+  aiInteract = false;
+  aiInteractLock = 0; // 互动意图保持（思考节流之间不丢失）
+  aiGoal = { x: 0, z: 0 };
+  aiState = 'idle';
+
+  // 子弹示踪（渲染用）
+  emit: { dx: number; dy: number; dz: number } | null = null;
+
+  constructor(index: number, team: Team) {
+    this.index = index;
+    this.team = team;
+  }
+
+  setupLoadout(pistolRound: boolean): void {
+    const ids = pistolRound
+      ? (this.team === 1 ? ['glock', 'knife'] : ['usp', 'knife'])
+      : (this.team === 1 ? ['ak47', 'glock', 'knife'] : ['m4a4', 'usp', 'knife']);
+    this.weapons = ids as WeaponId[];
+    this.armor = pistolRound ? 0 : 100;
+    this.hp = 100;
+    this.switchWeapon('secondary');
+    if (this.activeWeapon === 'knife') this.switchWeapon('melee');
+  }
+
+  /** 获取当前可用武器列表（保持 slot 顺序） */
+  weaponList(): WeaponId[] {
+    return this.weapons;
+  }
+
+  hasWeapon(id: WeaponId): boolean {
+    return this.weapons.includes(id);
+  }
+
+  currentDef(): WeaponDef {
+    return WEAPONS[this.activeWeapon];
+  }
+
+  switchWeapon(slot: Slot): void {
+    const def = WEAPONS[this.activeWeapon];
+    this.switchT = def.switchTime;
+    this.reloading = false;
+    this.reloadT = 0;
+    // 选择该槽位武器
+    for (const w of this.weapons) {
+      if (WEAPONS[w].slot === slot) {
+        this.activeWeapon = w;
+        this.activeSlot = slot;
+        this.mag = WEAPONS[w].magSize;
+        this.reserve = WEAPONS[w].reserve;
+        this.spread = 0;
+        this.recoilKick = 0;
+        return;
+      }
+    }
+    // 槽位无武器 → 最近的非空槽
+    for (const w of this.weapons) {
+      this.activeWeapon = w;
+      this.activeSlot = WEAPONS[w].slot;
+      this.mag = WEAPONS[w].magSize;
+      this.reserve = WEAPONS[w].reserve;
+      this.spread = 0;
+      return;
+    }
+  }
+
+  cycleSlot(dir: 1 | -1): void {
+    const order: Slot[] = ['primary', 'secondary', 'melee'];
+    let i = order.indexOf(this.activeSlot);
+    for (let k = 0; k < 3; k++) {
+      i = (i + dir + 3) % 3;
+      const s = order[i];
+      if (this.weapons.some((w) => WEAPONS[w].slot === s)) {
+        this.switchWeapon(s);
+        return;
+      }
+    }
+  }
+
+  startReload(): void {
+    const def = this.currentDef();
+    if (def.slot === 'melee' || this.reloading) return;
+    if (this.mag >= def.magSize || this.reserve <= 0) return;
+    this.reloading = true;
+    this.reloadT = def.reloadTime;
+  }
+
+  updateReload(dt: number): void {
+    if (!this.reloading) return;
+    this.reloadT -= dt;
+    if (this.reloadT <= 0) {
+      const def = this.currentDef();
+      const need = def.magSize - this.mag;
+      const take = Math.min(need, this.reserve);
+      this.mag += take;
+      this.reserve -= take;
+      this.reloading = false;
+    }
+  }
+
+  canFire(): boolean {
+    const def = this.currentDef();
+    if (def.slot === 'melee') return this.fireCooldown <= 0;
+    return !this.reloading && this.mag > 0 && this.fireCooldown <= 0;
+  }
+
+  /**
+   * 物理更新：输入 moveX/moveZ（本地坐标 -1..1），run 是否奔跑
+   * 返回是否移动
+   */
+  updatePhysics(dt: number, moveX: number, moveZ: number, run: boolean, speedMult: number): boolean {
+    const speed = (run ? RUN_SPEED : RUN_SPEED * 0.55) * speedMult;
+    // 世界前向 F = (cos yaw, sin yaw)，右向 R = (-sin yaw, cos yaw)
+    // 世界位移 = F * moveZ + R * moveX
+    const sinY = Math.sin(this.yaw);
+    const cosY = Math.cos(this.yaw);
+    const wx = moveZ * cosY - moveX * sinY;
+    const wz = moveZ * sinY + moveX * cosY;
+    const len = Math.hypot(wx, wz);
+    let tx = this.x, tz = this.z;
+    let moved = false;
+    if (len > 0.01) {
+      const nx = wx / len;
+      const nz = wz / len;
+      // X 轴独立移动 + 碰撞
+      let nx2 = this.x + nx * speed * dt;
+      if (!this.collideXZ(nx2, this.z)) { tx = nx2; moved = true; }
+      let nz2 = this.z + nz * speed * dt;
+      if (!this.collideXZ(this.x, nz2)) { tz = nz2; moved = true; }
+      this.x = tx; this.z = tz;
+    }
+    // 跳跃与重力
+    if (this.vy !== 0 || !this.onGround) {
+      this.vy -= GRAVITY * dt;
+      this.y += this.vy * dt;
+      if (this.y <= 0) { this.y = 0; this.vy = 0; this.onGround = true; }
+      else this.onGround = false;
+    }
+    this.x = Math.min(WORLD_MAX_X - PLAYER_RADIUS, Math.max(WORLD_MIN_X + PLAYER_RADIUS, this.x));
+    this.z = Math.min(WORLD_MAX_Z - PLAYER_RADIUS, Math.max(WORLD_MIN_Z + PLAYER_RADIUS, this.z));
+    this.moveAmount = moved ? 1 : Math.max(0, this.moveAmount - dt * 4);
+    return moved;
+  }
+
+  jump(): void {
+    if (this.onGround) {
+      this.vy = JUMP_SPEED;
+      this.onGround = false;
+    }
+  }
+
+  /** 与所有障碍物碰撞检测（以玩家 AABB 投影） */
+  collideXZ(nx: number, nz: number): boolean {
+    const r = PLAYER_RADIUS;
+    for (let i = 0; i < OBSTACLES.length; i++) {
+      const o = OBSTACLES[i];
+      if (nx + r > o.x0 && nx - r < o.x1 && nz + r > o.z0 && nz - r < o.z1) {
+        return true; // 所有障碍物均阻挡移动
+      }
+    }
+    return false;
+  }
+
+  /** 障碍物是否在给定点阻挡视线（高度无关，2D） */
+  static lineBlocked(ax: number, az: number, bx: number, bz: number): boolean {
+    for (let i = 0; i < OBSTACLES.length; i++) {
+      const o = OBSTACLES[i];
+      if (o.height < 1.0) continue; // 矮箱不挡视线
+      // 快速 AABB-线段检测
+      const dx = bx - ax, dz = bz - az;
+      let tMin = 0, tMax = 1;
+      let ok = true;
+      if (Math.abs(dx) < 1e-9) { if (ax < o.x0 || ax > o.x1) ok = false; }
+      else {
+        let t1 = (o.x0 - ax) / dx, t2 = (o.x1 - ax) / dx;
+        if (t1 > t2) { const t = t1; t1 = t2; t2 = t; }
+        tMin = Math.max(tMin, t1); tMax = Math.min(tMax, t2);
+        if (tMin > tMax) ok = false;
+      }
+      if (!ok) continue;
+      if (Math.abs(dz) < 1e-9) { if (az < o.z0 || az > o.z1) ok = false; }
+      else {
+        let t1 = (o.z0 - az) / dz, t2 = (o.z1 - az) / dz;
+        if (t1 > t2) { const t = t1; t1 = t2; t2 = t; }
+        tMin = Math.max(tMin, t1); tMax = Math.min(tMax, t2);
+        if (tMin > tMax) ok = false;
+      }
+      if (ok && tMin > 0.001 && tMin < 1) return true;
+    }
+    return false;
+  }
+
+  /** 命中区判定：按射线命中高度与横向偏移 */
+  static hitZoneFor(pointY: number, horizontalDist: number): HitZoneResult {
+    if (horizontalDist < 0.24) {
+      if (pointY > 1.42) return { zone: 'head', mult: 2 };
+      if (pointY > 1.05) return { zone: 'chest', mult: 1 };
+      if (pointY > 0.75) return { zone: 'stomach', mult: 1 };
+      return { zone: 'legs', mult: 0.8 };
+    }
+    if (horizontalDist < 0.4) {
+      if (pointY > 0.75) return { zone: 'arm', mult: 1 };
+      return { zone: 'legs', mult: 0.8 };
+    }
+    return { zone: 'legs', mult: 0.8 };
+  }
+
+}
+
+// 给引擎使用的快速命中判定
+export function computeHitZoneAt(pointY: number, hDist: number): HitZoneResult {
+  return PlayerEntity.hitZoneFor(pointY, hDist);
+}

--- a/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/game/game.ts
+++ b/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/game/game.ts
@@ -1,0 +1,252 @@
+// 游戏主类：引擎 + 渲染器 + 输入 + 主循环 + HUD 桥接
+
+import * as THREE from 'three';
+import { GameEngine, type InputState } from './engine';
+import { Renderer } from './render';
+import { SoundManager } from './audio';
+import { WEAPONS } from './weapons';
+import { EYE_HEIGHT, type GameEvent, type HudState, type KillEvent } from './types';
+
+export type KillfeedItem = KillEvent;
+
+export class Game {
+  engine: GameEngine;
+  renderer: Renderer;
+  audio = new SoundManager();
+  private canvas: HTMLCanvasElement;
+  private keys = new Set<string>();
+  private mouseDown = new Set<number>();
+  private raf = 0;
+  private lastT = 0;
+  private time = 0;
+  private locked = false;
+  private started = false;
+  private hudCb: ((s: HudState) => void) | null = null;
+  private snapT = 0;
+  private killfeed: KillfeedItem[] = [];
+  private kfId = 0;
+  private hitmarkT = 0;
+  private damageFlashT = 0;
+  private sens = 0.0021;
+  private scopeFov = 24;
+  private baseFov = 84;
+  private pendingSlot: 'primary' | 'secondary' | 'melee' | null = null;
+
+  constructor(canvas: HTMLCanvasElement) {
+    this.canvas = canvas;
+    this.renderer = new Renderer(canvas);
+    this.engine = new GameEngine(this.audio, (e) => this.handleEvent(e));
+    this.bindInput();
+    const resize = () => {
+      const w = canvas.clientWidth || window.innerWidth;
+      const h = canvas.clientHeight || window.innerHeight;
+      this.renderer.resize(w, h);
+    };
+    resize();
+    window.addEventListener('resize', resize);
+  }
+
+  onHud(cb: (s: HudState) => void): void {
+    this.hudCb = cb;
+  }
+
+  private handleEvent(e: GameEvent): void {
+    switch (e.type) {
+      case 'kill': {
+        const killer = this.engine.players[e.killer];
+        const victim = this.engine.players[e.victim];
+        const item: KillfeedItem = {
+          id: ++this.kfId,
+          time: this.time,
+          killer: e.killer,
+          victim: e.victim,
+          weapon: e.weapon,
+          headshot: e.headshot,
+          killerName: `${killer.team === 1 ? 'T' : 'CT'}-${(e.killer % 5) + 1}`,
+          victimName: `${victim.team === 1 ? 'T' : 'CT'}-${(e.victim % 5) + 1}`,
+          weaponName: WEAPONS[e.weapon].name,
+        };
+        this.killfeed.push(item);
+        if (this.killfeed.length > 8) this.killfeed.shift();
+        break;
+      }
+      case 'hit':
+        if (e.fatal) this.hitmarkT = 0.5;
+        else this.hitmarkT = 0.22;
+        break;
+      case 'roundStart':
+        this.killfeed = [];
+        break;
+      default:
+        break;
+    }
+  }
+
+  // ---------------- 输入 ----------------
+  private bindInput(): void {
+    window.addEventListener('keydown', (ev) => {
+      if (ev.code === 'F2') { this.engine.cycleSpectate(); return; }
+      if (ev.code === 'KeyM') { this.audio.setMuted(!this.audio.muted); return; }
+      this.keys.add(ev.code);
+      if (!this.started || !this.locked) return;
+      switch (ev.code) {
+        case 'KeyR': this.engine.input.reload = true; break;
+        case 'Space': this.engine.input.jump = true; break;
+        case 'KeyE': this.engine.input.interact = true; break;
+        case 'KeyQ': this.engine.input.cycleSlot = -1; break;
+        case 'Digit1': this.pendingSlot = 'primary'; break;
+        case 'Digit2': this.pendingSlot = 'secondary'; break;
+        case 'Digit3': this.pendingSlot = 'melee'; break;
+      }
+    });
+    window.addEventListener('keyup', (ev) => {
+      this.keys.delete(ev.code);
+      if (ev.code === 'Space') this.engine.input.jump = false;
+      if (ev.code === 'KeyE') this.engine.input.interact = false;
+    });
+    this.canvas.addEventListener('mousedown', (ev) => {
+      if (!this.started) return;
+      this.mouseDown.add(ev.button);
+      if (ev.button === 0) this.engine.input.fire = true;
+      if (ev.button === 2) this.engine.setZoom(true);
+    });
+    window.addEventListener('mouseup', (ev) => {
+      this.mouseDown.delete(ev.button);
+      if (ev.button === 0) this.engine.input.fire = false;
+      if (ev.button === 2) this.engine.setZoom(false);
+    });
+    window.addEventListener('mousemove', (ev) => {
+      if (!this.locked) return;
+      const s = this.sens;
+      this.engine.input.mx += ev.movementX * s;
+      this.engine.input.mz += ev.movementY * s;
+    });
+    this.canvas.addEventListener('wheel', (ev) => {
+      if (!this.locked) return;
+      this.engine.input.cycleSlot = ev.deltaY > 0 ? 1 : -1;
+    });
+    this.canvas.addEventListener('contextmenu', (ev) => ev.preventDefault());
+    window.addEventListener('pointerlockchange', () => {
+      this.locked = document.pointerLockElement === this.canvas;
+      if (!this.locked) {
+        this.engine.input.fire = false;
+        this.engine.input.zoom = false;
+        this.mouseDown.clear();
+      }
+    });
+  }
+
+  requestStart(): void {
+    this.audio.ensure();
+    this.started = true;
+    this.canvas.requestPointerLock();
+  }
+
+  private updateInput(): void {
+    const inp = this.engine.input as InputState;
+    const has = (code: string) => this.keys.has(code);
+    const up = has('KeyW') || has('ArrowUp');
+    const down = has('KeyS') || has('ArrowDown');
+    const left = has('KeyA') || has('ArrowLeft');
+    const right = has('KeyD') || has('ArrowRight');
+    inp.moveX = (right ? 1 : 0) - (left ? 1 : 0);
+    inp.moveZ = (up ? 1 : 0) - (down ? 1 : 0);
+    inp.run = !has('ShiftLeft') && !has('ShiftRight');
+    if (this.pendingSlot) {
+      inp.slotSelect = this.pendingSlot;
+      this.pendingSlot = null;
+    }
+  }
+
+  // ---------------- 主循环 ----------------
+  start(): void {
+    this.lastT = performance.now();
+    const loop = (now: number) => {
+      this.raf = requestAnimationFrame(loop);
+      let dt = (now - this.lastT) / 1000;
+      this.lastT = now;
+      if (dt > 0.05) dt = 0.05;
+      this.time += dt;
+      this.update(dt);
+    };
+    this.raf = requestAnimationFrame(loop);
+  }
+
+  private update(dt: number): void {
+    this.updateInput();
+    // 开始界面或指针解锁（暂停）时不推进模拟，仅渲染
+    const paused = !this.started || !this.locked;
+    if (!paused) this.engine.update(dt);
+
+    const cam = this.engine.players[this.engine.camIndex];
+    const r = this.renderer;
+    const camera = r.camera;
+
+    // 相机同步（世界前向 F=(cos yaw, sin yaw)，映射到 three 相机前向 -Z）
+    camera.position.set(cam.x, EYE_HEIGHT, cam.z);
+    camera.rotation.order = 'YXZ';
+    camera.rotation.y = -(cam.yaw + Math.PI / 2);
+    const kick = cam.recoilKick * 0.55;
+    camera.rotation.x = cam.pitch + kick;
+
+    // 开镜
+    const zooming = this.engine.playerZoom && WEAPONS[cam.activeWeapon].scope;
+    const targetFov = zooming ? this.scopeFov : this.baseFov;
+    camera.fov += (targetFov - camera.fov) * Math.min(1, dt * 12);
+    camera.updateProjectionMatrix();
+
+    // 角色同步
+    for (const p of this.engine.players) {
+      const m = r.modelFor(p.index, p.team);
+      r.syncEntity(p, m, dt, this.time);
+      // 示踪
+      if (p.emit) {
+        const e = p.emit;
+        r.spawnTracer(p.x, EYE_HEIGHT, p.z, e.dx, e.dy, e.dz, 90);
+        p.emit = null;
+      }
+    }
+
+    // 炸弹
+    r.syncBomb(
+      this.engine.bombPlanted,
+      this.engine.bombDropped,
+      this.engine.bombX,
+      this.engine.bombZ,
+      this.time,
+      this.engine.bombTime,
+    );
+
+    // 第一人称武器
+    const firing = cam.firingAnim > 0.4;
+    const reloading = cam.reloading;
+    r.setViewWeapon(cam.activeWeapon);
+    r.update(dt, this.time, firing, kick, reloading, zooming);
+
+    // 受击红色覆盖
+    if (cam.hitFlash > 0.5) this.damageFlashT = 0.25;
+    this.damageFlashT = Math.max(0, this.damageFlashT - dt);
+    this.hitmarkT = Math.max(0, this.hitmarkT - dt);
+
+    r.render();
+
+    // HUD 快照（10Hz）
+    this.snapT -= dt;
+    if (this.snapT <= 0) {
+      this.snapT = 0.1;
+      if (this.hudCb) {
+        const snap = this.engine.buildSnapshot();
+        snap.killfeed = this.killfeed.map((i) => ({ ...i }));
+        this.hudCb({ ...snap, hitmark: this.hitmarkT, damageFlash: this.damageFlashT });
+      }
+    }
+  }
+
+  reset(): void {
+    this.engine.resetGame();
+  }
+
+  destroy(): void {
+    cancelAnimationFrame(this.raf);
+  }
+}

--- a/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/game/map.ts
+++ b/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/game/map.ts
@@ -1,0 +1,331 @@
+// Dust2 风格地图数据：墙体 AABB、箱子、出生点、炸弹点、寻路节点
+// 坐标系：x 向东，z 向南，y 向上；地面 y=0；墙高 2.6m
+
+export interface Rect {
+  x0: number;
+  x1: number;
+  z0: number;
+  z1: number;
+}
+
+export interface WallDef extends Rect {
+  height: number;
+  color: number; // 0xrrggbb
+}
+
+export interface BoxDef extends Rect {
+  height: number; // 箱子高度（多层箱 = 更高）
+  color: number;
+  stack: number; // 1 = 单层 2 = 双层
+}
+
+export const WORLD_MIN_X = -33;
+export const WORLD_MAX_X = 33;
+export const WORLD_MIN_Z = -37;
+export const WORLD_MAX_Z = 37;
+
+const H = 2.6;
+const WALL: number = 0xb8a884;
+const WALL_D: number = 0xa8956f;
+const BOX: number = 0x8a7a5c;
+const BOX2: number = 0x6e6148;
+
+// ---------- 墙体（AABB，实心） ----------
+export const WALLS: WallDef[] = [
+  // 外围
+  { x0: -33, x1: 33, z0: -38, z1: -36.8, height: H, color: WALL },
+  { x0: -33, x1: 33, z0: 36.8, z1: 38, height: H, color: WALL },
+  { x0: -34.2, x1: -33, z0: -38, z1: 38, height: H, color: WALL },
+  { x0: 33, x1: 34.2, z0: -38, z1: 38, height: H, color: WALL },
+
+  // A 长（A 大）北墙：与 A 点 / T 出生点之间的分隔（含两个门洞：x[-31,-29] 与 x[-15,-13]）
+  { x0: -32, x1: -31, z0: 4.6, z1: 5.4, height: H, color: WALL },
+  { x0: -29, x1: -15, z0: 4.6, z1: 5.4, height: H, color: WALL },
+  { x0: -13, x1: -8, z0: 4.6, z1: 5.4, height: H, color: WALL },
+  // A 长与 T 区之间的墙（门洞 x[25.5,27.5]）
+  { x0: 8, x1: 25.5, z0: 16.4, z1: 17.2, height: H, color: WALL },
+  { x0: 27.5, x1: 34, z0: 16.4, z1: 17.2, height: H, color: WALL },
+  // A 长东端墙
+  { x0: 27.2, x1: 28, z0: 6.2, z1: 16.4, height: H, color: WALL },
+  // A 长南侧边界（走廊边缘）
+  { x0: -33, x1: -32, z0: 6.2, z1: 15.6, height: H, color: WALL },
+  { x0: 28, x1: 33, z0: 6.2, z1: 15.6, height: H, color: WALL },
+  // A 长转角墙体（汽车位）
+  { x0: -26, x1: -24, z0: 6.2, z1: 9, height: H, color: WALL_D },
+
+  // 中门（mid）北墙：中门门体，两扇薄门 + 中间可穿过的门缝
+  { x0: 4, x1: 6.4, z0: -18.8, z1: -18, height: H, color: WALL_D },
+  { x0: 9.6, x1: 12, z0: -18.8, z1: -18, height: H, color: WALL_D },
+  // 中门东侧到 B 洞的墙（开口 z[-12,-6] = 中门↔B洞 门洞）
+  { x0: 12.4, x1: 14, z0: -20, z1: -12, height: H, color: WALL },
+  { x0: 12.4, x1: 14, z0: -6, z1: 5, height: H, color: WALL },
+  // 中门与 A 长之间的墙（门洞 x[-4.5,-2.5] = A 短入口）
+  { x0: -6, x1: -4.5, z0: 10.4, z1: 11.2, height: H, color: WALL },
+  { x0: -2.5, x1: 12, z0: 10.4, z1: 11.2, height: H, color: WALL },
+  // 中门西侧与 A 点东侧的墙（门洞 z[-15.2,-13.8]）
+  { x0: -6.4, x1: -5.6, z0: -18, z1: -15.2, height: H, color: WALL },
+  { x0: -6.4, x1: -5.6, z0: -13.8, z1: 12, height: H, color: WALL },
+
+  // 猫道：北墙 + 西段南墙（东段俯瞰 A 点 / 中门）
+  { x0: -32, x1: -4, z0: -26.8, z1: -26, height: H, color: WALL_D },
+  { x0: -32, x1: -15, z0: -19.6, z1: -18.8, height: H, color: WALL_D },
+  // 猫道东端墙（与 CT 区通道之间的入口）
+  { x0: -4.8, x1: -4, z0: -26, z1: -24.4, height: H, color: WALL_D },
+  { x0: -4.8, x1: -4, z0: -21.2, z1: -18.8, height: H, color: WALL_D },
+
+  // A 点北墙（门洞 x[-14,-12] 通往猫道）
+  { x0: -32, x1: -14, z0: -17.4, z1: -16.6, height: H, color: WALL },
+  { x0: -12, x1: -8, z0: -17.4, z1: -16.6, height: H, color: WALL },
+
+  // CT 出生区南墙（门洞 x[6.4,9.6] = 中门北口）
+  { x0: -32, x1: 6.4, z0: -29.6, z1: -28.8, height: H, color: WALL },
+  { x0: 9.6, x1: 12, z0: -29.6, z1: -28.8, height: H, color: WALL },
+  // CT 出生区东墙
+  { x0: 11.2, x1: 12, z0: -38, z1: -29.6, height: H, color: WALL },
+
+  // B 点西墙 / B 点南墙（B 洞洞口 x[18,26]）
+  { x0: 11.2, x1: 12, z0: -38, z1: -20, height: H, color: WALL },
+  { x0: 12, x1: 18, z0: -20.4, z1: -19.6, height: H, color: WALL },
+  { x0: 26, x1: 33, z0: -20.4, z1: -19.6, height: H, color: WALL },
+
+  // T 区北墙（B 洞南口 x[15,29]）
+  { x0: 8, x1: 15, z0: 17.2, z1: 18, height: H, color: WALL },
+  { x0: 29, x1: 34, z0: 17.2, z1: 18, height: H, color: WALL },
+];
+
+// ---------- 箱子 / 掩体 ----------
+export const BOXES: BoxDef[] = [
+  // A 点
+  { x0: -16, x1: -12, z0: -12, z1: -8, height: 1.4, color: BOX2, stack: 2 },
+  { x0: -22, x1: -18, z0: 0, z1: 3, height: 0.7, color: BOX, stack: 1 },
+  { x0: -30, x1: -26, z0: -5, z1: -2, height: 1.1, color: BOX2, stack: 1 },
+  { x0: -12, x1: -9, z0: -16.4, z1: -13, height: 0.9, color: BOX, stack: 1 },
+  { x0: -28, x1: -26, z0: -14, z1: -12, height: 0.7, color: BOX, stack: 1 },
+  { x0: -15, x1: -13.5, z0: -6.5, z1: -5, height: 0.7, color: BOX, stack: 1 },
+  // A 长
+  { x0: -20, x1: -16, z0: 9, z1: 11, height: 0.9, color: BOX, stack: 1 },
+  { x0: 20, x1: 24, z0: 9, z1: 12, height: 1.1, color: BOX2, stack: 1 },
+  { x0: 4, x1: 7, z0: 8, z1: 10, height: 0.7, color: BOX, stack: 1 },
+  // 中门
+  { x0: 0, x1: 3, z0: -8, z1: -5, height: 1.1, color: BOX2, stack: 1 },
+  { x0: 6, x1: 9, z0: 2, z1: 4.5, height: 0.9, color: BOX, stack: 1 },
+  // B 洞
+  { x0: 18, x1: 20, z0: 6, z1: 10, height: 0.9, color: BOX, stack: 1 },
+  { x0: 22, x1: 26, z0: -4, z1: -1, height: 1.1, color: BOX2, stack: 1 },
+  // B 点
+  { x0: 20, x1: 24, z0: -32, z1: -28, height: 1.4, color: BOX2, stack: 2 },
+  { x0: 26, x1: 29, z0: -26, z1: -23, height: 0.9, color: BOX, stack: 1 },
+  { x0: 14, x1: 17, z0: -36, z1: -33, height: 1.1, color: BOX2, stack: 1 },
+  { x0: 27, x1: 30, z0: -34, z1: -31, height: 0.7, color: BOX, stack: 1 },
+  // T 区
+  { x0: 22, x1: 26, z0: 26, z1: 30, height: 1.1, color: BOX2, stack: 1 },
+  { x0: 28, x1: 32, z0: 30, z1: 33, height: 0.9, color: BOX, stack: 1 },
+  // CT 区
+  { x0: -24, x1: -21, z0: -34, z1: -31, height: 0.9, color: BOX, stack: 1 },
+  { x0: -14, x1: -11, z0: -36, z1: -33, height: 1.1, color: BOX2, stack: 1 },
+  // 猫道
+  { x0: -24, x1: -22, z0: -24.5, z1: -21.5, height: 0.9, color: BOX, stack: 1 },
+  { x0: -10, x1: -8, z0: -25, z1: -22, height: 0.7, color: BOX, stack: 1 },
+];
+
+// ---------- 炸弹点 ----------
+export interface SiteDef {
+  name: string;
+  x: number;
+  z: number;
+  radius: number; // 可下包半径
+}
+
+export const SITES: SiteDef[] = [
+  { name: 'A', x: -21, z: -6, radius: 11 },
+  { name: 'B', x: 24, z: -24, radius: 10 },
+];
+
+// ---------- 出生点 ----------
+export const T_SPAWNS: { x: number; z: number; yaw: number }[] = [
+  { x: 14, z: 34, yaw: -Math.PI / 2 }, // 面朝北（-z）
+  { x: 20, z: 36, yaw: -Math.PI / 2 },
+  { x: 26, z: 34, yaw: -Math.PI / 2 },
+  { x: 31, z: 22, yaw: -Math.PI / 2 },
+  { x: 16, z: 20, yaw: -Math.PI / 2 },
+];
+
+export const CT_SPAWNS: { x: number; z: number; yaw: number }[] = [
+  { x: -29, z: -34, yaw: Math.PI / 2 },
+  { x: -25, z: -33.5, yaw: Math.PI / 2 },
+  { x: -20, z: -32, yaw: Math.PI / 2 },
+  { x: -27, z: -31, yaw: Math.PI / 2 },
+  { x: -9, z: -34.5, yaw: Math.PI / 2 },
+];
+
+// ---------- 寻路节点（waypoint 图，每个节点均位于可行走空地） ----------
+export interface NavNode {
+  id: number;
+  x: number;
+  z: number;
+  name: string;
+}
+
+export const NAV: NavNode[] = [
+  { id: 0, x: 16, z: 34, name: 't-spawn1' },
+  { id: 1, x: 26, z: 34, name: 't-spawn2' },
+  { id: 2, x: 24, z: 20, name: 't-north' },
+  { id: 3, x: 28, z: 28, name: 't-east' },
+  { id: 4, x: 22, z: 14, name: 'bt-south' },
+  { id: 5, x: 22, z: -8, name: 'bt-mid' },
+  { id: 6, x: 22, z: -16, name: 'bt-north' },
+  { id: 7, x: 27, z: 4, name: 'bt-east' },
+  { id: 8, x: 18, z: -16, name: 'bt-west' },
+  { id: 9, x: 21, z: -25, name: 'b-site' },
+  { id: 10, x: 13, z: -30, name: 'b-west' },
+  { id: 11, x: 29, z: -28, name: 'b-east' },
+  { id: 12, x: 26, z: 12, name: 'long-east' },
+  { id: 13, x: 14, z: 10, name: 'long-mid' },
+  { id: 14, x: 2, z: 12.5, name: 'long-junc' },
+  { id: 15, x: -18, z: 13, name: 'long-car' },
+  { id: 16, x: -28, z: 12, name: 'long-door' },
+  { id: 17, x: -13.5, z: 6.5, name: 'long-pit' },
+  { id: 18, x: 8, z: 0, name: 'mid-east' },
+  { id: 19, x: 4, z: -8, name: 'mid-center' },
+  { id: 20, x: -2, z: -14, name: 'mid-west' },
+  { id: 21, x: 8, z: -14, name: 'mid-door' },
+  { id: 22, x: -3, z: 4, name: 'mid-south' },
+  { id: 23, x: -8, z: -21, name: 'cat-east' },
+  { id: 24, x: -18, z: -20.5, name: 'cat-mid' },
+  { id: 25, x: -28, z: -20.5, name: 'cat-west' },
+  { id: 26, x: -6, z: -24, name: 'ct-alley' },
+  { id: 27, x: 8, z: -26, name: 'doors-north' },
+  { id: 28, x: -13, z: -16, name: 'a-north' },
+  { id: 29, x: -20, z: -6, name: 'a-site' },
+  { id: 30, x: -28, z: -9, name: 'a-west' },
+  { id: 31, x: -11, z: -3, name: 'a-east' },
+  { id: 32, x: -24, z: -30.2, name: 'ct-spawn1' },
+  { id: 33, x: -15, z: -30.2, name: 'ct-spawn2' },
+  { id: 34, x: -6, z: -33, name: 'ct-east' },
+  { id: 35, x: -30, z: -30.2, name: 'ct-west' },
+  // 门洞 / 绕行节点
+  { id: 39, x: 13.2, z: -9, name: 'bt-mid-door' },
+  { id: 40, x: -4.4, z: -23, name: 'cat-door' },
+  { id: 41, x: -13, z: -17.6, name: 'a-north-door' },
+  { id: 42, x: -14, z: 4.2, name: 'a-long-door1' },
+  { id: 43, x: -30, z: 4.2, name: 'a-long-door2' },
+  { id: 45, x: 26.5, z: 17.6, name: 't-long-door' },
+  { id: 46, x: -7, z: -14.5, name: 'mid-a-door' },
+  { id: 47, x: 8, z: -30, name: 'ct-mid-door' },
+  { id: 48, x: 18, z: 14.8, name: 'long-north' },
+  { id: 49, x: -11, z: -31.5, name: 'ct-plaza' },
+  { id: 51, x: 25, z: 14, name: 'bt-north' },
+  { id: 53, x: 28, z: -5, name: 'bt-east2' },
+  { id: 38, x: -3.5, z: 10.8, name: 'a-short-door' },
+  { id: 55, x: 8, z: 12, name: 'long-south' },
+  { id: 56, x: -14.5, z: 12, name: 'car-north' },
+  { id: 58, x: -3.5, z: 12, name: 'a-short-north' },
+];
+
+/** id → 节点 快速查找（id 不连续） */
+export const NAV_BY_ID: Map<number, NavNode> = new Map(NAV.map((n) => [n.id, n]));
+
+/** 按 id 取节点（AI 寻路用） */
+export function navNode(id: number): NavNode {
+  return NAV_BY_ID.get(id) ?? NAV[0];
+}
+
+// 邻接表（边，均经过通行性校验：线段不与墙体/高箱相交）
+export const NAV_EDGES: [number, number][] = [
+  // T 出生区
+  [0, 1], [0, 2], [1, 3], [2, 3], [2, 45], [3, 45], [3, 12],
+  // B 洞
+  [4, 51], [51, 7], [51, 12], [7, 12], [7, 53], [53, 5], [53, 12],
+  [12, 48], [48, 13], [5, 8], [8, 18], [5, 6], [6, 8], [6, 9], [8, 39],
+  [39, 5], [39, 18],
+  // B 点
+  [9, 10], [9, 11], [10, 6],
+  // A 长
+  [13, 48], [48, 12], [48, 55], [55, 58], [58, 14], [14, 15],
+  [15, 16], [16, 15], [17, 56], [56, 15], [56, 16], [17, 42],
+  [42, 29], [42, 31], [16, 43], [43, 29],
+  // 中门
+  [18, 19], [19, 20], [20, 21], [21, 19], [18, 22], [20, 22],
+  [22, 38], [38, 58], [20, 46],
+  [46, 42], [46, 31],
+  // 猫道 / CT 通道
+  [23, 24], [24, 25], [23, 26], [26, 40], [40, 23], [40, 27],
+  // A 点
+  [29, 30], [29, 31], [30, 28], [28, 41], [41, 23],
+  // 中门北口 → CT 区
+  [21, 27], [27, 47], [47, 49], [49, 34], [49, 33], [33, 32], [32, 35], [33, 35],
+];
+
+// ---------- 障碍物汇总（碰撞用） ----------
+export interface Obstacle extends Rect {
+  height: number;
+}
+
+export const OBSTACLES: Obstacle[] = [
+  ...WALLS.map((w) => ({ x0: w.x0, x1: w.x1, z0: w.z0, z1: w.z1, height: w.height })),
+  ...BOXES.map((b) => ({ x0: b.x0, x1: b.x1, z0: b.z0, z1: b.z1, height: b.height })),
+];
+
+export function isInSite(x: number, z: number): SiteDef | null {
+  for (const s of SITES) {
+    const dx = x - s.x;
+    const dz = z - s.z;
+    if (dx * dx + dz * dz <= s.radius * s.radius) return s;
+  }
+  return null;
+}
+
+// 2D 线段与 AABB 相交（视野 / 射线检测）
+export function segmentHitsObstacle(ax: number, az: number, bx: number, bz: number): boolean {
+  const dx = bx - ax;
+  const dz = bz - az;
+  const lenSq = dx * dx + dz * dz;
+  for (let i = 0; i < OBSTACLES.length; i++) {
+    const o = OBSTACLES[i];
+    const ex0 = o.x0, ex1 = o.x1, ez0 = o.z0, ez1 = o.z1;
+    // slab 方法
+    let tMin = 0, tMax = 1;
+    if (Math.abs(dx) < 1e-9) {
+      if (ax < ex0 || ax > ex1) continue;
+    } else {
+      let t1 = (ex0 - ax) / dx;
+      let t2 = (ex1 - ax) / dx;
+      if (t1 > t2) { const t = t1; t1 = t2; t2 = t; }
+      tMin = Math.max(tMin, t1);
+      tMax = Math.min(tMax, t2);
+      if (tMin > tMax) continue;
+    }
+    if (Math.abs(dz) < 1e-9) {
+      if (az < ez0 || az > ez1) continue;
+    } else {
+      let t1 = (ez0 - az) / dz;
+      let t2 = (ez1 - az) / dz;
+      if (t1 > t2) { const t = t1; t1 = t2; t2 = t; }
+      tMin = Math.max(tMin, t1);
+      tMax = Math.min(tMax, t2);
+      if (tMin > tMax) continue;
+    }
+    if (tMin >= 0 && tMin <= 1 && tMin * tMin * lenSq > 0.01) return true;
+  }
+  return false;
+}
+
+// 点到 AABB 最近点（用于避障滑移）
+export function clampPointInWorld(x: number, z: number): { x: number; z: number } {
+  return {
+    x: Math.min(WORLD_MAX_X, Math.max(WORLD_MIN_X, x)),
+    z: Math.min(WORLD_MAX_Z, Math.max(WORLD_MIN_Z, z)),
+  };
+}
+
+// 迷你地图区域色块（用于 minimap 底图）
+export const MINIMAP_REGIONS: { x0: number; x1: number; z0: number; z1: number; color: string; label: string }[] = [
+  { x0: -33, x1: -8, z0: -17, z1: 4.5, color: '#8d805f', label: 'A' },
+  { x0: -33, x1: 33, z0: 6.2, z1: 15.6, color: '#7d7355', label: 'A LONG' },
+  { x0: -6, x1: 12, z0: -18.8, z1: 11, color: '#6f674e', label: 'MID' },
+  { x0: 14, x1: 30, z0: -20, z1: 20, color: '#756b50', label: 'B TUNNEL' },
+  { x0: 12, x1: 32, z0: -37, z1: -20, color: '#8d805f', label: 'B' },
+  { x0: -33, x1: -4, z0: -26, z1: -18.8, color: '#6f674e', label: 'CATWALK' },
+  { x0: -32, x1: 12, z0: -37, z1: -29.6, color: '#6a6f80', label: 'CT SPAWN' },
+  { x0: 8, x1: 33, z0: 17.2, z1: 37, color: '#7d7355', label: 'T SPAWN' },
+];

--- a/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/game/render.ts
+++ b/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/game/render.ts
@@ -1,0 +1,474 @@
+// three.js 渲染器：场景构建（全程序化几何体）、角色模型、第一人称武器、C4
+
+import * as THREE from 'three';
+import { WALLS, BOXES, SITES } from './map';
+import { TEAM_CT, type WeaponId, type Team } from './types';
+import type { PlayerEntity } from './entity';
+
+export interface CharacterModel {
+  group: THREE.Group;
+  head: THREE.Group;
+  torso: THREE.Mesh;
+  armL: THREE.Group;
+  armR: THREE.Group;
+  legL: THREE.Group;
+  legR: THREE.Group;
+  gun: THREE.Group;
+  flash: THREE.PointLight;
+  flashMesh: THREE.Mesh;
+  nameLabel: THREE.Sprite;
+  dead: boolean;
+}
+
+const MATS = {
+  ctBody: new THREE.MeshStandardMaterial({ color: 0x2f4f8f, roughness: 0.7 }),
+  ctArm: new THREE.MeshStandardMaterial({ color: 0x243f75, roughness: 0.7 }),
+  ctLeg: new THREE.MeshStandardMaterial({ color: 0x1d3159, roughness: 0.8 }),
+  ctHelm: new THREE.MeshStandardMaterial({ color: 0x1c3d6e, roughness: 0.4 }),
+  tBody: new THREE.MeshStandardMaterial({ color: 0xc9a35a, roughness: 0.8 }),
+  tArm: new THREE.MeshStandardMaterial({ color: 0xad8c4a, roughness: 0.8 }),
+  tLeg: new THREE.MeshStandardMaterial({ color: 0x8a6f3c, roughness: 0.85 }),
+  tHead: new THREE.MeshStandardMaterial({ color: 0xd9b98a, roughness: 0.6 }),
+  head: new THREE.MeshStandardMaterial({ color: 0xd9b98a, roughness: 0.6 }),
+  gunDark: new THREE.MeshStandardMaterial({ color: 0x2b2b2b, roughness: 0.35, metalness: 0.6 }),
+  gunWood: new THREE.MeshStandardMaterial({ color: 0x6d4c2f, roughness: 0.7 }),
+  gunGreen: new THREE.MeshStandardMaterial({ color: 0x4a4f35, roughness: 0.5 }),
+  bomb: new THREE.MeshStandardMaterial({ color: 0x333333, roughness: 0.4, metalness: 0.5 }),
+  flashMat: new THREE.MeshBasicMaterial({ color: 0xffdd66 }),
+};
+
+function box(w: number, h: number, d: number, mat: THREE.Material, x = 0, y = 0, z = 0): THREE.Mesh {
+  const m = new THREE.Mesh(new THREE.BoxGeometry(w, h, d), mat);
+  m.position.set(x, y, z);
+  return m;
+}
+
+/** 构造一件武器的网格（世界模型，右手持） */
+export function buildWeaponMesh(id: WeaponId): THREE.Group {
+  const g = new THREE.Group();
+  const dark = MATS.gunDark, wood = MATS.gunWood, green = MATS.gunGreen;
+  switch (id) {
+    case 'ak47': {
+      const body = box(0.06, 0.09, 0.62, dark, 0, 0, -0.05);
+      const barrel = new THREE.Mesh(new THREE.CylinderGeometry(0.016, 0.016, 0.4, 8), dark);
+      barrel.rotation.x = Math.PI / 2;
+      barrel.position.set(0, 0.03, -0.42);
+      const mag = box(0.05, 0.2, 0.1, wood, 0, -0.12, -0.08);
+      const stock = box(0.05, 0.1, 0.24, wood, 0, -0.02, 0.32);
+      const grip = box(0.04, 0.12, 0.05, wood, 0, -0.06, 0.16);
+      const sight = box(0.01, 0.03, 0.05, dark, 0, 0.06, -0.25);
+      g.add(body, barrel, mag, stock, grip, sight);
+      break;
+    }
+    case 'm4a4': {
+      const body = box(0.05, 0.08, 0.58, dark, 0, 0, -0.04);
+      const barrel = new THREE.Mesh(new THREE.CylinderGeometry(0.014, 0.014, 0.42, 8), dark);
+      barrel.rotation.x = Math.PI / 2;
+      barrel.position.set(0, 0.025, -0.4);
+      const mag = box(0.045, 0.16, 0.09, dark, 0, -0.1, -0.06);
+      const stock = box(0.05, 0.09, 0.22, dark, 0, -0.01, 0.3);
+      const handle = box(0.03, 0.05, 0.14, dark, 0, 0.05, -0.02);
+      g.add(body, barrel, mag, stock, handle);
+      break;
+    }
+    case 'awp': {
+      const body = box(0.05, 0.07, 0.7, green, 0, 0, 0);
+      const barrel = new THREE.Mesh(new THREE.CylinderGeometry(0.013, 0.013, 0.75, 8), dark);
+      barrel.rotation.x = Math.PI / 2;
+      barrel.position.set(0, 0.02, -0.6);
+      const scope = new THREE.Mesh(new THREE.CylinderGeometry(0.03, 0.03, 0.22, 10), dark);
+      scope.rotation.x = Math.PI / 2;
+      scope.position.set(0, 0.07, -0.1);
+      const mag = box(0.04, 0.12, 0.14, dark, 0, -0.08, 0.05);
+      const stock = box(0.045, 0.08, 0.26, green, 0, -0.01, 0.42);
+      g.add(body, barrel, scope, mag, stock);
+      break;
+    }
+    case 'glock':
+    case 'usp':
+    case 'deagle': {
+      const body = box(0.035, 0.06, 0.2, dark, 0, 0, 0);
+      const barrel = box(0.028, 0.04, 0.08, dark, 0, 0.005, -0.13);
+      const grip = box(0.032, 0.1, 0.05, dark, 0, -0.07, 0.05);
+      g.add(body, barrel, grip);
+      break;
+    }
+    case 'knife': {
+      const blade = box(0.012, 0.03, 0.22, new THREE.MeshStandardMaterial({ color: 0xcccccc, metalness: 0.9, roughness: 0.2 }), 0, 0, -0.1);
+      blade.rotation.x = 0.2;
+      const handle = box(0.02, 0.035, 0.1, dark, 0, 0, 0.06);
+      g.add(blade, handle);
+      break;
+    }
+  }
+  return g;
+}
+
+/** 类人型角色模型：头 / 躯干 / 双臂 / 双腿，持枪姿态 */
+export function buildCharacter(team: Team): CharacterModel {
+  const g = new THREE.Group();
+  const isCT = team === TEAM_CT;
+  const bodyM = isCT ? MATS.ctBody : MATS.tBody;
+  const armM = isCT ? MATS.ctArm : MATS.tArm;
+  const legM = isCT ? MATS.ctLeg : MATS.tLeg;
+
+  // 躯干
+  const torso = box(0.42, 0.58, 0.26, bodyM, 0, 1.0, 0);
+  // 骨盆
+  const pelvis = box(0.36, 0.2, 0.24, legM, 0, 0.68, 0);
+  // 头 + 头饰（CT 头盔 / T 头巾）
+  const head = new THREE.Group();
+  head.position.set(0, 1.44, 0);
+  const headMesh = box(0.24, 0.26, 0.26, isCT ? MATS.ctHelm : MATS.tHead, 0, 0.13, 0);
+  const face = box(0.2, 0.14, 0.18, MATS.head, 0, -0.05, 0.02);
+  if (isCT) {
+    const visor = box(0.22, 0.05, 0.05, new THREE.MeshStandardMaterial({ color: 0x111122, roughness: 0.1 }), 0, 0.12, 0.14);
+    head.add(headMesh, visor);
+  } else {
+    const band = box(0.25, 0.06, 0.25, new THREE.MeshStandardMaterial({ color: 0x6d5a3a }), 0, 0.13, 0);
+    head.add(headMesh, face, band);
+  }
+  // 武器挂在右手（由 torso 前方向前延伸的握持点）
+  const gun = new THREE.Group();
+  gun.position.set(0.24, 1.18, 0.1);
+  gun.rotation.y = Math.PI / 2;
+
+  // 左臂（上臂 + 前臂）
+  const armL = new THREE.Group();
+  armL.position.set(-0.27, 1.32, 0);
+  const upL = box(0.11, 0.3, 0.11, armM, 0, -0.15, 0);
+  const foreL = new THREE.Group();
+  foreL.position.set(0, -0.3, 0.06);
+  const loL = box(0.1, 0.28, 0.1, armM, 0, -0.13, 0);
+  foreL.add(loL);
+  armL.add(upL, foreL);
+
+  // 右臂（持枪）
+  const armR = new THREE.Group();
+  armR.position.set(0.27, 1.32, 0);
+  const upR = box(0.11, 0.3, 0.11, armM, 0, -0.15, 0);
+  const foreR = new THREE.Group();
+  foreR.position.set(0, -0.3, 0.08);
+  const loR = box(0.1, 0.28, 0.1, armM, 0, -0.13, 0);
+  foreR.add(loR);
+  armR.add(upR, foreR);
+
+  // 双腿（大腿 + 小腿）
+  const legL = new THREE.Group();
+  legL.position.set(-0.12, 0.68, 0);
+  const thighL = box(0.13, 0.42, 0.14, legM, 0, -0.2, 0);
+  const shinL = box(0.11, 0.4, 0.12, legM, 0, -0.6, 0);
+  legL.add(thighL, shinL);
+  const legR = new THREE.Group();
+  legR.position.set(0.12, 0.68, 0);
+  const thighR = box(0.13, 0.42, 0.14, legM, 0, -0.2, 0);
+  const shinR = box(0.11, 0.4, 0.12, legM, 0, -0.6, 0);
+  legR.add(thighR, shinR);
+
+  // 开火闪光
+  const flash = new THREE.PointLight(0xffcc66, 0, 7, 1.5);
+  flash.position.set(0.3, 1.2, 0.4);
+  const flashMesh = new THREE.Mesh(new THREE.SphereGeometry(0.045, 6, 6), MATS.flashMat);
+  flashMesh.visible = false;
+  gun.add(flash, flashMesh);
+
+  g.add(torso, pelvis, head, gun, armL, armR, legL, legR);
+  g.rotation.order = 'YXZ';
+
+  // 名牌
+  const canvas = document.createElement('canvas');
+  canvas.width = 128; canvas.height = 32;
+  const ctx = canvas.getContext('2d')!;
+  ctx.fillStyle = isCT ? 'rgba(70,130,255,0.9)' : 'rgba(255,190,80,0.9)';
+  ctx.font = 'bold 18px sans-serif';
+  ctx.textAlign = 'center';
+  ctx.fillText(isCT ? 'CT' : 'T', 64, 22);
+  const tex = new THREE.CanvasTexture(canvas);
+  const nameLabel = new THREE.Sprite(new THREE.SpriteMaterial({ map: tex, depthTest: false }));
+  nameLabel.scale.set(0.7, 0.18, 1);
+  nameLabel.position.set(0, 1.95, 0);
+
+  return { group: g, head, torso, armL, armR, legL, legR, gun, flash, flashMesh, nameLabel, dead: false };
+}
+
+export class Renderer {
+  scene = new THREE.Scene();
+  camera: THREE.PerspectiveCamera;
+  renderer: THREE.WebGLRenderer;
+  private models = new Map<number, CharacterModel>();
+  private viewModel = new THREE.Group();
+  private viewGun = new THREE.Group();
+  private muzzle = new THREE.PointLight(0xffcc66, 0, 8, 1.5);
+  private muzzleMesh: THREE.Mesh;
+  private tracer: THREE.Line | null = null;
+  private tracerT = 0;
+  private bombModel = new THREE.Group();
+  private bombPlantedBeam: THREE.Mesh;
+  private bombDroppedModel = new THREE.Group();
+  private plantMarker: THREE.Group | null = null;
+  private shakeT = 0;
+  private floorMat: THREE.MeshStandardMaterial;
+
+  constructor(canvas: HTMLCanvasElement) {
+    this.renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    this.renderer.shadowMap.enabled = true;
+    this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+    this.camera = new THREE.PerspectiveCamera(90, 1, 0.05, 300);
+    this.scene.fog = new THREE.Fog(0xcbb894, 60, 180);
+    this.scene.background = new THREE.Color(0x9db4cc);
+    this.floorMat = new THREE.MeshStandardMaterial({ color: 0xcbb894, roughness: 1 });
+    this.muzzleMesh = new THREE.Mesh(new THREE.SphereGeometry(0.05, 6, 6), MATS.flashMat);
+    this.muzzleMesh.visible = false;
+    this.bombPlantedBeam = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.05, 0.05, 6, 8, 1, true),
+      new THREE.MeshBasicMaterial({ color: 0xff5533, transparent: true, opacity: 0.35 }),
+    );
+    this.buildStatic();
+    this.buildViewModel();
+  }
+
+  resize(w: number, h: number): void {
+    this.camera.aspect = w / h;
+    this.camera.updateProjectionMatrix();
+    this.renderer.setSize(w, h, false);
+  }
+
+  private buildStatic(): void {
+    const light = new THREE.DirectionalLight(0xfff2dd, 1.6);
+    light.position.set(30, 45, 20);
+    light.castShadow = true;
+    light.shadow.mapSize.set(2048, 2048);
+    light.shadow.camera.left = -60;
+    light.shadow.camera.right = 60;
+    light.shadow.camera.top = 60;
+    light.shadow.camera.bottom = -60;
+    light.shadow.camera.far = 150;
+    this.scene.add(light);
+    this.scene.add(new THREE.HemisphereLight(0xbfd4ff, 0x8a7a5c, 0.75));
+
+    // 地面（程序化噪点纹理）
+    const c = document.createElement('canvas');
+    c.width = 512; c.height = 512;
+    const ctx = c.getContext('2d')!;
+    ctx.fillStyle = '#cbb894';
+    ctx.fillRect(0, 0, 512, 512);
+    for (let i = 0; i < 2600; i++) {
+      ctx.fillStyle = `rgba(${120 + Math.random() * 60},${100 + Math.random() * 50},${70 + Math.random() * 40},${0.15 + Math.random() * 0.3})`;
+      ctx.fillRect(Math.random() * 512, Math.random() * 512, 2, 2);
+    }
+    const tex = new THREE.CanvasTexture(c);
+    tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+    tex.repeat.set(8, 8);
+    const floor = new THREE.Mesh(new THREE.PlaneGeometry(160, 160), new THREE.MeshStandardMaterial({ map: tex, roughness: 1 }));
+    floor.rotation.x = -Math.PI / 2;
+    floor.receiveShadow = true;
+    this.scene.add(floor);
+
+    // 墙体
+    for (const w of WALLS) {
+      const cx = (w.x0 + w.x1) / 2, cz = (w.z0 + w.z1) / 2;
+      const mesh = box(w.x1 - w.x0, w.height, w.z1 - w.z0, new THREE.MeshStandardMaterial({ color: w.color, roughness: 0.95 }), cx, w.height / 2, cz);
+      mesh.castShadow = true;
+      mesh.receiveShadow = true;
+      this.scene.add(mesh);
+    }
+    // 箱子
+    for (const b of BOXES) {
+      const cx = (b.x0 + b.x1) / 2, cz = (b.z0 + b.z1) / 2;
+      const h = b.stack >= 2 ? b.height * 2 : b.height;
+      const mesh = box(b.x1 - b.x0, h, b.z1 - b.z0, new THREE.MeshStandardMaterial({ color: b.color, roughness: 0.9 }), cx, h / 2, cz);
+      mesh.castShadow = true;
+      mesh.receiveShadow = true;
+      this.scene.add(mesh);
+    }
+    // 包点地面标记（A / B 大圆）
+    for (const s of SITES) {
+      const ring = new THREE.Mesh(
+        new THREE.RingGeometry(s.radius, s.radius + 0.35, 40),
+        new THREE.MeshBasicMaterial({ color: s.name === 'A' ? 0x44bbff : 0xffaa33, transparent: true, opacity: 0.5, side: THREE.DoubleSide }),
+      );
+      ring.rotation.x = -Math.PI / 2;
+      ring.position.set(s.x, 0.02, s.z);
+      this.scene.add(ring);
+      // 文字牌（canvas 纹理）
+      const cv = document.createElement('canvas');
+      cv.width = 128; cv.height = 128;
+      const cx2 = cv.getContext('2d')!;
+      cx2.fillStyle = 'rgba(0,0,0,0.55)';
+      cx2.beginPath();
+      cx2.arc(64, 64, 58, 0, Math.PI * 2);
+      cx2.fill();
+      cx2.fillStyle = s.name === 'A' ? '#55ccff' : '#ffbb44';
+      cx2.font = 'bold 76px sans-serif';
+      cx2.textAlign = 'center';
+      cx2.textBaseline = 'middle';
+      cx2.fillText(s.name, 64, 66);
+      const sprite = new THREE.Sprite(new THREE.SpriteMaterial({ map: new THREE.CanvasTexture(cv), transparent: true }));
+      sprite.scale.set(3.4, 3.4, 1);
+      sprite.position.set(s.x, 0.12, s.z);
+      this.scene.add(sprite);
+    }
+    // 中门区域门框标记
+    const door = new THREE.Mesh(
+      new THREE.BoxGeometry(3.0, 2.7, 0.15),
+      new THREE.MeshBasicMaterial({ color: 0x443322, transparent: true, opacity: 0.25, side: THREE.DoubleSide }),
+    );
+    door.position.set(8, 1.35, -18.4);
+    door.rotation.y = 0;
+    this.scene.add(door);
+
+    // C4 模型（爆炸物盒子 + 天线）
+    const c4box = box(0.28, 0.12, 0.22, MATS.bomb, 0, 0.06, 0);
+    const led = box(0.06, 0.03, 0.06, new THREE.MeshBasicMaterial({ color: 0xff3300 }), 0, 0.13, 0);
+    this.bombModel.add(c4box, led);
+    this.bombModel.visible = false;
+    this.scene.add(this.bombModel);
+    this.bombPlantedBeam.position.y = 3;
+    this.bombPlantedBeam.visible = false;
+    this.scene.add(this.bombPlantedBeam);
+    this.bombDroppedModel.add(c4box.clone(), led.clone());
+    this.bombDroppedModel.visible = false;
+    this.scene.add(this.bombDroppedModel);
+  }
+
+  /** 第一人称武器（挂在相机上） */
+  private buildViewModel(): void {
+    this.muzzle.position.set(0, -0.08, -0.85);
+    this.muzzleMesh.position.set(0, -0.08, -0.95);
+    this.viewGun.add(this.muzzle, this.muzzleMesh);
+    this.viewGun.position.set(0.28, -0.26, -0.5);
+    this.viewModel.add(this.viewGun);
+    this.viewModel.position.set(0, 0, 0);
+    this.camera.add(this.viewModel);
+    this.scene.add(this.camera);
+  }
+
+  /** 设置当前手持武器模型 */
+  setViewWeapon(id: WeaponId): void {
+    this.viewGun.clear();
+    this.viewGun.add(buildWeaponMesh(id));
+    this.viewGun.add(this.muzzle, this.muzzleMesh);
+    this.viewGun.rotation.set(0, 0, 0);
+  }
+
+  /** 注册/获取角色模型 */
+  modelFor(index: number, team: Team): CharacterModel {
+    let m = this.models.get(index);
+    if (!m) {
+      m = buildCharacter(team);
+      this.scene.add(m.group);
+      this.scene.add(m.nameLabel);
+      this.models.set(index, m);
+    }
+    return m;
+  }
+
+  /** 每帧同步角色 */
+  syncEntity(p: PlayerEntity, m: CharacterModel, dt: number, time: number): void {
+    m.group.position.set(p.x, 0, p.z);
+    // 模型内部前向为 -Z，旋转到世界前向 F=(cos yaw, sin yaw)
+    m.group.rotation.y = -(p.yaw + Math.PI / 2);
+    m.group.visible = p.alive;
+    m.nameLabel.visible = p.alive;
+    if (!p.alive) {
+      // 死亡姿态：向侧倒
+      if (!m.dead) {
+        m.dead = true;
+        m.group.rotation.x = Math.PI / 2;
+        m.group.rotation.z = 0.6;
+        m.group.position.y = 0.2;
+      }
+      return;
+    }
+    if (m.dead) { m.dead = false; m.group.rotation.x = 0; m.group.rotation.z = 0; m.group.position.y = 0; }
+    // 走路摆动
+    const moving = p.aiMoveX !== 0 || p.aiMoveZ !== 0 || p.moveAmount > 0.01;
+    if (moving) p.walkPhase += dt * 9;
+    const swing = moving ? Math.sin(p.walkPhase) * 0.55 : 0;
+    m.legL.rotation.x = swing;
+    m.legR.rotation.x = -swing;
+    m.armL.rotation.x = -swing * 0.6;
+    m.armR.rotation.x = swing * 0.6 + 0.2;
+    // 开火后坐
+    const kick = p.firingAnim * 0.18;
+    m.gun.position.z = 0.1 + kick;
+    m.gun.rotation.x = kick * 2.2;
+    m.armR.rotation.x += kick * 1.4;
+    // 受击闪红（躯干高光）
+    (m.torso.material as THREE.MeshStandardMaterial).emissive.setRGB(p.hitFlash, p.hitFlash * 0.25, p.hitFlash * 0.12);
+    // 枪口闪光
+    m.flashMesh.visible = p.firingAnim > 0.5;
+    m.flash.intensity = p.firingAnim > 0.5 ? 2.5 : 0;
+  }
+
+  /** 炸弹状态同步 */
+  syncBomb(planted: boolean, dropped: boolean, bx: number, bz: number, time: number, fuseLeft: number): void {
+    this.bombDroppedModel.visible = dropped;
+    this.bombPlantedBeam.visible = planted;
+    if (dropped) {
+      this.bombDroppedModel.position.set(bx, 0.06, bz);
+    }
+    if (planted) {
+      this.bombModel.visible = true;
+      this.bombModel.position.set(bx, 0.06, bz);
+      this.bombModel.rotation.y = time * 0.6;
+      const urgency = 0.35 + 0.45 * (fuseLeft / 40);
+      const blink = Math.sin(time * (2 + fuseLeft)) > 0 ? 1 : 0.2;
+      (this.bombPlantedBeam.material as THREE.MeshBasicMaterial).opacity = (1 - urgency) * 0.55 * blink + 0.08;
+    } else {
+      this.bombModel.visible = false;
+    }
+  }
+
+  /** 弹道示踪 */
+  spawnTracer(ox: number, oy: number, oz: number, dx: number, dy: number, dz: number, dist: number): void {
+    const pts = [
+      new THREE.Vector3(ox + dx * 0.3, oy + dy * 0.3, oz + dz * 0.3),
+      new THREE.Vector3(ox + dx * dist, oy + dy * dist, oz + dz * dist),
+    ];
+    if (this.tracer) { this.scene.remove(this.tracer); }
+    const geo = new THREE.BufferGeometry().setFromPoints(pts);
+    this.tracer = new THREE.Line(geo, new THREE.LineBasicMaterial({ color: 0xffe9a0, transparent: true, opacity: 0.8 }));
+    this.scene.add(this.tracer);
+    this.tracerT = 0.08;
+  }
+
+  update(dt: number, time: number, fire: boolean, viewRecoil: number, reloading: boolean, zooming: boolean): void {
+    // 示踪淡出
+    if (this.tracer) {
+      this.tracerT -= dt;
+      if (this.tracerT <= 0) {
+        this.scene.remove(this.tracer);
+        this.tracer = null;
+      }
+    }
+    // 第一人称武器动画
+    const bob = Math.sin(time * 7.5) * 0.012;
+    const targetX = 0.28, targetY = -0.26;
+    let tx = targetX + bob;
+    let ty = targetY + Math.abs(Math.cos(time * 7.5)) * 0.01;
+    let rz = 0;
+    if (reloading) {
+      tx -= 0.15;
+      ty -= 0.2;
+      rz = 0.6 * Math.sin(time * 16) * 0.4;
+    }
+    if (zooming) {
+      tx = 0;
+      ty = -0.17;
+      rz = 0;
+    }
+    this.viewGun.position.x += (tx - this.viewGun.position.x) * Math.min(1, dt * 12);
+    this.viewGun.position.y += (ty - this.viewGun.position.y) * Math.min(1, dt * 12);
+    this.viewGun.rotation.z += (rz - this.viewGun.rotation.z) * Math.min(1, dt * 10);
+    this.viewGun.rotation.x += (-viewRecoil * 0.8 - this.viewGun.rotation.x) * Math.min(1, dt * 14);
+    this.viewGun.position.z += (0.08 * viewRecoil - this.viewGun.position.z) * Math.min(1, dt * 14);
+    this.muzzleMesh.visible = fire;
+    this.muzzle.intensity = fire ? 3 : 0;
+  }
+
+  render(): void {
+    this.renderer.render(this.scene, this.camera);
+  }
+}

--- a/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/game/types.ts
+++ b/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/game/types.ts
@@ -1,0 +1,158 @@
+// 共享类型与常量
+
+export type Team = 0 | 1; // 0 = CT, 1 = T
+
+export const TEAM_CT: Team = 0;
+export const TEAM_T: Team = 1;
+
+export interface Vec3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export type WeaponId =
+  | 'ak47'
+  | 'm4a4'
+  | 'awp'
+  | 'glock'
+  | 'usp'
+  | 'deagle'
+  | 'knife';
+
+export type Slot = 'primary' | 'secondary' | 'melee';
+
+export interface WeaponDef {
+  id: WeaponId;
+  name: string;
+  slot: Slot;
+  damage: number; // 身体伤害
+  headMult: number; // 头部倍率（爆头 = body * headMult）
+  fireInterval: number; // 秒 / 发
+  magSize: number;
+  reloadTime: number;
+  reserve: number; // 备弹（初始）
+  spreadBase: number; // 基础散布（弧度）
+  spreadPerShot: number; // 每发增加散布
+  spreadMax: number;
+  spreadDecay: number; // 每秒恢复
+  recoilPitch: number; // 视角上扬（弧度/发）
+  recoilRandom: number;
+  auto: boolean; // 是否全自动
+  zoom: number; // 开镜倍率（1 = 无）
+  scope: boolean; // 是否有瞄准镜（AWP）
+  range: number; // 有效射程（米）
+  pen: number; // 护甲穿透系数（1 = 完全穿透）
+  price: number;
+  rpm: number; // 仅展示
+  switchTime: number; // 切换到此武器的时间
+  moveSpeedMult: number; // 手持时的移动速度倍率
+  bullets: number; // 每发子弹数量（霰弹等用，这里统一 1）
+  tracer: boolean;
+}
+
+export interface HitZone {
+  name: string;
+  mult: number; // 伤害倍率（头 = headMult，其余 1 或更小）
+  armor: boolean; // 是否受护甲保护
+}
+
+export interface HitResult {
+  target: number; // entity index
+  weapon: WeaponId;
+  zone: string;
+  damage: number; // 最终扣血
+  fatal: boolean;
+  killer: number;
+  victim: number;
+}
+
+// 玩家 3D 碰撞体（AABB，x/z 为半宽，y 为全高）
+export const PLAYER_RADIUS = 0.38;
+export const PLAYER_HEIGHT = 1.82;
+export const EYE_HEIGHT = 1.62;
+
+export const GRAVITY = 24;
+export const JUMP_SPEED = 8.2;
+export const RUN_SPEED = 5.4;
+export const WALK_SPEED = 2.6;
+
+export const ROUND_TIME = 110; // 回合秒数
+export const PLANT_TIME = 3.4; // 安放时长
+export const DEFUSE_TIME = 5.0; // 拆除时长
+export const BOMB_FUSE = 40; // 爆炸倒计时
+
+export const MAX_PLAYERS = 10; // 5v5
+export const TEAM_SIZE = 5;
+
+export interface KillEvent {
+  id: number;
+  time: number;
+  killer: number;
+  victim: number;
+  weapon: WeaponId;
+  headshot: boolean;
+  killerName: string;
+  victimName: string;
+  weaponName: string;
+}
+
+export interface HudState {
+  phase: 'intro' | 'freeze' | 'live' | 'over';
+  roundNum: number;
+  roundTime: number;
+  roundTimeMax: number;
+  freezeTime: number;
+  scoreCT: number;
+  scoreT: number;
+  lastRoundWinner: Team | -1;
+  lastRoundReason: string;
+  // 玩家视角实体（可能接管 bot）
+  camIndex: number;
+  spectating: boolean;
+  aliveCT: number;
+  aliveT: number;
+  playerAlive: boolean;
+  // 玩家自身
+  hp: number;
+  armor: number;
+  slot: Slot;
+  weapons: { id: WeaponId; name: string; slot: Slot }[];
+  ammoMag: number;
+  ammoReserve: number;
+  reloading: boolean;
+  spread: number;
+  zooming: boolean;
+  hasBomb: boolean;
+  bombPlanted: boolean;
+  bombTime: number; // 剩余爆炸时间
+  plantProgress: number; // -1 = 未在安放/拆除
+  defuseProgress: number;
+  actionLabel: string;
+  weaponName: string;
+  killfeed: KillEvent[];
+  hitmark: number; // 命中反馈剩余显示时间
+  damageFlash: number; // 受击红屏剩余时间
+  // 小地图
+  minimap: MinimapData;
+}
+
+export interface MinimapData {
+  // 世界坐标 -> 小地图像素坐标映射由组件完成
+  self: { x: number; z: number; yaw: number; alive: boolean };
+  allies: { x: number; z: number; alive: boolean }[];
+  enemies: { x: number; z: number; alive: boolean }[]; // 仅被看见的
+  bomb: { x: number; z: number; state: 'carried' | 'dropped' | 'planted' } | null;
+}
+
+export type GameEvent =
+  | { type: 'kill'; killer: number; victim: number; weapon: WeaponId; headshot: boolean }
+  | { type: 'roundStart'; roundNum: number; pistol: boolean }
+  | { type: 'roundEnd'; winner: Team; reason: string }
+  | { type: 'plant' }
+  | { type: 'defuse' }
+  | { type: 'explode' }
+  | { type: 'bombDropped' }
+  | { type: 'bombPicked' }
+  | { type: 'playerTakeover'; index: number }
+  | { type: 'hit'; fatal: boolean; headshot: boolean };

--- a/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/game/weapons.ts
+++ b/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/game/weapons.ts
@@ -1,0 +1,75 @@
+import type { WeaponDef, WeaponId, Slot } from './types';
+
+export const WEAPONS: Record<WeaponId, WeaponDef> = {
+  ak47: {
+    id: 'ak47', name: 'AK-47', slot: 'primary', damage: 36, headMult: 2,
+    fireInterval: 0.1, magSize: 30, reloadTime: 2.4, reserve: 90,
+    spreadBase: 0.004, spreadPerShot: 0.014, spreadMax: 0.085, spreadDecay: 0.5,
+    recoilPitch: 0.028, recoilRandom: 0.02, auto: true, zoom: 1, scope: false,
+    range: 100, pen: 0.7, price: 2700, rpm: 600, switchTime: 1.0,
+    moveSpeedMult: 0.95, bullets: 1, tracer: true,
+  },
+  m4a4: {
+    id: 'm4a4', name: 'M4A4', slot: 'primary', damage: 33, headMult: 2,
+    fireInterval: 0.09, magSize: 30, reloadTime: 2.1, reserve: 90,
+    spreadBase: 0.003, spreadPerShot: 0.008, spreadMax: 0.05, spreadDecay: 0.6,
+    recoilPitch: 0.012, recoilRandom: 0.008, auto: true, zoom: 1, scope: false,
+    range: 100, pen: 0.7, price: 3100, rpm: 667, switchTime: 0.85,
+    moveSpeedMult: 0.97, bullets: 1, tracer: true,
+  },
+  awp: {
+    id: 'awp', name: 'AWP', slot: 'primary', damage: 115, headMult: 2,
+    fireInterval: 1.55, magSize: 5, reloadTime: 3.7, reserve: 30,
+    spreadBase: 0.0004, spreadPerShot: 0.02, spreadMax: 0.02, spreadDecay: 0.4,
+    recoilPitch: 0.06, recoilRandom: 0.02, auto: false, zoom: 4, scope: true,
+    range: 200, pen: 0.95, price: 4750, rpm: 39, switchTime: 1.2,
+    moveSpeedMult: 0.6, bullets: 1, tracer: true,
+  },
+  glock: {
+    id: 'glock', name: 'Glock-18', slot: 'secondary', damage: 28, headMult: 2,
+    fireInterval: 0.14, magSize: 20, reloadTime: 2.2, reserve: 120,
+    spreadBase: 0.008, spreadPerShot: 0.01, spreadMax: 0.055, spreadDecay: 0.7,
+    recoilPitch: 0.012, recoilRandom: 0.01, auto: false, zoom: 1, scope: false,
+    range: 60, pen: 0.45, price: 200, rpm: 400, switchTime: 0.55,
+    moveSpeedMult: 1.0, bullets: 1, tracer: true,
+  },
+  usp: {
+    id: 'usp', name: 'USP-S', slot: 'secondary', damage: 35, headMult: 2,
+    fireInterval: 0.17, magSize: 12, reloadTime: 2.1, reserve: 48,
+    spreadBase: 0.006, spreadPerShot: 0.008, spreadMax: 0.045, spreadDecay: 0.75,
+    recoilPitch: 0.014, recoilRandom: 0.008, auto: false, zoom: 1, scope: false,
+    range: 70, pen: 0.5, price: 200, rpm: 352, switchTime: 0.55,
+    moveSpeedMult: 1.0, bullets: 1, tracer: true,
+  },
+  deagle: {
+    id: 'deagle', name: 'Desert Eagle', slot: 'secondary', damage: 53, headMult: 2,
+    fireInterval: 0.25, magSize: 7, reloadTime: 2.4, reserve: 35,
+    spreadBase: 0.01, spreadPerShot: 0.03, spreadMax: 0.09, spreadDecay: 0.55,
+    recoilPitch: 0.035, recoilRandom: 0.018, auto: false, zoom: 1, scope: false,
+    range: 90, pen: 0.8, price: 700, rpm: 240, switchTime: 0.6,
+    moveSpeedMult: 1.0, bullets: 1, tracer: true,
+  },
+  knife: {
+    id: 'knife', name: 'Knife', slot: 'melee', damage: 55, headMult: 2,
+    fireInterval: 0.4, magSize: Infinity, reloadTime: 0.01, reserve: Infinity,
+    spreadBase: 0, spreadPerShot: 0, spreadMax: 0, spreadDecay: 0,
+    recoilPitch: 0, recoilRandom: 0, auto: false, zoom: 1, scope: false,
+    range: 1.9, pen: 1, price: 0, rpm: 150, switchTime: 0.25,
+    moveSpeedMult: 1.05, bullets: 1, tracer: false,
+  },
+};
+
+export function slotOf(id: WeaponId): Slot {
+  return WEAPONS[id].slot;
+}
+
+// 默认负载：T 带 AK 或手枪局只有 Glock；CT 带 M4A4 或手枪局只有 USP
+export function defaultLoadout(team: 0 | 1, pistolRound: boolean): WeaponId[] {
+  if (pistolRound) {
+    return team === 1 ? ['glock', 'knife'] : ['usp', 'knife'];
+  }
+  return team === 1 ? ['ak47', 'glock', 'knife'] : ['m4a4', 'usp', 'knife'];
+}
+
+// 手枪局可捡起 AWP 等（用 key 切换购买——简化：开局按数字 5 切换主武器模式）
+export const PISTOL_ONLY_IDS: WeaponId[] = ['glock', 'usp', 'deagle'];

--- a/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/index.css
+++ b/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/index.css
@@ -1,0 +1,313 @@
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body, #root, .app {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: #000;
+  font-family: 'Segoe UI', 'Microsoft YaHei', system-ui, sans-serif;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.game-canvas {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  cursor: crosshair;
+}
+
+.hud {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 10;
+}
+
+/* ---------- 准星 ---------- */
+.crosshair { position: absolute; inset: 0; }
+.ch-v, .ch-h {
+  position: absolute;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 0 2px rgba(0, 0, 0, 0.8);
+  width: 2px; height: 2px;
+}
+.ch-v { left: calc(50% - 1px); }
+.ch-h { top: calc(50% - 1px); }
+.ch-dot {
+  position: absolute;
+  left: calc(50% - 1.5px); top: calc(50% - 1.5px);
+  width: 3px; height: 3px;
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 50%;
+}
+
+/* ---------- 命中反馈 ---------- */
+.hitmark { position: absolute; left: 50%; top: 50%; width: 0; height: 0; }
+.hm { position: absolute; width: 3px; height: 3px; background: #ff4444; }
+.hm1 { left: -9px; top: -1.5px; }
+.hm2 { left: 6px; top: -1.5px; }
+.hm3 { left: -1.5px; top: -9px; }
+.hm4 { left: -1.5px; top: 6px; }
+
+.damage-flash {
+  position: absolute; inset: 0;
+  background: radial-gradient(ellipse at center, rgba(255,0,0,0) 45%, rgba(200,0,0,0.55) 100%);
+}
+.lowhp {
+  position: absolute; inset: 0;
+  background: radial-gradient(ellipse at center, rgba(255,0,0,0) 50%, rgba(180,0,0,0.4) 100%);
+  animation: lowhp-pulse 1.2s ease-in-out infinite;
+}
+@keyframes lowhp-pulse {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 0.9; }
+}
+
+/* ---------- 顶部中央 ---------- */
+.top-center {
+  position: absolute;
+  top: 14px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  text-align: center;
+}
+.score {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  background: rgba(10, 12, 18, 0.72);
+  border-radius: 10px;
+  padding: 8px 22px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+.score-ct { color: #64b5f6; font-size: 26px; font-weight: 800; min-width: 34px; }
+.score-t { color: #ffb74d; font-size: 26px; font-weight: 800; min-width: 34px; }
+.score-vs { color: #ddd; font-size: 15px; letter-spacing: 2px; }
+.round-info { color: #cfd8e3; font-size: 13px; background: rgba(10,12,18,0.6); padding: 4px 12px; border-radius: 6px; }
+.alive-info { color: #9aa7b5; }
+.bomb-timer {
+  color: #ff5252;
+  font-size: 18px;
+  font-weight: 800;
+  background: rgba(30, 0, 0, 0.75);
+  padding: 5px 16px;
+  border-radius: 8px;
+  border: 1px solid #ff5252;
+  animation: bomb-blink 0.5s steps(2) infinite;
+}
+.bomb-timer.urgent { animation: bomb-blink 0.3s steps(2) infinite; }
+@keyframes bomb-blink { 0% { opacity: 1; } 100% { opacity: 0.55; } }
+.action-label { color: #ffe082; font-size: 14px; font-weight: 700; }
+.progress {
+  width: 220px; height: 8px;
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.progress-fill { height: 100%; transition: width 0.08s linear; }
+
+/* ---------- 击杀播报 ---------- */
+.killfeed {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-end;
+}
+.kf-item {
+  background: rgba(10, 12, 18, 0.72);
+  color: #e8edf2;
+  font-size: 13px;
+  padding: 4px 10px;
+  border-radius: 5px;
+  border-left: 3px solid #546e7a;
+  white-space: nowrap;
+}
+.kf-item.me { border-left-color: #7cff6b; }
+.kf-name { font-weight: 700; }
+.kf-weapon { color: #ffd54f; margin: 0 5px; font-size: 12px; }
+
+/* ---------- 左下状态 ---------- */
+.bottom-left {
+  position: absolute;
+  left: 16px;
+  bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.stat {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.stat .bar {
+  width: 170px; height: 14px;
+  background: rgba(10, 12, 18, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.stat .fill { height: 100%; transition: width 0.15s ease-out; }
+.stat .num {
+  color: #fff;
+  font-size: 14px;
+  font-weight: 700;
+  min-width: 28px;
+  text-shadow: 0 1px 3px #000;
+}
+.bomb-icon {
+  color: #ff9800;
+  font-size: 13px;
+  font-weight: 700;
+  background: rgba(40, 20, 0, 0.7);
+  padding: 3px 10px;
+  border-radius: 5px;
+  width: fit-content;
+}
+.spec-hint {
+  color: #b9c4d0;
+  font-size: 12px;
+  background: rgba(10, 12, 18, 0.7);
+  padding: 4px 10px;
+  border-radius: 5px;
+  width: fit-content;
+}
+
+/* ---------- 右下弹药 ---------- */
+.bottom-right {
+  position: absolute;
+  right: 16px;
+  bottom: 16px;
+  text-align: right;
+}
+.weapon-name {
+  color: #ffd54f;
+  font-size: 14px;
+  font-weight: 700;
+  text-shadow: 0 1px 3px #000;
+  margin-bottom: 3px;
+}
+.ammo { color: #fff; font-size: 26px; font-weight: 800; text-shadow: 0 1px 3px #000; }
+.ammo-mag { color: #fff; }
+.ammo-res { color: #b9c4d0; font-size: 18px; }
+.reloading { color: #ffab40; font-size: 13px; margin-left: 10px; font-weight: 600; }
+
+/* ---------- 小地图 ---------- */
+.minimap-wrap {
+  position: absolute;
+  left: 16px;
+  top: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.6);
+}
+.minimap-canvas { display: block; width: 180px; height: 180px; }
+
+/* ---------- 瞄准镜 ---------- */
+.scope-overlay { position: absolute; inset: 0; }
+.scope-svg { width: 100%; height: 100%; }
+.scope-cross { position: absolute; inset: 0; }
+.sc-v, .sc-h { position: absolute; background: #000; }
+.sc-v { width: 100%; }
+.sc-h { height: 100%; }
+
+/* ---------- 回合结束 ---------- */
+.round-end {
+  position: absolute;
+  top: 18%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(10, 12, 18, 0.85);
+  border: 2px solid rgba(255, 255, 255, 0.2);
+  border-radius: 14px;
+  padding: 22px 40px;
+  text-align: center;
+  pointer-events: auto;
+  min-width: 320px;
+}
+.round-end.ct { border-color: #64b5f6; }
+.round-end.t { border-color: #ffb74d; }
+.re-title { font-size: 30px; font-weight: 800; color: #fff; margin-bottom: 6px; }
+.re-reason { color: #b9c4d0; font-size: 15px; margin-bottom: 14px; }
+.re-next { color: #8b95a1; font-size: 13px; }
+.btn {
+  pointer-events: auto;
+  background: linear-gradient(180deg, #ffb74d, #f57c00);
+  color: #1a1206;
+  border: none;
+  border-radius: 8px;
+  padding: 10px 26px;
+  font-size: 16px;
+  font-weight: 800;
+  cursor: pointer;
+}
+.btn:hover { filter: brightness(1.1); }
+.btn.big { font-size: 19px; padding: 13px 40px; margin-top: 8px; }
+
+/* ---------- 暂停 ---------- */
+.pause-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.pause-box { text-align: center; color: #fff; }
+.pause-title { font-size: 34px; font-weight: 800; margin-bottom: 8px; }
+.pause-tip { color: #b9c4d0; }
+
+/* ---------- 开始界面 ---------- */
+.intro {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at center, rgba(30, 25, 12, 0.88), rgba(8, 8, 10, 0.94));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: auto;
+}
+.intro-box {
+  text-align: center;
+  max-width: 560px;
+  padding: 30px 40px;
+  border: 1px solid rgba(255, 200, 100, 0.25);
+  border-radius: 16px;
+  background: rgba(16, 18, 24, 0.6);
+}
+.intro-title {
+  font-size: 44px;
+  font-weight: 900;
+  letter-spacing: 6px;
+  background: linear-gradient(180deg, #ffe0a3, #e08c2d);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  margin-bottom: 6px;
+}
+.intro-sub { color: #b9c4d0; margin-bottom: 22px; font-size: 14px; }
+.controls {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px 24px;
+  text-align: left;
+  color: #cfd8e3;
+  font-size: 13.5px;
+  margin-bottom: 22px;
+}
+.controls b { color: #ffe082; }
+.intro-note { color: #ffb74d; font-size: 12.5px; margin-top: 14px; }
+
+/* 提示按钮获得焦点样式 */
+button:focus-visible { outline: 2px solid #ffb74d; }

--- a/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/main.tsx
+++ b/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/main.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useRef, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { Game } from './game/game';
+import { Hud } from './ui/Hud';
+import type { HudState } from './game/types';
+import './index.css';
+
+function App() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const gameRef = useRef<Game | null>(null);
+  const [snap, setSnap] = useState<HudState | null>(null);
+  const [started, setStarted] = useState(false);
+  const [locked, setLocked] = useState(false);
+
+  useEffect(() => {
+    const cv = canvasRef.current;
+    if (!cv || gameRef.current) return;
+    const game = new Game(cv);
+    gameRef.current = game;
+    game.onHud((s) => setSnap(s));
+    game.start();
+    const onLock = () => setLocked(document.pointerLockElement === cv);
+    document.addEventListener('pointerlockchange', onLock);
+    const onErr = (e: Event) => e.preventDefault();
+    cv.addEventListener('error', onErr);
+    return () => {
+      document.removeEventListener('pointerlockchange', onLock);
+      cv.removeEventListener('error', onErr);
+      game.destroy();
+    };
+  }, []);
+
+  const handleStart = () => {
+    gameRef.current?.requestStart();
+    setStarted(true);
+  };
+
+  return (
+    <div className="app">
+      <canvas ref={canvasRef} className="game-canvas" />
+      {snap && (
+        <Hud
+          snap={snap}
+          started={started}
+          locked={locked}
+          onStart={handleStart}
+          onRestart={() => gameRef.current?.reset()}
+        />
+      )}
+    </div>
+  );
+}
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/ui/Hud.tsx
+++ b/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/src/ui/Hud.tsx
@@ -1,0 +1,293 @@
+// HUD 覆盖层：准星、生命/护甲、弹药、击杀播报、小地图、炸弹状态、回合横幅
+
+import { useEffect, useRef } from 'react';
+import { MINIMAP_REGIONS, SITES } from '../game/map';
+import type { HudState } from '../game/types';
+
+const WX0 = -34, WX1 = 34, WZ0 = -38, WZ1 = 38;
+
+export function Minimap({ snap }: { snap: HudState }) {
+  const ref = useRef<HTMLCanvasElement>(null);
+  useEffect(() => {
+    const cv = ref.current;
+    if (!cv) return;
+    const ctx = cv.getContext('2d');
+    if (!ctx) return;
+    const W = cv.width, H = cv.height;
+    const s = Math.min(W / (WX1 - WX0), H / (WZ1 - WZ0));
+    const ox = (W - (WX1 - WX0) * s) / 2;
+    const oy = (H - (WZ1 - WZ0) * s) / 2;
+    const px = (x: number) => ox + (x - WX0) * s;
+    const py = (z: number) => oy + (z - WZ0) * s;
+    ctx.clearRect(0, 0, W, H);
+    ctx.fillStyle = '#0d1117';
+    ctx.fillRect(0, 0, W, H);
+    // 区域底图
+    for (const r of MINIMAP_REGIONS) {
+      ctx.fillStyle = r.color;
+      ctx.globalAlpha = 0.85;
+      ctx.fillRect(px(r.x0), py(r.z0), (r.x1 - r.x0) * s, (r.z1 - r.z0) * s);
+    }
+    ctx.globalAlpha = 1;
+    // 包点环
+    for (const st of SITES) {
+      ctx.strokeStyle = st.name === 'A' ? '#4fc3f7' : '#ffb74d';
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      ctx.arc(px(st.x), py(st.z), st.radius * s, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+    const m = snap.minimap;
+    // 炸弹
+    if (m.bomb) {
+      const bx = px(m.bomb.x), by = py(m.bomb.z);
+      ctx.fillStyle = m.bomb.state === 'planted' ? '#ff5722' : '#ff9800';
+      if (m.bomb.state === 'planted') {
+        const pulse = 3 + Math.sin(Date.now() / 150) * 1.5;
+        ctx.beginPath();
+        ctx.arc(bx, by, pulse, 0, Math.PI * 2);
+        ctx.strokeStyle = '#ff5722';
+        ctx.lineWidth = 2;
+        ctx.stroke();
+      }
+      ctx.save();
+      ctx.translate(bx, by);
+      ctx.rotate(Math.PI / 4);
+      ctx.fillRect(-3.5, -3.5, 7, 7);
+      ctx.restore();
+    }
+    // 队友
+    for (const a of m.allies) {
+      ctx.fillStyle = a.alive ? '#33b5ff' : '#555a66';
+      ctx.beginPath();
+      ctx.arc(px(a.x), py(a.z), 3.2, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    // 被看见的敌人
+    for (const e of m.enemies) {
+      ctx.fillStyle = '#ff4444';
+      ctx.beginPath();
+      ctx.arc(px(e.x), py(e.z), 3, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    // 自己（方向箭头）
+    if (m.self.alive) {
+      const sx = px(m.self.x), sy = py(m.self.z);
+      ctx.save();
+      ctx.translate(sx, sy);
+      // 世界前向 (cos yaw, sin yaw) → 屏幕方向（屏幕 y 与 z 同向，向下）
+      ctx.rotate(Math.atan2(Math.cos(m.self.yaw), -Math.sin(m.self.yaw)));
+      ctx.fillStyle = '#7CFF6B';
+      ctx.beginPath();
+      ctx.moveTo(0, -6);
+      ctx.lineTo(4.5, 4.5);
+      ctx.lineTo(0, 1.8);
+      ctx.lineTo(-4.5, 4.5);
+      ctx.closePath();
+      ctx.fill();
+      ctx.restore();
+      ctx.fillStyle = '#ffffff';
+      ctx.beginPath();
+      ctx.arc(sx, sy, 1.8, 0, Math.PI * 2);
+      ctx.fill();
+    } else {
+      ctx.fillStyle = '#888';
+      ctx.font = 'bold 10px sans-serif';
+      ctx.textAlign = 'center';
+      ctx.fillText('×', px(m.self.x), py(m.self.z) + 3);
+    }
+  }, [snap.minimap, snap.roundNum]);
+  return <canvas ref={ref} width={240} height={240} className="minimap-canvas" />;
+}
+
+function Crosshair({ spread, zooming }: { spread: number; zooming: boolean }) {
+  if (zooming) return null;
+  const gap = 6 + spread * 60;
+  const len = 7 + spread * 30;
+  return (
+    <div className="crosshair">
+      <div className="ch-v" style={{ top: `calc(50% - ${gap + len}px)`, height: len }} />
+      <div className="ch-v" style={{ top: `calc(50% + ${gap}px)`, height: len }} />
+      <div className="ch-h" style={{ left: `calc(50% - ${gap + len}px)`, width: len }} />
+      <div className="ch-h" style={{ left: `calc(50% + ${gap}px)`, width: len }} />
+      <div className="ch-dot" />
+    </div>
+  );
+}
+
+function ScopeOverlay() {
+  return (
+    <div className="scope-overlay">
+      <svg className="scope-svg" viewBox="0 0 100 100" preserveAspectRatio="none">
+        <circle cx="50" cy="50" r="46" fill="none" stroke="rgba(0,0,0,0.9)" strokeWidth="46" />
+        <circle cx="50" cy="50" r="49" fill="none" stroke="#000" strokeWidth="1.5" />
+        <circle cx="50" cy="50" r="1.2" fill="#000" />
+        <line x1="0" y1="50" x2="100" y2="50" stroke="#000" strokeWidth="0.7" />
+        <line x1="50" y1="0" x2="50" y2="100" stroke="#000" strokeWidth="0.7" />
+      </svg>
+      <div className="scope-cross">
+        <div className="sc-v" style={{ top: 'calc(50% - 46vh)', height: '40vh' }} />
+        <div className="sc-v" style={{ top: 'calc(50% + 6vh)', height: '40vh' }} />
+        <div className="sc-h" style={{ left: 'calc(50% - 46vw)', width: '40vw' }} />
+        <div className="sc-h" style={{ left: 'calc(50% + 6vw)', width: '40vw' }} />
+      </div>
+    </div>
+  );
+}
+
+export function Hud(props: {
+  snap: HudState;
+  started: boolean;
+  locked: boolean;
+  onStart: () => void;
+  onRestart: () => void;
+}) {
+  const { snap, started, locked, onStart, onRestart } = props;
+  const kf = snap.killfeed.slice(-6).reverse();
+
+  return (
+    <div className="hud">
+      {/* 十字准星 */}
+      {started && !snap.zooming && <Crosshair spread={snap.spread} zooming={snap.zooming} />}
+      {started && snap.zooming && <ScopeOverlay />}
+
+      {/* 命中反馈 */}
+      {snap.hitmark > 0 && (
+        <div className="hitmark" style={{ opacity: Math.min(1, snap.hitmark * 4) }}>
+          <div className="hm hm1" /><div className="hm hm2" />
+          <div className="hm hm3" /><div className="hm hm4" />
+        </div>
+      )}
+
+      {/* 受击红屏 */}
+      {snap.damageFlash > 0 && <div className="damage-flash" style={{ opacity: snap.damageFlash * 3 }} />}
+
+      {/* 低血量警示 */}
+      {snap.hp < 35 && started && <div className="lowhp" />}
+
+      {/* 顶部：比分 + 回合信息 */}
+      <div className="top-center">
+        <div className="score">
+          <span className="score-ct">{snap.scoreCT}</span>
+          <span className="score-vs">Dust2 对决</span>
+          <span className="score-t">{snap.scoreT}</span>
+        </div>
+        <div className="round-info">
+          第 {snap.roundNum} 回合 {snap.phase === 'freeze' && `· 开始倒计时 ${snap.freezeTime}`}
+          <span className="alive-info"> CT {snap.aliveCT} vs T {snap.aliveT}</span>
+        </div>
+        {snap.bombPlanted && (
+          <div className={`bomb-timer ${snap.bombTime <= 10 ? 'urgent' : ''}`}>
+            💣 爆炸倒计时 {snap.bombTime}s
+          </div>
+        )}
+        {snap.actionLabel && <div className="action-label">{snap.actionLabel}</div>}
+        {snap.plantProgress >= 0 && <ProgressBar v={snap.plantProgress} color="#ff9800" />}
+        {snap.defuseProgress >= 0 && <ProgressBar v={snap.defuseProgress} color="#4fc3f7" />}
+      </div>
+
+      {/* 击杀播报 */}
+      <div className="killfeed">
+        {kf.map((item, i) => (
+          <div key={item.id} className={`kf-item ${item.killer === 0 ? 'me' : ''}`} style={{ opacity: 1 - i * 0.14 }}>
+            <span className="kf-name">{item.killerName}</span>
+            <span className="kf-weapon">[{item.weaponName}{item.headshot ? ' ◎' : ''}]</span>
+            <span className="kf-name">{item.victimName}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* 左下：生命 / 护甲 */}
+      {started && (
+        <div className="bottom-left">
+          <div className="stat hp">
+            <div className="bar"><div className="fill" style={{ width: `${snap.hp}%`, background: snap.hp > 50 ? '#4caf50' : snap.hp > 25 ? '#ff9800' : '#f44336' }} /></div>
+            <span className="num">{snap.hp}</span>
+          </div>
+          <div className="stat armor">
+            <div className="bar"><div className="fill" style={{ width: `${snap.armor}%`, background: '#42a5f5' }} /></div>
+            <span className="num">{snap.armor}</span>
+          </div>
+          {snap.hasBomb && <div className="bomb-icon">💣 持有 C4</div>}
+          {snap.spectating && <div className="spec-hint">观战中 · 按 F2 切换队友 · 当前操控 {snap.weapons.length > 0 ? '队友' : ''}</div>}
+        </div>
+      )}
+
+      {/* 右下：弹药 */}
+      {started && (
+        <div className="bottom-right">
+          <div className="weapon-name">{snap.weaponName}</div>
+          <div className="ammo">
+            {snap.ammoMag === Infinity ? (
+              <span className="ammo-mag inf">∞</span>
+            ) : (
+              <>
+                <span className="ammo-mag">{snap.ammoMag}</span>
+                <span className="ammo-sep"> / </span>
+                <span className="ammo-res">{snap.ammoReserve === Infinity ? '∞' : snap.ammoReserve}</span>
+              </>
+            )}
+            {snap.reloading && <span className="reloading">换弹中...</span>}
+          </div>
+        </div>
+      )}
+
+      {/* 小地图 */}
+      <div className="minimap-wrap">
+        <Minimap snap={snap} />
+      </div>
+
+      {/* 回合结束横幅 */}
+      {snap.phase === 'over' && (
+        <div className={`round-end ${snap.lastRoundWinner === 0 ? 'ct' : 't'}`}>
+          <div className="re-title">
+            {snap.lastRoundWinner === 0 ? 'CT 阵营获胜' : 'T 阵营获胜'}
+          </div>
+          <div className="re-reason">{snap.lastRoundReason}</div>
+          {snap.scoreCT >= 8 || snap.scoreT >= 8 ? (
+            <button className="btn" onClick={onRestart}>再来一局</button>
+          ) : (
+            <div className="re-next">下一回合即将开始...</div>
+          )}
+        </div>
+      )}
+
+      {/* 暂停遮罩 */}
+      {started && !locked && (
+        <div className="pause-overlay">
+          <div className="pause-box">
+            <div className="pause-title">已暂停</div>
+            <div className="pause-tip">点击画面继续</div>
+          </div>
+        </div>
+      )}
+
+      {/* 开始界面 */}
+      {!started && (
+        <div className="intro">
+          <div className="intro-box">
+            <h1 className="intro-title">DUST2 · 5v5</h1>
+            <p className="intro-sub">第一人称射击原型 · 全程序化生成</p>
+            <div className="controls">
+              <div><b>WASD</b> 移动</div>
+              <div><b>鼠标</b> 视角 · <b>左键</b> 开火 · <b>右键</b> 开镜(AWP)</div>
+              <div><b>空格</b> 跳跃 · <b>R</b> 换弹 · <b>E</b> 下包/拆包</div>
+              <div><b>1/2/3</b> 或 <b>滚轮</b> 切换武器 · <b>Q</b> 循环切换</div>
+              <div><b>F2</b> 阵亡后切换队友视角 · <b>M</b> 静音</div>
+            </div>
+            <button className="btn big" onClick={onStart}>进入战场</button>
+            <p className="intro-note">第 1 回合为手枪局（仅手枪 · 无护甲）</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProgressBar({ v, color }: { v: number; color: string }) {
+  return (
+    <div className="progress">
+      <div className="progress-fill" style={{ width: `${v * 100}%`, background: color }} />
+    </div>
+  );
+}

--- a/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/tsconfig.json
+++ b/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/vite.config.ts
+++ b/outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: './',
+  server: {
+    host: true,
+    port: 5173,
+  },
+  build: {
+    target: 'es2020',
+    chunkSizeWarningLimit: 1600,
+  },
+});

--- a/outputs/deepseek-v4-flash-0731/claude-code-max/mythos-craft.html
+++ b/outputs/deepseek-v4-flash-0731/claude-code-max/mythos-craft.html
@@ -1,0 +1,1360 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>神话大陆 · MYTHOSCRAFT</title>
+<style>
+  *{ box-sizing:border-box; }
+  html,body{ height:100%; margin:0; overflow:hidden; background:#000; }
+  body{
+    font-family:"Segoe UI","PingFang SC","Microsoft YaHei",system-ui,sans-serif;
+    color:#dfe6f0; -webkit-font-smoothing:antialiased;
+  }
+  .glass{
+    background:rgba(8,12,20,.66);
+    border:1px solid rgba(255,255,255,.09);
+    border-radius:10px;
+    backdrop-filter:blur(6px);
+    -webkit-backdrop-filter:blur(6px);
+  }
+  #hud{ position:fixed; inset:0; pointer-events:none; z-index:50; }
+  #title{
+    position:absolute; top:14px; left:50%; transform:translateX(-50%);
+    text-align:center; font-family:Georgia,"Times New Roman",serif;
+    letter-spacing:.5em; font-size:15px; color:#f0d9a0;
+    text-shadow:0 2px 8px rgba(0,0,0,.6); padding:8px 26px; white-space:nowrap;
+  }
+  #title small{ display:block; font-size:10px; letter-spacing:.3em; color:#9aa8bd; margin-top:3px; }
+  #help{
+    position:absolute; top:14px; left:14px; padding:12px 16px;
+    font-size:12px; line-height:2; color:#b9c4d6; max-width:250px;
+  }
+  #help h3{ margin:0 0 4px; font-size:12px; letter-spacing:.3em; color:#e8cf9a; font-weight:600; }
+  #help b{ color:#e8cf9a; font-weight:600; }
+  #coords{
+    position:absolute; top:14px; right:14px; padding:10px 16px;
+    font-size:12px; line-height:2; color:#b9c4d6; text-align:right; min-width:170px;
+  }
+  #coords b{ color:#e8cf9a; font-weight:600; }
+  #crosshair{
+    position:absolute; left:50%; top:50%; width:22px; height:22px;
+    transform:translate(-50%,-50%);
+  }
+  #crosshair::before, #crosshair::after{
+    content:""; position:absolute; background:rgba(255,255,255,.92);
+    box-shadow:0 0 2px rgba(0,0,0,.8);
+  }
+  #crosshair::before{ left:10px; top:0; width:2px; height:22px; }
+  #crosshair::after{ left:0; top:10px; width:22px; height:2px; }
+  #hotbar{
+    position:absolute; bottom:16px; left:50%; transform:translateX(-50%);
+    display:flex; gap:6px; padding:7px; border-radius:12px;
+  }
+  #hotbar .slot{
+    width:48px; height:48px; border:2px solid rgba(255,255,255,.14);
+    border-radius:8px; background:rgba(0,0,0,.42);
+    display:flex; align-items:center; justify-content:center; position:relative;
+  }
+  #hotbar .slot.on{ border-color:#e8cf9a; box-shadow:0 0 10px rgba(232,207,154,.45); }
+  #hotbar .slot canvas{ width:34px; height:34px; image-rendering:pixelated; }
+  #hotbar .slot i{
+    position:absolute; left:3px; bottom:1px; font-style:normal;
+    font-size:9px; color:rgba(255,255,255,.75);
+  }
+  #toast{
+    position:absolute; top:82px; left:50%; transform:translateX(-50%);
+    padding:10px 24px; font-size:14px; letter-spacing:.12em; color:#ffe9b8;
+    border-radius:10px; opacity:0; transition:opacity .5s;
+    text-align:center; max-width:72vw;
+  }
+  #toast.show{ opacity:1; }
+  #toast small{
+    display:block; font-size:11px; color:#aeb9cc; letter-spacing:.06em;
+    margin-top:3px; font-weight:400;
+  }
+  #vignette{
+    position:fixed; inset:0; pointer-events:none; z-index:40;
+    background:radial-gradient(90% 90% at 50% 45%, transparent 62%, rgba(0,0,0,.42) 100%);
+  }
+  #boot{
+    position:fixed; inset:0; z-index:200;
+    display:flex; flex-direction:column; align-items:center; justify-content:center;
+    gap:18px; background:linear-gradient(180deg,#0a0e16 0%,#0c1424 60%,#121c30 100%);
+    transition:opacity .8s;
+  }
+  #boot.hide{ opacity:0; pointer-events:none; }
+  #boot .ring{
+    width:52px; height:52px; border-radius:50%;
+    border:3px solid rgba(232,207,154,.14); border-top-color:#e8cf9a;
+    animation:spin 1.1s linear infinite;
+  }
+  @keyframes spin{ to{ transform:rotate(360deg); } }
+  #boot h1{
+    font-family:Georgia,serif; letter-spacing:.5em; font-size:26px; margin:0;
+    color:#f0d9a0; text-shadow:0 0 24px rgba(232,207,154,.35);
+  }
+  #boot .tip{ font-size:11px; letter-spacing:.25em; color:#7f8ca3; }
+  #boot .sub{ font-size:12px; color:#8fa0b8; letter-spacing:.12em; text-align:center; line-height:1.9; }
+  #boot button{
+    margin-top:6px; pointer-events:auto; cursor:pointer; font:inherit;
+    font-size:14px; letter-spacing:.35em; color:#241a06;
+    background:linear-gradient(180deg,#f5d78c,#d9ac58);
+    border:none; border-radius:24px; padding:12px 44px;
+    box-shadow:0 8px 26px rgba(217,172,88,.35);
+  }
+  #boot button:hover{ filter:brightness(1.08); }
+  @media (max-width:760px){
+    #help{ display:none; }
+    #title{ font-size:12px; letter-spacing:.3em; }
+    #hotbar .slot{ width:40px; height:40px; }
+  }
+</style>
+</head>
+<body>
+<div id="vignette"></div>
+<div id="hud">
+  <div id="title" class="glass">神话大陆<small>MYTHOSCRAFT · 传说级沙盒</small></div>
+  <div id="help" class="glass">
+    <h3>操 作</h3>
+    <b>WASD</b> 移动 · <b>空格</b> 跳跃<br>
+    <b>鼠标</b> 环视 · <b>左键</b> 挖掘 · <b>右键</b> 建造<br>
+    <b>Shift</b> 疾跑 · <b>F</b> 飞行 · <b>T</b> 快进时间<br>
+    <b>滚轮 / 1~9</b> 选择方块 · <b>R</b> 回到起点<br>
+    <b>Esc</b> 释放鼠标指针
+  </div>
+  <div id="coords" class="glass">
+    坐标&nbsp; <b id="cX">0</b> · <b id="cY">0</b> · <b id="cZ">0</b><br>
+    群系&nbsp; <b id="cBiome">平原</b><br>
+    时辰&nbsp; <b id="cTime">正午</b>
+  </div>
+  <div id="crosshair"></div>
+  <div id="toast" class="glass"></div>
+  <div id="hotbar" class="glass"></div>
+</div>
+<div id="boot">
+  <div class="ring"></div>
+  <h1>神话大陆</h1>
+  <div class="tip" id="bootTip">正在编织大地…</div>
+  <div class="sub">传说中，龙辉堡的钟声仍在这片大陆回荡。<br>穿过森林、沙漠与雪原，去寻访众神的遗迹。</div>
+  <button id="btnStart">进 入 世 界</button>
+</div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+<script>
+'use strict';
+/* ==================== 工具 ==================== */
+const TAU = Math.PI * 2;
+function clamp(v,a,b){ return v<a?a:(v>b?b:v); }
+function lerp(a,b,t){ return a+(b-a)*t; }
+function mulberry32(a){
+  return function(){
+    a|=0; a=a+0x6D2B79F5|0;
+    let t=Math.imul(a^a>>>15,1|a);
+    t=t+Math.imul(t^t>>>7,61|t)^t;
+    return ((t^t>>>14)>>>0)/4294967296;
+  };
+}
+/* 确定性整数哈希 -> [0,1) */
+function hash2(x,z,s){
+  let n=(x*374761393 + z*668265263 + s*1274126177)|0;
+  n=(n^(n>>13))|0; n=Math.imul(n,1274126177);
+  n=(n^(n>>16))>>>0;
+  return n/4294967296;
+}
+
+/* ==================== 柏林噪声 ==================== */
+const PERM = new Uint8Array(512);
+(function(){
+  const rng=mulberry32(20260731);
+  const p=new Uint8Array(256);
+  for(let i=0;i<256;i++) p[i]=i;
+  for(let i=255;i>0;i--){
+    const j=(rng()*(i+1))|0, t=p[i]; p[i]=p[j]; p[j]=t;
+  }
+  for(let i=0;i<512;i++) PERM[i]=p[i&255];
+})();
+function fade(t){ return t*t*t*(t*(t*6-15)+10); }
+const GRAD2=[[1,1],[-1,1],[1,-1],[-1,-1],[1,0],[-1,0],[0,1],[0,-1]];
+function gradDot(h,x,y){ const g=GRAD2[h&7]; return g[0]*x+g[1]*y; }
+function perlin2(x,y){
+  const X=Math.floor(x)&255, Y=Math.floor(y)&255;
+  x-=Math.floor(x); y-=Math.floor(y);
+  const u=fade(x), v=fade(y);
+  const a=PERM[X]+Y, b=PERM[X+1]+Y;
+  return lerp(
+    lerp(gradDot(PERM[a],x,y),      gradDot(PERM[b],x-1,y),    u),
+    lerp(gradDot(PERM[a+1],x,y-1),  gradDot(PERM[b+1],x-1,y-1),u), v);
+}
+function fbm(x,z,oct,lac,gain){
+  let amp=1,f=1,sum=0,norm=0;
+  for(let i=0;i<oct;i++){ sum+=perlin2(x*f,z*f)*amp; norm+=amp; amp*=gain; f*=lac; }
+  return sum/norm; /* ~[-1,1] */
+}
+
+/* ==================== 渲染器 / 场景 / 摄像机 ==================== */
+const renderer=new THREE.WebGLRenderer({ antialias:true });
+renderer.setPixelRatio(Math.min(window.devicePixelRatio,2));
+renderer.setSize(window.innerWidth, window.innerHeight);
+renderer.setClearColor(0x7fb2e5);
+document.body.appendChild(renderer.domElement);
+
+const scene=new THREE.Scene();
+scene.fog=new THREE.Fog(0x7fb2e5, 60, 150);
+
+const camera=new THREE.PerspectiveCamera(72, window.innerWidth/window.innerHeight, 0.1, 400);
+camera.rotation.order='YXZ';
+
+/* 灯光 */
+const sunLight=new THREE.DirectionalLight(0xfff3e0, 1.05);
+sunLight.position.set(60,90,40);
+scene.add(sunLight);
+const hemi=new THREE.HemisphereLight(0xbfd8ff, 0x6b5a3f, 0.55);
+scene.add(hemi);
+
+/* 星空（夜晚可见） */
+const starCnt=650, starPos=new Float32Array(starCnt*3);
+(function(){
+  const rng=mulberry32(99);
+  for(let i=0;i<starCnt;i++){
+    const th=Math.acos(rng()*2-1), ph=rng()*TAU;
+    starPos[i*3]  =Math.sin(th)*Math.cos(ph)*180;
+    starPos[i*3+1]=Math.abs(Math.cos(th))*180;
+    starPos[i*3+2]=Math.sin(th)*Math.sin(ph)*180;
+  }
+})();
+const starGeo=new THREE.BufferGeometry();
+starGeo.setAttribute('position', new THREE.BufferAttribute(starPos,3));
+const stars=new THREE.Points(starGeo, new THREE.PointsMaterial({
+  color:0xffffff, size:1.6, transparent:true, opacity:0, fog:false, depthWrite:false
+}));
+scene.add(stars);
+
+/* 太阳与月亮 */
+function makeOrb(core, glow){
+  const cv=document.createElement('canvas'); cv.width=cv.height=64;
+  const c=cv.getContext('2d');
+  const g=c.createRadialGradient(32,32,2,32,32,30);
+  g.addColorStop(0,core);
+  g.addColorStop(0.45,glow);
+  g.addColorStop(1,'rgba(0,0,0,0)');
+  c.fillStyle=g; c.fillRect(0,0,64,64);
+  const tex=new THREE.CanvasTexture(cv);
+  return new THREE.Sprite(new THREE.SpriteMaterial({ map:tex, transparent:true, fog:false, depthWrite:false }));
+}
+const sunSprite=makeOrb('#fff8e0','rgba(255,220,140,0.75)');
+sunSprite.scale.set(34,34,1);
+scene.add(sunSprite);
+const moonSprite=makeOrb('#e8f0ff','rgba(180,210,255,0.6)');
+moonSprite.scale.set(26,26,1);
+scene.add(moonSprite);
+
+/* ==================== 日夜循环 ==================== */
+const DAY_LEN=420; /* 秒 */
+let tOfDay=0.28;   /* 0=黎明 0.25=正午 0.5=黄昏 0.75=午夜 */
+const skyDay=new THREE.Color(0x7fb2e5);
+const skyDusk=new THREE.Color(0xe8934f);
+const skyNight=new THREE.Color(0x0a1226);
+const tmpC=new THREE.Color();
+function updateSky(dt){
+  tOfDay+=dt/DAY_LEN;
+  if(tOfDay>=1) tOfDay-=1;
+  const e=Math.cos((tOfDay-0.25)*TAU);            /* 1=正午 0=晨昏 -1=午夜 */
+  const dayF=clamp(e*2.6+0.12,0,1);               /* 白昼亮度因子 */
+  const duskF=clamp(1-Math.abs(e)*4.5,0,1);       /* 晨昏红霞因子 */
+  tmpC.copy(skyDay).lerp(skyNight,1-dayF).lerp(skyDusk,duskF*0.55);
+  scene.background=tmpC.clone();
+  scene.fog.color.copy(tmpC);
+  sunLight.intensity=0.06+dayF*1.05;
+  sunLight.color.setRGB(1,0.9+0.1*dayF,0.78+0.22*dayF);
+  hemi.intensity=0.14+dayF*0.5;
+  stars.material.opacity=clamp(1-dayF*1.4,0,1);
+  const ang=(tOfDay-0.25)*TAU;
+  sunLight.position.set(Math.cos(ang)*90, Math.sin(ang)*90, 45);
+  sunSprite.position.set(Math.cos(ang)*170, Math.sin(ang)*170, 60);
+  moonSprite.position.set(-Math.cos(ang)*170, -Math.sin(ang)*170, 60);
+  sunSprite.visible=e>0.02;
+  moonSprite.visible=e<=0.02;
+}
+/* ==================== 方块贴图（程序化绘制） ==================== */
+const TILE=16, ATLAS_N=8, ATLAS=TILE*ATLAS_N;
+const atlasCv=document.createElement('canvas');
+atlasCv.width=atlasCv.height=ATLAS;
+const actx=atlasCv.getContext('2d');
+const TILES={};         /* 贴图名 -> 序号 */
+const tileCvs={};       /* 贴图名 -> 16x16 canvas */
+let tileIdx=0;
+function newTile(name, painter){
+  TILES[name]=tileIdx;
+  const cv=document.createElement('canvas');
+  cv.width=cv.height=TILE;
+  painter(cv.getContext('2d'));
+  tileCvs[name]=cv;
+  actx.drawImage(cv,(tileIdx%ATLAS_N)*TILE,((tileIdx/ATLAS_N)|0)*TILE);
+  tileIdx++;
+}
+function pxC(c,x,y,ch){ /* 像素填充 */
+  c.fillStyle=ch; c.fillRect(x,y,1,1);
+}
+function nz(c,x,y,base,sp,rng){
+  const d=(rng()-0.5)*sp*2;
+  pxC(c,x,y,'rgb('+Math.round(clamp(base[0]+d,0,255))+','+
+    Math.round(clamp(base[1]+d,0,255))+','+Math.round(clamp(base[2]+d,0,255))+')');
+}
+function tilePainter(base,sp){ /* 纯噪声 */
+  return function(c){
+    const rng=mulberry32(hash2(base[0],base[1],base[2])*4294967296);
+    for(let y=0;y<TILE;y++)for(let x=0;x<TILE;x++) nz(c,x,y,base,sp,rng);
+  };
+}
+function tileBrick(mortar,brickBase,brickSp,moss){
+  return function(c){
+    const rng=mulberry32(hash2(brickBase[0],brickBase[1],brickBase[2])*4294967296);
+    for(let y=0;y<TILE;y++)for(let x=0;x<TILE;x++) pxC(c,x,y,'rgb('+mortar+')');
+    for(let row=0;row<4;row++){
+      const off=(row%2)*TILE/2;
+      for(let col=0;col<2;col++){
+        const x0=(col*TILE/2+off)%TILE, y0=row*TILE/4;
+        for(let y=1;y<TILE/4-1;y++)for(let x=1;x<TILE/2-1;x++){
+          const nx=(x0+x)%TILE, ny=y0+y;
+          const v=(rng()-0.5)*brickSp*2;
+          let colr='rgb('+Math.round(clamp(brickBase[0]+v,0,255))+','+
+            Math.round(clamp(brickBase[1]+v,0,255))+','+Math.round(clamp(brickBase[2]+v,0,255))+')';
+          if(moss && rng()<0.12) colr='rgb('+(60+(rng()*30|0))+','+(110+(rng()*30|0))+',70)';
+          pxC(c,nx,ny,colr);
+        }
+      }
+    }
+  };
+}
+function tileGrassSide(){
+  return function(c){
+    const rng=mulberry32(0x51de);
+    for(let y=0;y<TILE;y++)for(let x=0;x<TILE;x++){
+      if(y<3) nz(c,x,y,[96,158,58],28,rng);
+      else if(y===3){ if(rng()<0.6) nz(c,x,y,[96,158,58],28,rng); else nz(c,x,y,[134,96,67],30,rng); }
+      else nz(c,x,y,[134,96,67],30,rng);
+    }
+  };
+}
+function tileWoodSide(){
+  return function(c){
+    const rng=mulberry32(0x70d1);
+    for(let y=0;y<TILE;y++){
+      const shade=(rng()-0.5)*44;
+      for(let x=0;x<TILE;x++){
+        const k=(rng()-0.5)*16;
+        pxC(c,x,y,'rgb('+Math.round(clamp(148+shade+k,0,255))+','+
+          Math.round(clamp(112+shade+k,0,255))+','+Math.round(clamp(74+shade+k,0,255))+')');
+      }
+    }
+    for(let i=0;i<3;i++){
+      const x=(rng()*TILE)|0;
+      for(let y=0;y<TILE;y++) pxC(c,x,y,'rgb(96,70,44)');
+    }
+  };
+}
+function tileWoodTop(){
+  return function(c){
+    const rng=mulberry32(0x22c4);
+    for(let y=0;y<TILE;y++)for(let x=0;x<TILE;x++){
+      const d=Math.max(Math.abs(x-7.5),Math.abs(y-7.5))|0;
+      const ring=(d%4<2)?0:-14;
+      const v=(rng()-0.5)*26+ring;
+      pxC(c,x,y,'rgb('+Math.round(clamp(166+v,0,255))+','+
+        Math.round(clamp(128+v,0,255))+','+Math.round(clamp(84+v,0,255))+')');
+    }
+    for(let y=6;y<10;y++)for(let x=6;x<10;x++)
+      pxC(c,x,y,'rgb(128,96,60)');
+  };
+}
+function tileLeaves(){
+  return function(c){
+    c.clearRect(0,0,TILE,TILE);
+    const rng=mulberry32(0x1eaf);
+    for(let y=0;y<TILE;y++)for(let x=0;x<TILE;x++){
+      if(rng()<0.16) continue; /* 镂空 */
+      const v=(rng()-0.5)*40;
+      const dark=(rng()<0.22)?-26:0;
+      pxC(c,x,y,'rgb('+Math.round(clamp(52+v+dark,0,255))+','+
+        Math.round(clamp(118+v+dark,0,255))+','+Math.round(clamp(44+v+dark,0,255))+')');
+    }
+  };
+}
+function tilePlanks(){
+  return function(c){
+    const rng=mulberry32(0x9b3c);
+    for(let y=0;y<TILE;y++)for(let x=0;x<TILE;x++){
+      const row=(y/4)|0, seam=(y%4===0)?-30:0;
+      const v=(rng()-0.5)*24+seam;
+      pxC(c,x,y,'rgb('+Math.round(clamp(172+v,0,255))+','+
+        Math.round(clamp(130+v,0,255))+','+Math.round(clamp(84+v,0,255))+')');
+    }
+  };
+}
+function tileWater(){
+  return function(c){
+    const rng=mulberry32(0x0fce);
+    for(let y=0;y<TILE;y++)for(let x=0;x<TILE;x++){
+      const sparkle=(rng()<0.08)?46:0;
+      const v=(rng()-0.5)*30+sparkle;
+      pxC(c,x,y,'rgb('+Math.round(clamp(50+v,0,255))+','+
+        Math.round(clamp(118+v,0,255))+','+Math.round(clamp(192+v,0,255))+')');
+    }
+  };
+}
+function tileCobble(){
+  return function(c){
+    const rng=mulberry32(0xcb11);
+    for(let y=0;y<TILE;y++)for(let x=0;x<TILE;x++)
+      pxC(c,x,y,'rgb(68,70,78)');
+    for(let i=0;i<9;i++){
+      const cx=(rng()*TILE)|0, cy=(rng()*TILE)|0;
+      const r=2+(rng()*2|0);
+      const base=105+(rng()*34|0);
+      for(let dy=-r;dy<=r;dy++)for(let dx=-r;dx<=r;dx++){
+        if(dx*dx+dy*dy>r*r) continue;
+        const x=cx+dx, y=cy+dy;
+        if(x<0||y<0||x>=TILE||y>=TILE) continue;
+        const v=(rng()-0.5)*18;
+        pxC(c,x,y,'rgb('+Math.round(clamp(base+v,0,255))+','+
+          Math.round(clamp(base+v,0,255))+','+Math.round(clamp(base+v+8,0,255))+')');
+      }
+    }
+  };
+}
+function tileBedrock(){
+  return function(c){
+    const rng=mulberry32(0xbe40);
+    for(let y=0;y<TILE;y++)for(let x=0;x<TILE;x++){
+      const v=(rng()-0.5)*40-14;
+      pxC(c,x,y,'rgb('+Math.round(clamp(74+v,0,255))+','+
+        Math.round(clamp(72+v,0,255))+','+Math.round(clamp(80+v,0,255))+')');
+    }
+    for(let i=0;i<7;i++){
+      const cx=(rng()*TILE)|0, cy=(rng()*TILE)|0;
+      for(let dy=-1;dy<=1;dy++)for(let dx=-1;dx<=1;dx++){
+        const x=cx+dx,y=cy+dy;
+        if(x<0||y<0||x>=TILE||y>=TILE) continue;
+        pxC(c,x,y,'rgb(28,28,34)');
+      }
+    }
+  };
+}
+function tileCrystal(){
+  return function(c){
+    c.clearRect(0,0,TILE,TILE);
+    const rng=mulberry32(0x5a1f);
+    for(let y=0;y<TILE;y++)for(let x=0;x<TILE;x++){
+      if(rng()<0.18) continue;
+      const facet=(x+y)%8<4?0:30;
+      const v=(rng()-0.5)*26+facet;
+      pxC(c,x,y,'rgba('+Math.round(clamp(150+v,0,255))+','+
+        Math.round(clamp(225+v,0,255))+','+Math.round(clamp(255+v,0,255))+',0.78)');
+    }
+  };
+}
+function tileGold(){
+  return function(c){
+    const rng=mulberry32(0xa7e3);
+    for(let y=0;y<TILE;y++)for(let x=0;x<TILE;x++){
+      const v=(rng()-0.5)*26;
+      pxC(c,x,y,'rgb('+Math.round(clamp(126+v,0,255))+','+
+        Math.round(clamp(126+v,0,255))+','+Math.round(clamp(130+v,0,255))+')');
+    }
+    for(let i=0;i<5;i++){
+      const cx=(rng()*TILE)|0, cy=(rng()*TILE)|0;
+      for(let dy=-1;dy<=1;dy++)for(let dx=-1;dx<=1;dx++){
+        const x=cx+dx,y=cy+dy;
+        if(x<0||y<0||x>=TILE||y>=TILE) continue;
+        const v=(rng()-0.5)*20;
+        pxC(c,x,y,'rgb('+Math.round(clamp(224+v,0,255))+','+
+          Math.round(clamp(186+v,0,255))+','+Math.round(clamp(64+v,0,255))+')');
+      }
+    }
+  };
+}
+/* 按固定顺序注册贴图，保证序号稳定 */
+newTile('gTop',   tilePainter([100,166,60],26));
+newTile('gSide',  tileGrassSide());
+newTile('dirt',   tilePainter([134,96,67],30));
+newTile('stone',  tilePainter([127,127,130],24));
+newTile('cobble', tileCobble());
+newTile('sbrick', tileBrick([95,95,102],[140,140,148],16,false));
+newTile('mbrick', tileBrick([95,95,102],[134,134,142],16,true));
+newTile('sand',   tilePainter([219,206,158],18));
+newTile('wSide',  tileWoodSide());
+newTile('wTop',   tileWoodTop());
+newTile('leaves', tileLeaves());
+newTile('planks', tilePlanks());
+newTile('water',  tileWater());
+newTile('snow',   tilePainter([240,244,250],9));
+newTile('bedrock',tileBedrock());
+newTile('brick',  tileBrick([110,70,58],[150,74,58],18,false));
+newTile('crystal',tileCrystal());
+newTile('gold',   tileGold());
+const blockTex=new THREE.CanvasTexture(atlasCv);
+blockTex.magFilter=THREE.NearestFilter;
+blockTex.minFilter=THREE.NearestFilter;
+blockTex.generateMipmaps=false;
+
+/* ==================== 方块定义 ==================== */
+const AIR=0,GRASS=1,DIRT=2,STONE=3,COBBLE=4,SBRICK=5,MBRICK=6,SAND=7,
+      WOOD=8,LEAVES=9,PLANKS=10,WATER=11,SNOW=12,BEDROCK=13,BRICK=14,CRYSTAL=15,GOLD=16;
+const BLOCKS=[
+  null,
+  {n:'草方块', t:'gTop',  tint:true },
+  {n:'泥土',   t:'dirt' },
+  {n:'石头',   t:'stone' },
+  {n:'圆石',   t:'cobble' },
+  {n:'石砖',   t:'sbrick' },
+  {n:'苔石砖', t:'mbrick' },
+  {n:'沙子',   t:'sand' },
+  {n:'橡木原木',t:'wSide' },
+  {n:'树叶',   t:'leaves', tint:true },
+  {n:'橡木木板',t:'planks' },
+  {n:'水',     t:'water' },
+  {n:'雪方块', t:'snow' },
+  {n:'基岩',   t:'bedrock' },
+  {n:'红砖',   t:'brick' },
+  {n:'魔水晶', t:'crystal' },
+  {n:'金矿',   t:'gold' },
+];
+function blockName(b){ return BLOCKS[b]?BLOCKS[b].n:'空气'; }
+function tileFor(b,f){
+  if(b===GRASS) return f===2?'gTop':(f===3?'dirt':'gSide');
+  if(b===WOOD)  return (f===2||f===3)?'wTop':'wSide';
+  return BLOCKS[b].t;
+}
+function uvRect(name){
+  const i=TILES[name];
+  const x0=(i%ATLAS_N)*TILE, y0=((i/ATLAS_N)|0)*TILE;
+  return [x0/ATLAS, 1-(y0+TILE)/ATLAS, (x0+TILE)/ATLAS, 1-y0/ATLAS];
+}
+/* ==================== 世界数据 ==================== */
+const CHUNK=16, H=96;          /* 区块边长 / 世界高度 */
+const SEA=26;                  /* 海平面 */
+const chunks=new Map();        /* "cx,cz" -> chunk */
+function ckey(cx,cz){ return cx+','+cz; }
+function chunkAt(cx,cz){
+  const k=ckey(cx,cz);
+  let c=chunks.get(k);
+  if(!c){
+    c={x:cx,z:cz,data:new Uint8Array(CHUNK*H*CHUNK),gen:false,dirty:false,
+       mesh:null,wmesh:null,meshMat:null};
+    chunks.set(k,c);
+  }
+  return c;
+}
+function bIdx(x,y,z){ return (y*CHUNK+z)*CHUNK+x; }
+function getBlock(x,y,z){
+  if(y<0) return BEDROCK;
+  if(y>=H) return AIR;
+  const c=chunkAt(Math.floor(x/CHUNK),Math.floor(z/CHUNK));
+  return c.data[bIdx(x&15,y,z&15)];
+}
+function setBlock(x,y,z,b){
+  if(y<0||y>=H) return;
+  const c=chunkAt(Math.floor(x/CHUNK),Math.floor(z/CHUNK));
+  c.data[bIdx(x&15,y,z&15)]=b;
+  c.dirty=true;
+  /* 边界相邻区块也标记 */
+  const lx=x&15, lz=z&15;
+  if(lx===0)  { const n=chunkAt(Math.floor(x/CHUNK)-1,Math.floor(z/CHUNK)); n.dirty=true; }
+  if(lx===15){ const n=chunkAt(Math.floor(x/CHUNK)+1,Math.floor(z/CHUNK)); n.dirty=true; }
+  if(lz===0)  { const n=chunkAt(Math.floor(x/CHUNK),Math.floor(z/CHUNK)-1); n.dirty=true; }
+  if(lz===15){ const n=chunkAt(Math.floor(x/CHUNK),Math.floor(z/CHUNK)+1); n.dirty=true; }
+}
+function isSolid(b){ return b!==AIR && b!==WATER; }
+function isTransparent(b){ return b===AIR || b===WATER || b===LEAVES || b===CRYSTAL; }
+
+/* ==================== 地形生成 ==================== */
+const BIOME_PLAINS=0,BIOME_FOREST=1,BIOME_DESERT=2,BIOME_SNOW=3,BIOME_SWAMP=4,BIOME_MOUNTAIN=5;
+const BIOME_NAMES=['平原','森林','沙漠','雪原','沼泽','群山'];
+function biomeAt(x,z){
+  const h=heightAt(x,z);
+  if(h>58) return BIOME_SNOW;
+  if(h>46) return BIOME_MOUNTAIN;
+  const t=fbm(x*0.0022+31.7,z*0.0022-19.3,3,2.0,0.5);
+  const m=fbm(x*0.0026-57.1,z*0.0026+23.4,3,2.0,0.5);
+  if(t>0.34&&m<-0.12) return BIOME_DESERT;
+  if(m>0.42&&t<0.2)   return BIOME_SWAMP;
+  if(m>0.16)          return BIOME_FOREST;
+  return BIOME_PLAINS;
+}
+function heightAt(x,z){
+  const cont=fbm(x*0.0016,z*0.0016,4,2.1,0.5);                       /* 大陆 */
+  const mount=Math.pow(Math.max(0,fbm(x*0.004+91.7,z*0.004-37.9,4,2.0,0.5)),1.7);
+  const rough=clamp((fbm(x*0.0012+7.3,z*0.0012-13.9,2,2.0,0.5)+1)*0.5,0,1);
+  let h=20+cont*16+mount*52*rough;
+  return Math.floor(clamp(h,3,H-10));
+}
+function topBlockFor(h,biome){
+  if(biome===BIOME_DESERT) return h<=SEA+1?SAND:SAND;
+  if(biome===BIOME_SNOW||biome===BIOME_MOUNTAIN) return SNOW;
+  if(h<=SEA+1) return SAND;
+  return GRASS;
+}
+function grassTintAt(x,z){
+  const b=biomeAt(x,z);
+  switch(b){
+    case BIOME_FOREST: return [0.45,0.78,0.34];
+    case BIOME_SWAMP:  return [0.5,0.7,0.42];
+    case BIOME_DESERT: return [0.9,0.85,0.55];
+    case BIOME_SNOW: case BIOME_MOUNTAIN: return [0.82,0.9,0.85];
+    default: return [0.78,0.92,0.55];
+  }
+}
+function genChunk(cx,cz){
+  const c=chunkAt(cx,cz);
+  if(c.gen) return;
+  c.gen=true;
+  const data=c.data;
+  for(let lx=0;lx<CHUNK;lx++)for(let lz=0;lz<CHUNK;lz++){
+    const wx=cx*CHUNK+lx, wz=cz*CHUNK+lz;
+    const h=heightAt(wx,wz), bio=biomeAt(wx,wz);
+    const top=topBlockFor(h,bio);
+    for(let y=0;y<H;y++){
+      let b=AIR;
+      if(y===0) b=BEDROCK;
+      else if(y<3&&hash2(wx,y,wz)<0.6) b=BEDROCK;
+      else if(y<h-4) b=STONE;
+      else if(y<h-1) b=DIRT;
+      else if(y===h) b=top;
+      else if(y<=SEA) b=WATER;
+      data[bIdx(lx,y,lz)]=b;
+    }
+    /* 植被与装饰 */
+    const rnd=hash2(wx,wz,77);
+    if(rnd<0.05&&bio===BIOME_FOREST) placeTree(wx,h+1,wz);
+    else if(rnd<0.085&&bio===BIOME_FOREST) placeTree(wx,h+1,wz);
+    else if(rnd<0.02&&bio===BIOME_PLAINS) placeTree(wx,h+1,wz);
+    else if(rnd<0.012&&bio===BIOME_DESERT) placeCactus(wx,h+1,wz);
+    else if(rnd<0.02&&bio===BIOME_SNOW) placeRock(wx,h+1,wz);
+  }
+}
+function placeTree(x,y,z){
+  const hgt=4+((hash2(x,z,12)*3)|0);
+  for(let i=0;i<hgt;i++) setBlock(x,y+i,z,WOOD);
+  const top=y+hgt;
+  for(let dy=-2;dy<=1;dy++){
+    const r=dy>=0?2:2;
+    for(let dx=-r;dx<=r;dx++)for(let dz=-r;dz<=r;dz++){
+      if(dx*dx+dz*dz>r*r+1) continue;
+      if(dx===0&&dz===0&&dy<0) continue;
+      setBlock(x+dx,top+dy,z+dz,LEAVES);
+    }
+  }
+  setBlock(x,top+1,z,LEAVES);
+  setBlock(x,top+2,z,LEAVES);
+}
+function placeCactus(x,y,z){
+  const hgt=2+((hash2(x,z,34)*2)|0);
+  for(let i=0;i<hgt;i++) setBlock(x,y+i,z,WOOD);
+}
+function placeRock(x,y,z){
+  setBlock(x,y,z,STONE);
+  setBlock(x+1,y,z,STONE);
+  setBlock(x,y,z+1,STONE);
+  setBlock(x,y+1,z,STONE);
+}
+function surfaceH(x,z){
+  const h=heightAt(x,z);
+  return Math.max(h,SEA);
+}
+function ensureChunk(cx,cz){
+  const c=chunkAt(cx,cz);
+  if(!c.gen) genChunk(cx,cz);
+  return c;
+}
+function ensureArea(x0,z0,x1,z1){
+  for(let cx=Math.floor(x0/CHUNK);cx<=Math.floor(x1/CHUNK);cx++)
+    for(let cz=Math.floor(z0/CHUNK);cz<=Math.floor(z1/CHUNK);cz++)
+      ensureChunk(cx,cz);
+}
+/* ==================== 神话建筑 ==================== */
+function sBox(x0,y0,z0,x1,y1,z1,b){
+  for(let x=x0;x<=x1;x++)for(let y=y0;y<=y1;y++)for(let z=z0;z<=z1;z++)
+    setBlock(x,y,z,b);
+}
+function sCol(x,y0,y1,z,b){
+  for(let y=y0;y<=y1;y++) setBlock(x,y,z,b);
+}
+function flattenArea(ox,oz,size,fh){
+  for(let dx=-size;dx<=size;dx++)for(let dz=-size;dz<=size;dz++){
+    const x=ox+dx,z=oz+dz;
+    const h=surfaceH(x,z);
+    for(let y=h;y>fh;y--) setBlock(x,y,z,AIR);
+    for(let y=h+1;y<=fh;y++) setBlock(x,y,z,DIRT);
+    if(surfaceH(x,z)<fh) setBlock(x,fh,z,GRASS);
+    else setBlock(x,fh,z,GRASS);
+  }
+}
+function crenellate(x0,z0,x1,z1,fh,b){
+  for(let x=x0;x<=x1;x++){
+    if((x-x0)%2===0) setBlock(x,fh+1,z0,b);
+    if((x-x0)%2===0) setBlock(x,fh+1,z1,b);
+  }
+  for(let z=z0;z<=z1;z++){
+    if((z-z0)%2===0) setBlock(x0,fh+1,z,b);
+    if((z-z0)%2===0) setBlock(x1,fh+1,z,b);
+  }
+}
+/* ---- 龙辉堡 · 王城 (0,0) ---- */
+function buildCastle(){
+  const fh=surfaceH(0,0)+1;
+  flattenArea(0,0,26,fh);
+  const half=20;
+  /* 外墙 */
+  for(let x=-half;x<=half;x++){ sCol(x,fh,fh+3,-half,SBRICK); sCol(x,fh,fh+3,half,SBRICK); }
+  for(let z=-half;z<=half;z++){ sCol(-half,fh,fh+3,z,SBRICK); sCol(half,fh,fh+3,z,SBRICK); }
+  crenellate(-half,-half,half,half,fh+3,SBRICK);
+  /* 城门（南侧）+ 门楼 */
+  for(let z=half;z>=half-1;z--){ setBlock(-1,fh,z,AIR); setBlock(0,fh,z,AIR); setBlock(1,fh,z,AIR); }
+  setBlock(0,fh+2,half,BRICK); setBlock(-1,fh+1,half,BRICK); setBlock(1,fh+1,half,BRICK);
+  sBox(-1,fh+1,half+1, 1,fh+3,half+1, SBRICK);
+  setBlock(0,fh+3,half+1,BRICK);
+  /* 四角塔楼 */
+  const corners=[[-half,-half],[-half,half],[half,-half],[half,half]];
+  for(const [tx,tz] of corners){
+    sBox(tx-2,fh,tz-2, tx+2,fh+6,tz+2, SBRICK);
+    sBox(tx-3,fh+6,tz-3, tx+3,fh+6,tz+3, SBRICK);
+    sBox(tx-2,fh+7,tz-2, tx+2,fh+7,tz+2, SBRICK);
+    sBox(tx-1,fh+8,tz-1, tx+1,fh+8,tz+1, BRICK);
+    setBlock(tx,fh+9,tz,CRYSTAL);
+  }
+  /* 主殿 */
+  sBox(-8,fh, -6, 8,fh+5,6, SBRICK);
+  sBox(-8,fh+5,-6, 8,fh+6,6, SBRICK);
+  crenellate(-8,-6,8,6,fh+5,SBRICK);
+  for(let x=-6;x<=6;x+=3) setBlock(x,fh+6,-6,CRYSTAL);
+  /* 主殿大门与金窗 */
+  for(let y=fh;y<=fh+2;y++) setBlock(0,y,6,AIR);
+  setBlock(0,fh+3,6,BRICK);
+  for(let y=fh+2;y<=fh+4;y++){ setBlock(-6,y,6,GOLD); setBlock(6,y,6,GOLD); }
+  /* 中央水晶塔尖 */
+  sCol(0,fh+7,fh+10,CRYSTAL);
+  /* 庭院喷泉 */
+  for(let dx=-3;dx<=3;dx++)for(let dz=-3;dz<=3;dz++){
+    setBlock(dx,fh-1,dz,WATER);
+    setBlock(dx,fh,dz,AIR);
+  }
+  for(let x=-4;x<=4;x++){
+    setBlock(x,fh,-4,SBRICK); setBlock(x,fh,4,SBRICK);
+    setBlock(-4,fh,x,SBRICK); setBlock(4,fh,x,SBRICK);
+  }
+  setBlock(0,fh,0,CRYSTAL);
+}
+/* ---- 远古神庙 (-150,100) ---- */
+function buildTemple(ox,oz){
+  const fh=surfaceH(ox,oz)+1;
+  flattenArea(ox,oz,20,fh);
+  for(let k=0;k<4;k++){
+    const s=11-k*2;
+    sBox(ox-s,fh+k*3,oz-s, ox+s,fh+k*3+2,oz+s, k%2?SBRICK:MBRICK);
+    if(k>0) sBox(ox-s,fh+k*3-1,oz-s, ox+s,fh+k*3-1,oz+s, MBRICK);
+  }
+  sBox(ox-11,fh-1,oz-11, ox+11,fh-1,oz+11, COBBLE);
+  /* 正面台阶 */
+  for(let i=0;i<6;i++) sBox(ox-2,fh+i,oz+11-i, ox+2,fh+i,oz+11-i, PLANKS);
+  /* 顶层祭坛 */
+  sBox(ox-1,fh+12,oz-1, ox+1,fh+12,oz+1, GOLD);
+  sCol(ox,fh+13,fh+16,CRYSTAL);
+  /* 四角金饰 */
+  for(const dx of [-11,11])for(const dz of [-11,11])
+    setBlock(ox+dx,fh+2,oz+dz,GOLD);
+}
+/* ---- 世界之树 (210,-90) ---- */
+function buildWorldTree(ox,oz){
+  const fh=surfaceH(ox,oz)+1;
+  flattenArea(ox,oz,10,fh);
+  const th=26;
+  /* 主干 */
+  for(let y=0;y<th;y++){
+    const r=(y<6)?2:(y<18?1:1);
+    sBox(ox-r,fh+y,oz-r, ox+r,fh+y,oz+r, WOOD);
+  }
+  /* 根部隆起 */
+  for(let dx=-4;dx<=4;dx++)for(let dz=-4;dz<=4;dz++){
+    const d=dx*dx+dz*dz;
+    if(d<10) setBlock(ox+dx,fh,oz+dz,WOOD);
+    else if(d<17&&hash2(ox+dx,oz+dz,5)<0.6) setBlock(ox+dx,fh,oz+dz,WOOD);
+  }
+  /* 枝干 */
+  const br=[[6,2],[0,6],[-6,2],[0,-6],[4,4],[-4,-4],[4,-4],[-4,4]];
+  for(const [bx,bz] of br){
+    const sy=fh+th-6+((bx===0&&bz===0)?0:2);
+    const x0a=ox+Math.min(bx,bx*2), x1a=ox+Math.max(bx,bx*2);
+    const z0a=oz+Math.min(bz,bz*2), z1a=oz+Math.max(bz,bz*2);
+    sBox(x0a,sy,z0a, x1a,sy,z1a, WOOD);
+  }
+  /* 巨型树冠 */
+  for(let dy=0;dy<9;dy++){
+    const r=dy<3?7:(dy<6?5:3);
+    for(let dx=-r;dx<=r;dx++)for(let dz=-r;dz<=r;dz++){
+      if(dx*dx+dz*dz>r*r+2) continue;
+      setBlock(ox+dx,fh+th+dy,oz+dz,LEAVES);
+    }
+  }
+  sCol(ox,fh+th+9,fh+th+12,WOOD);
+  /* 垂下的藤蔓 */
+  for(let i=0;i<7;i++){
+    const a=hash2(ox+i,oz,61)*TAU;
+    const vx=Math.round(Math.cos(a)*6), vz=Math.round(Math.sin(a)*6);
+    const len=2+((hash2(ox+vx,oz+vz,8)*3)|0);
+    for(let l=1;l<=len;l++) setBlock(ox+vx,fh+th+5-l,oz+vz,LEAVES);
+  }
+}
+/* ---- 水晶尖塔 (180,170) ---- */
+function buildSpire(ox,oz){
+  const fh=surfaceH(ox,oz)+1;
+  flattenArea(ox,oz,8,fh);
+  sBox(ox-2,fh,oz-2, ox+2,fh+2,oz+2, STONE);
+  sBox(ox-1,fh+3,oz-1, ox+1,fh+4,oz+1, STONE);
+  for(let y=5;y<22;y++){
+    setBlock(ox,y+fh,oz,CRYSTAL);
+    if(y%3===0){ setBlock(ox+1,y+fh,oz,CRYSTAL); setBlock(ox-1,y+fh,oz,CRYSTAL); }
+    if(y%3===1){ setBlock(ox,y+fh,oz+1,CRYSTAL); setBlock(ox,y+fh,oz-1,CRYSTAL); }
+  }
+  sCol(ox,fh+22,fh+25,CRYSTAL);
+  for(let i=0;i<6;i++){
+    const a=hash2(ox,oz+i,23)*TAU;
+    const rx=ox+Math.round(Math.cos(a)*4), rz=oz+Math.round(Math.sin(a)*4);
+    sCol(rx,fh,fh+2,CRYSTAL);
+  }
+}
+/* ---- 浮空岛 (-70,230) ---- */
+function buildFloatingIsland(ox,oz){
+  const cy=86;
+  for(let dx=-8;dx<=8;dx++)for(let dz=-8;dz<=8;dz++){
+    const d2=dx*dx+dz*dz;
+    if(d2>64) continue;
+    const prof=Math.floor((8-Math.sqrt(d2))*0.62);
+    if(prof<=0) continue;
+    const top=cy+prof;
+    for(let y=0;y<=prof;y++){
+      const b=y===prof?GRASS:(y>=prof-1?DIRT:(d2<20?STONE:COBBLE));
+      setBlock(ox+dx,top-y,oz+dz,b);
+    }
+    if(d2>46&&hash2(ox+dx,oz+dz,3)<0.5)
+      for(let l=1;l<=2;l++) setBlock(ox+dx,cy-l,oz+dz,LEAVES);
+  }
+  /* 顶部水潭 */
+  sBox(ox-2,cy+2,oz-2, ox+2,cy+2,oz+2, WATER);
+  sBox(ox-3,cy+1,oz-3, ox+3,cy+1,oz+3, STONE);
+  /* 水晶簇 */
+  sCol(ox,cy+3,cy+5,CRYSTAL);
+  setBlock(ox+1,cy+3,oz+1,CRYSTAL);
+  setBlock(ox-1,cy+3,oz-1,CRYSTAL);
+}
+/* ---- 龙之巢穴 (90,-200) ---- */
+function buildDragonLair(ox,oz){
+  const fh=surfaceH(ox,oz)+1;
+  flattenArea(ox,oz,16,fh);
+  /* 荒丘 */
+  for(let dx=-7;dx<=7;dx++)for(let dz=-7;dz<=7;dz++){
+    const d2=dx*dx+dz*dz;
+    if(d2>49) continue;
+    const h=Math.floor((7-Math.sqrt(d2))*0.55);
+    for(let y=0;y<=h;y++)
+      setBlock(ox+dx,fh+y,oz+dz, y===h?MBRICK:COBBLE);
+  }
+  /* 龙身：沿 +z 盘曲 */
+  for(let i=0;i<14;i++){
+    const y=fh+2+((i%2)===0?1:0);
+    sBox(ox-1,y,oz-3+i, ox+1,y+1,oz-1+i, COBBLE);
+  }
+  /* 龙头（前方） */
+  sBox(ox-1,fh+4,oz+11, ox+1,fh+5,oz+13, COBBLE);
+  setBlock(ox-1,fh+4,oz+14,BRICK); setBlock(ox+1,fh+4,oz+14,BRICK);
+  setBlock(ox,fh+5,oz+13,MBRICK);
+  setBlock(ox-1,fh+5,oz+12,CRYSTAL); setBlock(ox+1,fh+5,oz+12,CRYSTAL);
+  sCol(ox,fh+6,fh+8,CRYSTAL);
+  /* 双翼 */
+  for(const s of [-1,1]){
+    for(let i=0;i<5;i++){
+      sBox(ox+s*2,fh+3+i,oz-2+i, ox+s*2,fh+3+i,oz+1+i, MBRICK);
+      if(i<3) sBox(ox+s*2,fh+4+i,oz-3, ox+s*2,fh+4+i,oz-2, MBRICK);
+    }
+  }
+  /* 四足 */
+  for(const [lx,lz] of [[-2,0],[2,0],[-1,5],[1,5]])
+    sCol(ox+lx,fh,fh+1,oz+lz);
+  /* 龙尾翘起 */
+  for(let i=0;i<4;i++){
+    const tz=oz-6-i;
+    setBlock(ox+((i%2)?1:0),fh+1+(i>1?1:0),tz,COBBLE);
+    if(i===3) setBlock(ox+1,fh+2,tz,BRICK);
+  }
+  /* 宝藏（巢穴一侧） */
+  sBox(ox+3,fh+2,oz+2, ox+5,fh+3,oz+4, GOLD);
+  setBlock(ox+6,fh+3,oz+3,CRYSTAL); setBlock(ox+3,fh+4,oz+3,CRYSTAL);
+}
+/* ---- 先民石阵 (-40,-130) ---- */
+function buildStoneCircle(ox,oz){
+  const fh=surfaceH(ox,oz)+1;
+  flattenArea(ox,oz,12,fh);
+  for(let i=0;i<8;i++){
+    const a=i/8*TAU+0.3;
+    const x=ox+Math.round(Math.cos(a)*9), z=oz+Math.round(Math.sin(a)*9);
+    const hh=3+(i%3);
+    sCol(x,fh,fh+hh,z, i%4===0?CRYSTAL:SBRICK);
+    sCol(x+1,fh,fh+hh,z, SBRICK);
+  }
+  sBox(ox-1,fh,oz-1, ox+1,fh+2,oz+1, SBRICK);
+  setBlock(ox,fh+3,oz,CRYSTAL);
+}
+/* ---- 传说遗迹总表 ---- */
+const SITES=[
+  {n:'龙辉堡 · 王城',   x:0,   z:0,   r:44, d:'传说中龙裔之王在此加冕，城头的水晶永不熄灭。'},
+  {n:'远古神庙',        x:-150,z:100, r:30, d:'台阶上刻着失传的符文，祭坛仍散发着微光。'},
+  {n:'世界之树',        x:210, z:-90, r:34, d:'诸神的树根深入大地，树冠托着整片天空。'},
+  {n:'水晶尖塔',        x:180, z:170, r:26, d:'法师们以魔晶铸成高塔，塔尖直指星辰。'},
+  {n:'浮空岛',          x:-70, z:230, r:30, d:'被遗忘的岛屿悬浮于云端，古潭依旧澄澈。'},
+  {n:'龙之巢穴',        x:90,  z:-200,r:36, d:'巨龙盘踞的荒丘，金银财宝堆满巢前。'},
+  {n:'先民石阵',        x:-40, z:-130,r:22, d:'巨石围成的圆环，每逢月夜便低吟古老祷词。'},
+];
+const siteFound={};
+function buildAllStructures(){
+  buildCastle();
+  buildTemple(-150,100);
+  buildWorldTree(210,-90);
+  buildSpire(180,170);
+  buildFloatingIsland(-70,230);
+  buildDragonLair(90,-200);
+  buildStoneCircle(-40,-130);
+}
+/* ==================== 网格构建 ==================== */
+/* 面序：+x,-x,+y,-y,+z,-z */
+const FDIRS=[[1,0,0],[-1,0,0],[0,1,0],[0,-1,0],[0,0,1],[0,0,-1]];
+const FSHADE=[0.82,0.82,1.0,0.58,0.72,0.72];
+const FCORNERS=[
+ [[.5,-.5,-.5],[.5,.5,-.5],[.5,.5,.5],[.5,-.5,.5]],
+ [[-.5,-.5,-.5],[-.5,-.5,.5],[-.5,.5,.5],[-.5,.5,-.5]],
+ [[-.5,.5,-.5],[-.5,.5,.5],[.5,.5,.5],[.5,.5,-.5]],
+ [[-.5,-.5,-.5],[.5,-.5,-.5],[.5,-.5,.5],[-.5,-.5,.5]],
+ [[-.5,-.5,.5],[.5,-.5,.5],[.5,.5,.5],[-.5,.5,.5]],
+ [[-.5,-.5,-.5],[-.5,.5,-.5],[.5,.5,-.5],[.5,-.5,-.5]],
+];
+const FUVCORN=[
+ [[0,0],[0,1],[1,1],[1,0]],   /* +x */
+ [[0,0],[1,0],[1,1],[0,1]],   /* -x */
+ [[0,1],[0,0],[1,0],[1,1]],   /* +y */
+ [[0,0],[1,0],[1,1],[0,1]],   /* -y */
+ [[0,0],[1,0],[1,1],[0,1]],   /* +z */
+ [[1,0],[1,1],[0,1],[0,0]],   /* -z */
+];
+const blockMat=new THREE.MeshLambertMaterial({ vertexColors:true, alphaTest:0.4 });
+const waterMat=new THREE.MeshLambertMaterial({
+  vertexColors:true, transparent:true, opacity:0.72, depthWrite:false
+});
+function buildChunkMesh(c){
+  if(c.mesh){ scene.remove(c.mesh); c.mesh.geometry.dispose(); c.mesh=null; }
+  if(c.wmesh){ scene.remove(c.wmesh); c.wmesh.geometry.dispose(); c.wmesh=null; }
+  const pos=[],nrm=[],uv=[],col=[],idx=[];
+  const wPos=[],wNrm=[],wUv=[],wCol=[],wIdx=[];
+  const o=0.5;
+  function emitFace(bx,by,bz,f,uvRectAr,tint,water){
+    const a=water?wPos:pos, an=water?wNrm:nrm, au=water?wUv:uv,
+          ac=water?wCol:col, ai=water?wIdx:idx;
+    const base=a.length/3;
+    const [u0,v0,u1,v1]=uvRectAr;
+    for(let k=0;k<4;k++){
+      const cn=FCORNERS[f][k], uc=FUVCORN[f][k];
+      a.push(bx+cn[0], by+cn[1], bz+cn[2]);
+      const d=FDIRS[f];
+      an.push(d[0],d[1],d[2]);
+      au.push(u0+uc[0]*(u1-u0), v0+(1-uc[1])*(v1-v0));
+      const sh=FSHADE[f];
+      ac.push(sh*tint[0], sh*tint[1], sh*tint[2]);
+    }
+    ai.push(base,base+1,base+2, base,base+2,base+3);
+  }
+  const data=c.data;
+  for(let y=0;y<H;y++)for(let lz=0;lz<CHUNK;lz++)for(let lx=0;lx<CHUNK;lx++){
+    const b=data[bIdx(lx,y,lz)];
+    if(b===AIR) continue;
+    const wx=c.x*CHUNK+lx, wz=c.z*CHUNK+lz;
+    let tint=[1,1,1];
+    if(b===GRASS||b===LEAVES){ const t=grassTintAt(wx,wz); tint=t; }
+    if(b===WATER){
+      for(let f=0;f<6;f++){
+        const nb=getBlock(wx+FDIRS[f][0], y+FDIRS[f][1], wz+FDIRS[f][2]);
+        if(f===2){ if(nb!==WATER&&nb!==AIR) continue; }
+        else if(nb!==AIR&&nb!==LEAVES&&nb!==CRYSTAL) continue;
+        if(f!==2&&nb===WATER) continue;
+        if(nb===WATER&&f===2) continue;
+        if(f===2&&nb===WATER) continue;
+        if(f===2&&nb!==AIR&&nb!==WATER) continue;
+        if(nb===WATER) continue;
+        emitFace(lx,y,lz,f,uvRect('water'),[1,1,1],true);
+      }
+      continue;
+    }
+    for(let f=0;f<6;f++){
+      const nx=lx+FDIRS[f][0], ny=y+FDIRS[f][1], nz=lz+FDIRS[f][2];
+      let nb;
+      if(nx<0||nx>=CHUNK||nz<0||nz>=CHUNK||ny<0||ny>=H)
+        nb=getBlock(wx+FDIRS[f][0], ny, wz+FDIRS[f][2]);
+      else nb=data[bIdx(nx,ny,nz)];
+      if(!isTransparent(nb)) continue;
+      emitFace(lx,y,lz,f,uvRect(tileFor(b,f)),tint,false);
+    }
+  }
+  if(idx.length){
+    const g=new THREE.BufferGeometry();
+    g.setAttribute('position',new THREE.Float32BufferAttribute(pos,3));
+    g.setAttribute('normal',new THREE.Float32BufferAttribute(nrm,3));
+    g.setAttribute('uv',new THREE.Float32BufferAttribute(uv,2));
+    g.setAttribute('color',new THREE.Float32BufferAttribute(col,3));
+    g.setIndex(idx);
+    const m=new THREE.Mesh(g,blockMat);
+    m.position.set(c.x*CHUNK,0,c.z*CHUNK);
+    m.matrixAutoUpdate=false;
+    m.updateMatrix();
+    scene.add(m);
+    c.mesh=m;
+  }
+  if(wIdx.length){
+    const g=new THREE.BufferGeometry();
+    g.setAttribute('position',new THREE.Float32BufferAttribute(wPos,3));
+    g.setAttribute('normal',new THREE.Float32BufferAttribute(wNrm,3));
+    g.setAttribute('uv',new THREE.Float32BufferAttribute(wUv,2));
+    g.setAttribute('color',new THREE.Float32BufferAttribute(wCol,3));
+    g.setIndex(wIdx);
+    const m=new THREE.Mesh(g,waterMat);
+    m.position.set(c.x*CHUNK,0,c.z*CHUNK);
+    m.matrixAutoUpdate=false;
+    m.updateMatrix();
+    m.renderOrder=1;
+    scene.add(m);
+    c.wmesh=m;
+  }
+  c.dirty=false;
+}
+const RENDER_R=4; /* 渲染半径（区块） */
+function updateChunks(budget){
+  const pcx=Math.floor(player.x/CHUNK), pcz=Math.floor(player.z/CHUNK);
+  const loaded=new Set();
+  let built=0;
+  for(let dx=-RENDER_R;dx<=RENDER_R;dx++)for(let dz=-RENDER_R;dz<=RENDER_R;dz++){
+    const cx=pcx+dx, cz=pcz+dz;
+    loaded.add(ckey(cx,cz));
+    const c=ensureChunk(cx,cz);
+    if(!c.mesh&&!c.wmesh&&built<budget){
+      buildChunkMesh(c);
+      built++;
+    }
+  }
+  for(const [k,c] of chunks){
+    if(!loaded.has(k)&&(c.mesh||c.wmesh)){
+      if(c.mesh){ scene.remove(c.mesh); c.mesh.geometry.dispose(); c.mesh=null; }
+      if(c.wmesh){ scene.remove(c.wmesh); c.wmesh.geometry.dispose(); c.wmesh=null; }
+      c.dirty=false;
+    }
+  }
+}
+function flushDirty(limit){
+  let n=0;
+  for(const c of chunks.values()){
+    if(c.dirty&&(c.mesh||c.wmesh)){
+      buildChunkMesh(c);
+      if(++n>=limit) return;
+    }
+  }
+}
+/* ==================== 玩家与物理 ==================== */
+const player={
+  x:0, y:0, z:0, vx:0, vy:0, vz:0,
+  yaw:0, pitch:-0.12, onGround:false, fly:false,
+  half:0.3, hgt:1.8
+};
+const keys={};
+const KEYMAP={ KeyW:'w',KeyA:'a',KeyS:'s',KeyD:'d',Space:'space',
+  ShiftLeft:'shift',ShiftRight:'shift',KeyF:'f',KeyR:'r',KeyT:'t' };
+function solidAt(x,y,z){
+  if(y<0) return true;
+  if(y>=H) return false;
+  return isSolid(getBlock(Math.floor(x),Math.floor(y),Math.floor(z)));
+}
+function moveAxis(i,dt){
+  const p=player;
+  const v=[p.vx,p.vy,p.vz];
+  if(i===0) p.x+=v[0]*dt;
+  else if(i===1) p.y+=v[1]*dt;
+  else p.z+=v[2]*dt;
+  const h=p.half, hh=p.hgt/2;
+  const x0=Math.floor(p.x-h), x1=Math.floor(p.x+h);
+  const y0=Math.floor(p.y-hh), y1=Math.floor(p.y+hh);
+  const z0=Math.floor(p.z-h), z1=Math.floor(p.z+h);
+  for(let bx=x0;bx<=x1;bx++)for(let by=y0;by<=y1;by++)for(let bz=z0;bz<=z1;bz++){
+    if(!solidAt(bx,by,bz)) continue;
+    if(i===0){
+      if(v[0]>0) p.x=Math.min(p.x,bx-h-0.5);
+      else if(v[0]<0) p.x=Math.max(p.x,bx+h+0.5);
+      p.vx=0;
+    }else if(i===1){
+      if(v[1]>0){ p.y=Math.min(p.y,by-hh-0.5); p.vy=0; }
+      else{ p.y=Math.max(p.y,by+hh+0.5); p.vy=0; p.onGround=true; }
+    }else{
+      if(v[2]>0) p.z=Math.min(p.z,bz-h-0.5);
+      else if(v[2]<0) p.z=Math.max(p.z,bz+h+0.5);
+      p.vz=0;
+    }
+  }
+}
+function inWater(){
+  const p=player;
+  return getBlock(Math.floor(p.x),Math.floor(p.y+p.hgt*0.4),Math.floor(p.z))===WATER;
+}
+function respawn(){
+  const p=player;
+  const sx=0, sz=26;
+  p.x=sx; p.z=sz;
+  p.y=surfaceH(sx,sz)+1.2;
+  p.vx=p.vy=p.vz=0;
+  p.yaw=0; p.pitch=-0.12;
+  p.fly=false;
+}
+function updatePlayer(dt){
+  const p=player;
+  const fwd=(keys.w?1:0)-(keys.s?1:0);
+  const strafe=(keys.d?1:0)-(keys.a?1:0);
+  const spd=4.4*(keys.shift?1.5:1);
+  const sy=Math.sin(p.yaw), cy=Math.cos(p.yaw);
+  const vx=(-sy*fwd+cy*strafe)*spd;
+  const vz=(-cy*fwd-sy*strafe)*spd;
+  if(p.fly){
+    const vs=10.5;
+    p.vx=vx; p.vz=vz;
+    p.vy=(keys.space?vs:0)-(keys.shift?vs:0);
+    p.onGround=false;
+  }else{
+    const w=inWater();
+    p.vx=vx; p.vz=vz;
+    if(w){
+      p.vy-=7*dt;
+      p.vy=clamp(p.vy,-4,7);
+      if(keys.space) p.vy=4.8;
+    }else{
+      p.vy-=26*dt;
+      if(p.vy<-46) p.vy=-46;
+      if(keys.space&&p.onGround){ p.vy=9.4; p.onGround=false; }
+    }
+  }
+  p.onGround=false;
+  moveAxis(1,dt);
+  moveAxis(0,dt);
+  moveAxis(2,dt);
+  if(p.y<-24) respawn();
+}
+function updateCamera(){
+  const p=player;
+  camera.position.set(p.x, p.y+p.hgt*0.9, p.z);
+  camera.rotation.y=p.yaw;
+  camera.rotation.x=p.pitch;
+}
+
+/* ==================== 输入 ==================== */
+let pointerLocked=false;
+document.addEventListener('keydown',e=>{
+  const k=KEYMAP[e.code];
+  if(!k) return;
+  keys[k]=true;
+  if(k==='f'){ player.fly=!player.fly; toast('飞行模式 '+(player.fly?'开启':'关闭'), player.fly?'空格上升 · Shift 下降':'按 F 再次开启'); }
+  if(k==='r') respawn();
+  if(k==='t') tOfDay=(tOfDay+0.16)%1;
+  if(e.code>='Digit1'&&e.code<='Digit9'){
+    const i=+e.code.slice(5)-1;
+    if(i<HOTBAR.length){ selSlot=i; updateHotbar(); }
+  }
+});
+document.addEventListener('keyup',e=>{
+  const k=KEYMAP[e.code];
+  if(k) keys[k]=false;
+});
+document.addEventListener('mousemove',e=>{
+  if(!pointerLocked) return;
+  player.yaw-=e.movementX*0.0023;
+  player.pitch=clamp(player.pitch-e.movementY*0.0023,-1.55,1.55);
+});
+document.addEventListener('pointerlockchange',()=>{
+  pointerLocked=(document.pointerLockElement===renderer.domElement);
+  if(!pointerLocked){
+    bootEl.style.display='flex';
+    bootEl.classList.remove('hide');
+    btnStart.textContent='继 续 冒 险';
+    bootTip.textContent='鼠标指针已释放 · 点击按钮继续';
+  }
+});
+document.addEventListener('contextmenu',e=>e.preventDefault());
+renderer.domElement.addEventListener('click',()=>{
+  if(!pointerLocked) renderer.domElement.requestPointerLock();
+});
+
+/* ==================== 方块交互（射线拾取） ==================== */
+const HL_MAX=6;
+function raycastBlock(){
+  const o=camera.position;
+  const d=new THREE.Vector3();
+  camera.getWorldDirection(d);
+  let x=Math.floor(o.x), y=Math.floor(o.y), z=Math.floor(o.z);
+  const sX=d.x>0?1:-1, sY=d.y>0?1:-1, sZ=d.z>0?1:-1;
+  const tDX=Math.abs(1/d.x), tDY=Math.abs(1/d.y), tDZ=Math.abs(1/d.z);
+  let tMX=(sX>0?(x+1-o.x):(o.x-x))*tDX;
+  let tMY=(sY>0?(y+1-o.y):(o.y-y))*tDY;
+  let tMZ=(sZ>0?(z+1-o.z):(o.z-z))*tDZ;
+  let px=x,py=y,pz=z, t=0;
+  for(let i=0;i<80;i++){
+    if(t>HL_MAX) break;
+    const b=getBlock(x,y,z);
+    if(b!==AIR&&b!==WATER) return {x,y,z,px,py,pz};
+    px=x;py=y;pz=z;
+    if(tMX<tMY&&tMX<tMZ){ x+=sX; t=tMX; tMX+=tDX; }
+    else if(tMY<tMZ){ y+=sY; t=tMY; tMY+=tDY; }
+    else{ z+=sZ; t=tMZ; tMZ+=tDZ; }
+  }
+  return null;
+}
+const hlGeo=new THREE.EdgesGeometry(new THREE.BoxGeometry(1.002,1.002,1.002));
+const hlMat=new THREE.LineBasicMaterial({ color:0x141414, transparent:true, opacity:0.8 });
+const highlight=new THREE.LineSegments(hlGeo,hlMat);
+highlight.visible=false;
+scene.add(highlight);
+
+let selSlot=0;
+const HOTBAR=[GRASS,DIRT,STONE,COBBLE,SBRICK,WOOD,PLANKS,SAND,CRYSTAL];
+document.addEventListener('mousedown',e=>{
+  if(!pointerLocked) return;
+  const hit=raycastBlock();
+  if(!hit) return;
+  if(e.button===0){
+    if(getBlock(hit.x,hit.y,hit.z)!==BEDROCK){
+      setBlock(hit.x,hit.y,hit.z,AIR);
+    }
+  }else if(e.button===2){
+    const b=HOTBAR[selSlot];
+    const bx=hit.px, by=hit.py, bz=hit.pz;
+    if(getBlock(bx,by,bz)!==AIR||by<=0||by>=H) return;
+    const p=player;
+    const cx=bx+0.5, cz=bz+0.5;
+    if(cx>p.x-p.half&&cx<p.x+p.half&&cz>p.z-p.half&&cz<p.z+p.half&&
+       by+0.5>p.y&&by+0.5<p.y+p.hgt) return;
+    setBlock(bx,by,bz,b);
+  }
+});
+document.addEventListener('wheel',e=>{
+  if(!pointerLocked) return;
+  selSlot=(selSlot+(e.deltaY>0?1:HOTBAR.length-1))%HOTBAR.length;
+  updateHotbar();
+});
+
+/* ==================== HUD ==================== */
+const hotbarEl=document.getElementById('hotbar');
+const slotsEls=[];
+HOTBAR.forEach((b,i)=>{
+  const s=document.createElement('div');
+  s.className='slot'+(i===0?' on':'');
+  const cv=document.createElement('canvas');
+  cv.width=cv.height=16;
+  cv.getContext('2d').drawImage(tileCvs[tileFor(b,2)],0,0);
+  s.appendChild(cv);
+  const num=document.createElement('i');
+  num.textContent=i+1;
+  s.appendChild(num);
+  hotbarEl.appendChild(s);
+  slotsEls.push(s);
+});
+function updateHotbar(){
+  slotsEls.forEach((s,i)=>s.classList.toggle('on',i===selSlot));
+}
+let toastTimer=null;
+function toast(title,sub){
+  const el=document.getElementById('toast');
+  el.innerHTML=title+(sub?'<small>'+sub+'</small>':'');
+  el.classList.add('show');
+  clearTimeout(toastTimer);
+  toastTimer=setTimeout(()=>el.classList.remove('show'),4200);
+}
+const cX=document.getElementById('cX');
+const cY=document.getElementById('cY');
+const cZ=document.getElementById('cZ');
+const cBiome=document.getElementById('cBiome');
+const cTime=document.getElementById('cTime');
+function updateHUD(){
+  const p=player;
+  cX.textContent=Math.floor(p.x);
+  cY.textContent=Math.floor(p.y);
+  cZ.textContent=Math.floor(p.z);
+  cBiome.textContent=BIOME_NAMES[biomeAt(Math.floor(p.x),Math.floor(p.z))];
+  const t=tOfDay;
+  let tn='深夜';
+  if(t>=0.22&&t<0.28) tn='黎明';
+  else if(t>=0.28&&t<0.45) tn='清晨';
+  else if(t>=0.45&&t<0.55) tn='正午';
+  else if(t>=0.55&&t<0.7)  tn='午后';
+  else if(t>=0.7&&t<0.78)  tn='黄昏';
+  else if(t>=0.78||t<0.05) tn='夜晚';
+  cTime.textContent=tn;
+}
+function checkSites(){
+  const p=player;
+  for(const s of SITES){
+    if(siteFound[s.n]) continue;
+    const dx=p.x-s.x, dz=p.z-s.z;
+    if(dx*dx+dz*dz<s.r*s.r){
+      siteFound[s.n]=true;
+      toast('发现传说之地 · '+s.n,s.d);
+    }
+  }
+}
+/* ==================== 主循环与启动 ==================== */
+const bootEl=document.getElementById('boot');
+const btnStart=document.getElementById('btnStart');
+const bootTip=document.getElementById('bootTip');
+
+const clock=new THREE.Clock();
+let frameCnt=0;
+function loop(){
+  requestAnimationFrame(loop);
+  const dt=Math.min(clock.getDelta(),0.05);
+  frameCnt++;
+  updateSky(dt);
+  updatePlayer(dt);
+  updateCamera();
+  updateChunks(2);
+  flushDirty(2);
+  const hit=raycastBlock();
+  if(hit){
+    highlight.position.set(hit.x+0.5, hit.y+0.5, hit.z+0.5);
+    highlight.visible=true;
+  }else{
+    highlight.visible=false;
+  }
+  if(frameCnt%6===0){ updateHUD(); checkSites(); }
+  if(frameCnt===4) bootEl.classList.add('hide');
+  renderer.render(scene,camera);
+}
+window.addEventListener('resize',()=>{
+  camera.aspect=window.innerWidth/window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth,window.innerHeight);
+});
+btnStart.addEventListener('click',()=>{
+  try{ renderer.domElement.requestPointerLock(); }
+  catch(err){ /* 忽略 */ }
+});
+function init(){
+  bootTip.textContent='正在生成大陆与遗迹…';
+  respawn();
+  ensureArea(-(RENDER_R+1)*CHUNK, -(RENDER_R+1)*CHUNK,
+             (RENDER_R+1)*CHUNK, (RENDER_R+1)*CHUNK);
+  for(const s of SITES) ensureArea(s.x-46, s.z-46, s.x+46, s.z+46);
+  bootTip.textContent='正在建造传说建筑…';
+  buildAllStructures();
+  bootTip.textContent='准备就绪';
+  requestAnimationFrame(loop);
+}
+init();
+</script>
+</body>
+</html>

--- a/outputs/deepseek-v4-flash-0731/claude-code-max/pelican-cycling.svg
+++ b/outputs/deepseek-v4-flash-0731/claude-code-max/pelican-cycling.svg
@@ -1,0 +1,258 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 700" width="100%" height="100%">
+  <defs>
+    <linearGradient id="skyGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#57b4ee"/>
+      <stop offset="0.55" stop-color="#a3d9f4"/>
+      <stop offset="0.82" stop-color="#e2f2fa"/>
+      <stop offset="1" stop-color="#fdeecd"/>
+    </linearGradient>
+    <linearGradient id="seaGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#2f9fd8"/>
+      <stop offset="1" stop-color="#5cbde2"/>
+    </linearGradient>
+    <linearGradient id="sandGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#f6e3b4"/>
+      <stop offset="0.35" stop-color="#f1d9a2"/>
+      <stop offset="1" stop-color="#eac983"/>
+    </linearGradient>
+    <radialGradient id="sunGlow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#fff7cf" stop-opacity="0.95"/>
+      <stop offset="0.5" stop-color="#ffed9e" stop-opacity="0.5"/>
+      <stop offset="1" stop-color="#ffed9e" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="sunCore" cx="0.35" cy="0.35" r="0.75">
+      <stop offset="0" stop-color="#fff3b0"/>
+      <stop offset="1" stop-color="#ffc94d"/>
+    </radialGradient>
+    <linearGradient id="beakGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffd75e"/>
+      <stop offset="1" stop-color="#f59e1f"/>
+    </linearGradient>
+    <linearGradient id="pouchGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#ffb347"/>
+      <stop offset="1" stop-color="#ff8c2e"/>
+    </linearGradient>
+  </defs>
+
+  <!-- sky -->
+  <rect x="0" y="0" width="1000" height="700" fill="url(#skyGrad)"/>
+
+  <!-- sun -->
+  <g>
+    <circle cx="770" cy="150" r="120" fill="url(#sunGlow)">
+      <animate attributeName="r" values="112;128;112" dur="7s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="770" cy="150" r="52" fill="url(#sunCore)"/>
+  </g>
+
+  <!-- clouds -->
+  <g transform="translate(1150,95)">
+    <g>
+      <animateTransform attributeName="transform" type="translate" values="0,0;-1500,0" dur="55s" repeatCount="indefinite"/>
+      <ellipse cx="0" cy="0" rx="52" ry="20" fill="#ffffff" opacity="0.92"/>
+      <ellipse cx="38" cy="-9" rx="44" ry="24" fill="#ffffff" opacity="0.92"/>
+      <ellipse cx="84" cy="1" rx="46" ry="19" fill="#ffffff" opacity="0.92"/>
+    </g>
+  </g>
+  <g transform="translate(1150,175) scale(0.8)">
+    <g>
+      <animateTransform attributeName="transform" type="translate" values="0,0;-1500,0" dur="78s" begin="-32s" repeatCount="indefinite"/>
+      <ellipse cx="0" cy="0" rx="44" ry="17" fill="#ffffff" opacity="0.85"/>
+      <ellipse cx="32" cy="-8" rx="38" ry="20" fill="#ffffff" opacity="0.85"/>
+      <ellipse cx="70" cy="1" rx="38" ry="16" fill="#ffffff" opacity="0.85"/>
+    </g>
+  </g>
+  <g transform="translate(1150,55) scale(1.2)">
+    <g>
+      <animateTransform attributeName="transform" type="translate" values="0,0;-1500,0" dur="64s" begin="-48s" repeatCount="indefinite"/>
+      <ellipse cx="0" cy="0" rx="62" ry="24" fill="#ffffff" opacity="0.95"/>
+      <ellipse cx="46" cy="-11" rx="52" ry="28" fill="#ffffff" opacity="0.95"/>
+      <ellipse cx="100" cy="1" rx="54" ry="22" fill="#ffffff" opacity="0.95"/>
+    </g>
+  </g>
+  <g transform="translate(1150,235) scale(0.65)">
+    <g>
+      <animateTransform attributeName="transform" type="translate" values="0,0;-1500,0" dur="90s" begin="-12s" repeatCount="indefinite"/>
+      <ellipse cx="0" cy="0" rx="36" ry="14" fill="#ffffff" opacity="0.75"/>
+      <ellipse cx="26" cy="-6" rx="30" ry="16" fill="#ffffff" opacity="0.75"/>
+      <ellipse cx="58" cy="1" rx="30" ry="13" fill="#ffffff" opacity="0.75"/>
+    </g>
+  </g>
+  <!-- sea -->
+  <rect x="0" y="395" width="1000" height="75" fill="url(#seaGrad)"/>
+  <g>
+    <animateTransform attributeName="transform" type="translate" values="0,0;-50,0;0,0" dur="6s" repeatCount="indefinite"/>
+    <path d="M0,414 q25,-14 50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 L1000,470 L0,470 Z" fill="#bfe7f6" opacity="0.55"/>
+  </g>
+  <g>
+    <animateTransform attributeName="transform" type="translate" values="0,0;50,0;0,0" dur="7s" repeatCount="indefinite"/>
+    <path d="M0,433 q25,-18 50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 L1000,478 L0,478 Z" fill="#8ed2ec" opacity="0.75"/>
+  </g>
+  <!-- sparkles -->
+  <circle cx="120" cy="420" r="2.2" fill="#ffffff" opacity="0.5"><animate attributeName="opacity" values="0.15;0.9;0.15" dur="3.2s" repeatCount="indefinite"/></circle>
+  <circle cx="300" cy="405" r="2.6" fill="#ffffff" opacity="0.5"><animate attributeName="opacity" values="0.15;0.9;0.15" dur="3.8s" begin="0.6s" repeatCount="indefinite"/></circle>
+  <circle cx="480" cy="415" r="2.2" fill="#ffffff" opacity="0.5"><animate attributeName="opacity" values="0.15;0.9;0.15" dur="2.9s" begin="1.2s" repeatCount="indefinite"/></circle>
+  <circle cx="660" cy="402" r="2.6" fill="#ffffff" opacity="0.5"><animate attributeName="opacity" values="0.15;0.9;0.15" dur="4.1s" begin="0.3s" repeatCount="indefinite"/></circle>
+  <circle cx="840" cy="412" r="2.2" fill="#ffffff" opacity="0.5"><animate attributeName="opacity" values="0.15;0.9;0.15" dur="3.5s" begin="1.8s" repeatCount="indefinite"/></circle>
+  <circle cx="560" cy="432" r="2.4" fill="#ffffff" opacity="0.5"><animate attributeName="opacity" values="0.15;0.9;0.15" dur="3s" begin="0.9s" repeatCount="indefinite"/></circle>
+  <circle cx="240" cy="438" r="2.2" fill="#ffffff" opacity="0.5"><animate attributeName="opacity" values="0.15;0.9;0.15" dur="3.6s" begin="2s" repeatCount="indefinite"/></circle>
+  <circle cx="720" cy="428" r="2.4" fill="#ffffff" opacity="0.5"><animate attributeName="opacity" values="0.15;0.9;0.15" dur="3.3s" begin="1.5s" repeatCount="indefinite"/></circle>
+
+  <!-- sand -->
+  <rect x="0" y="470" width="1000" height="230" fill="url(#sandGrad)"/>
+  <rect x="0" y="470" width="1000" height="14" fill="#ecd39c" opacity="0.85"/>
+  <rect x="0" y="484" width="1000" height="5" fill="#e7cf97" opacity="0.6"/>
+  <!-- foam -->
+  <g>
+    <animateTransform attributeName="transform" type="translate" values="0,0;30,0;0,0" dur="9s" repeatCount="indefinite"/>
+    <path d="M0,470 q25,-7 50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 t50,0 L1000,480 L0,480 Z" fill="#ffffff" opacity="0.8"/>
+  </g>
+  <!-- sand ripples -->
+  <path d="M150,545 q80,-12 160,0" fill="none" stroke="#e4c489" stroke-width="4" opacity="0.55" stroke-linecap="round"/>
+  <path d="M360,565 q90,-10 180,0" fill="none" stroke="#e4c489" stroke-width="4" opacity="0.55" stroke-linecap="round"/>
+  <path d="M420,612 q100,-14 200,0" fill="none" stroke="#e4c489" stroke-width="4" opacity="0.55" stroke-linecap="round"/>
+  <path d="M80,642 q70,-8 140,0" fill="none" stroke="#e4c489" stroke-width="4" opacity="0.55" stroke-linecap="round"/>
+  <path d="M620,652 q80,-10 160,0" fill="none" stroke="#e4c489" stroke-width="4" opacity="0.55" stroke-linecap="round"/>
+  <path d="M250,600 q60,-8 120,0" fill="none" stroke="#e4c489" stroke-width="3.5" opacity="0.5" stroke-linecap="round"/>
+  <path d="M520,585 q55,-7 110,0" fill="none" stroke="#e4c489" stroke-width="3.5" opacity="0.5" stroke-linecap="round"/>
+  <!-- shadow -->
+  <ellipse cx="468" cy="608" rx="128" ry="14" fill="#b08a4e" opacity="0.3"/>
+  <!-- rear wheel -->
+  <g>
+    <g>
+      <animateTransform attributeName="transform" type="rotate" values="0 395 545;360 395 545" dur="1.4s" repeatCount="indefinite"/>
+      <circle cx="395" cy="545" r="55" fill="none" stroke="#3d3d3d" stroke-width="9"/>
+      <circle cx="395" cy="545" r="49.5" fill="none" stroke="#f1f1f1" stroke-width="2.5"/>
+      <line x1="395" y1="545" x2="444" y2="545" stroke="#b9b9b9" stroke-width="3"/>
+      <line x1="395" y1="545" x2="429.7" y2="579.6" stroke="#b9b9b9" stroke-width="3"/>
+      <line x1="395" y1="545" x2="395" y2="594" stroke="#b9b9b9" stroke-width="3"/>
+      <line x1="395" y1="545" x2="360.3" y2="579.6" stroke="#b9b9b9" stroke-width="3"/>
+      <line x1="395" y1="545" x2="346" y2="545" stroke="#b9b9b9" stroke-width="3"/>
+      <line x1="395" y1="545" x2="360.3" y2="510.4" stroke="#b9b9b9" stroke-width="3"/>
+      <line x1="395" y1="545" x2="395" y2="496" stroke="#b9b9b9" stroke-width="3"/>
+      <line x1="395" y1="545" x2="429.7" y2="510.4" stroke="#b9b9b9" stroke-width="3"/>
+      <circle cx="395" cy="545" r="6.5" fill="#d9d9d9" stroke="#8a8a8a" stroke-width="1.5"/>
+    </g>
+  </g>
+  <!-- front wheel -->
+  <g>
+    <g>
+      <animateTransform attributeName="transform" type="rotate" values="0 545 545;360 545 545" dur="1.4s" repeatCount="indefinite"/>
+      <circle cx="545" cy="545" r="55" fill="none" stroke="#3d3d3d" stroke-width="9"/>
+      <circle cx="545" cy="545" r="49.5" fill="none" stroke="#f1f1f1" stroke-width="2.5"/>
+      <line x1="545" y1="545" x2="594" y2="545" stroke="#b9b9b9" stroke-width="3"/>
+      <line x1="545" y1="545" x2="579.7" y2="579.6" stroke="#b9b9b9" stroke-width="3"/>
+      <line x1="545" y1="545" x2="545" y2="594" stroke="#b9b9b9" stroke-width="3"/>
+      <line x1="545" y1="545" x2="510.3" y2="579.6" stroke="#b9b9b9" stroke-width="3"/>
+      <line x1="545" y1="545" x2="496" y2="545" stroke="#b9b9b9" stroke-width="3"/>
+      <line x1="545" y1="545" x2="510.3" y2="510.4" stroke="#b9b9b9" stroke-width="3"/>
+      <line x1="545" y1="545" x2="545" y2="496" stroke="#b9b9b9" stroke-width="3"/>
+      <line x1="545" y1="545" x2="579.7" y2="510.4" stroke="#b9b9b9" stroke-width="3"/>
+      <circle cx="545" cy="545" r="6.5" fill="#d9d9d9" stroke="#8a8a8a" stroke-width="1.5"/>
+    </g>
+  </g>
+  <!-- frame -->
+  <g stroke="#e0523c" stroke-width="9" stroke-linecap="round" fill="none">
+    <line x1="455" y1="545" x2="395" y2="545"/>
+    <line x1="455" y1="545" x2="448" y2="482"/>
+    <line x1="448" y1="482" x2="516" y2="470"/>
+    <line x1="455" y1="545" x2="521" y2="488"/>
+    <line x1="516" y1="470" x2="521" y2="488"/>
+    <line x1="521" y1="488" x2="545" y2="545"/>
+    <line x1="448" y1="482" x2="446" y2="460"/>
+  </g>
+  <!-- seat -->
+  <path d="M432,462 q14,-9 30,0 q0,6 -15,7 q-15,0 -15,-7 z" fill="#333333"/>
+  <path d="M436,466 q10,-4 22,0" fill="none" stroke="#555555" stroke-width="2"/>
+  <!-- handlebar -->
+  <g stroke="#e0523c" stroke-width="8" stroke-linecap="round" fill="none">
+    <line x1="516" y1="470" x2="511" y2="452"/>
+    <path d="M511,452 q-2,-16 -20,-13"/>
+    <path d="M511,452 q12,-8 20,2"/>
+  </g>
+  <circle cx="491" cy="438" r="6" fill="#333333"/>
+  <circle cx="531" cy="454" r="6" fill="#333333"/>
+  <!-- chain -->
+  <line x1="455" y1="533" x2="395" y2="533" stroke="#6b6b6b" stroke-width="2.5"/>
+  <line x1="455" y1="557" x2="395" y2="557" stroke="#6b6b6b" stroke-width="2.5"/>
+  <circle cx="395" cy="545" r="10" fill="none" stroke="#6b6b6b" stroke-width="3"/>
+  <!-- chainring + cranks -->
+  <circle cx="455" cy="545" r="17" fill="#d5d5d5" stroke="#9a9a9a" stroke-width="3"/>
+  <circle cx="455" cy="545" r="5" fill="#8a8a8a"/>
+  <g>
+    <animateTransform attributeName="transform" type="rotate" values="0 455 545;360 455 545" dur="1.4s" repeatCount="indefinite"/>
+    <line x1="455" y1="545" x2="455" y2="518" stroke="#7d7d7d" stroke-width="6" stroke-linecap="round"/>
+    <line x1="455" y1="545" x2="455" y2="572" stroke="#7d7d7d" stroke-width="6" stroke-linecap="round"/>
+    <rect x="441" y="513" width="28" height="9" rx="4.5" fill="#444444"/>
+    <rect x="441" y="568" width="28" height="9" rx="4.5" fill="#444444"/>
+  </g>
+  <!-- pelican with gentle sway -->
+  <g>
+    <animateTransform attributeName="transform" type="rotate" values="0 455 460;2 455 460;-2 455 460;0 455 460" dur="2.8s" repeatCount="indefinite"/>
+
+    <!-- far wing -->
+    <g>
+      <animateTransform attributeName="transform" type="rotate" values="0 448 400;11 448 400;0 448 400" dur="1.1s" repeatCount="indefinite"/>
+      <path d="M448,398 q-26,-16 -52,-4 q-4,24 12,30 q30,8 40,-6 z" fill="#e7eadf" stroke="#d2d6c9" stroke-width="2"/>
+    </g>
+
+    <!-- tail -->
+    <path d="M404,410 q-26,-6 -38,6 q-2,12 16,14 q18,4 24,-8 z" fill="#fdfbf5" stroke="#e2dcc9" stroke-width="2"/>
+
+    <!-- body -->
+    <ellipse cx="455" cy="420" rx="58" ry="40" fill="#fdfbf5" stroke="#e2dcc9" stroke-width="2"/>
+    <ellipse cx="452" cy="432" rx="46" ry="20" fill="#efe9d8" opacity="0.65"/>
+
+    <!-- neck -->
+    <path d="M486,396 q38,-26 24,-64 q-10,-22 10,-22" fill="none" stroke="#e2dcc9" stroke-width="30" stroke-linecap="round"/>
+    <path d="M486,396 q38,-26 24,-64 q-10,-22 10,-22" fill="none" stroke="#fdfbf5" stroke-width="26" stroke-linecap="round"/>
+
+    <!-- head -->
+    <circle cx="522" cy="292" r="26" fill="#fdfbf5" stroke="#e2dcc9" stroke-width="2"/>
+
+    <!-- beak -->
+    <g>
+      <animateTransform attributeName="transform" type="rotate" values="0 546 300;3 546 300;0 546 300" dur="4.2s" repeatCount="indefinite"/>
+      <path d="M542,284 q44,0 78,4 q14,4 16,10 q-2,6 -16,8 q-46,6 -78,-4 z" fill="url(#beakGrad)" stroke="#e08b1a" stroke-width="2"/>
+      <path d="M546,304 q44,4 78,0 q-2,26 -34,30 q-42,2 -44,-30 z" fill="url(#pouchGrad)" stroke="#e08b1a" stroke-width="2"/>
+      <path d="M556,346 q12,-8 22,-4 q2,10 -10,14 q-10,4 -16,-4 z" fill="#8fd0ee"/>
+    </g>
+
+    <!-- eye -->
+    <circle cx="534" cy="286" r="5.5" fill="#2b2b2b"/>
+    <circle cx="536" cy="284" r="2" fill="#ffffff"/>
+
+    <!-- crest feathers -->
+    <path d="M504,266 q-2,-14 10,-16 q-4,12 -8,16 z" fill="#fdfbf5" stroke="#e2dcc9" stroke-width="1.5"/>
+    <path d="M514,262 q4,-14 14,-12 q-6,10 -12,12 z" fill="#fdfbf5" stroke="#e2dcc9" stroke-width="1.5"/>
+
+    <!-- far arm to handlebar -->
+    <path d="M488,410 q8,18 6,34" fill="none" stroke="#e7eadf" stroke-width="10" stroke-linecap="round"/>
+    <circle cx="494" cy="444" r="5.5" fill="#e7eadf" stroke="#d2d6c9" stroke-width="1.5"/>
+
+    <!-- far leg -->
+    <g>
+      <animateTransform attributeName="transform" type="rotate" values="-24 428 448;22 428 448;-24 428 448" dur="1.4s" repeatCount="indefinite"/>
+      <path d="M428,448 L424,490 L446,516" fill="none" stroke="#f59e1f" stroke-width="9" stroke-linecap="round" stroke-linejoin="round"/>
+      <ellipse cx="448" cy="520" rx="9" ry="5" fill="#f59e1f"/>
+    </g>
+
+    <!-- near leg -->
+    <g>
+      <animateTransform attributeName="transform" type="rotate" values="22 428 448;-24 428 448;22 428 448" dur="1.4s" repeatCount="indefinite"/>
+      <path d="M428,448 L424,490 L446,516" fill="none" stroke="#ffb056" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+      <ellipse cx="448" cy="520" rx="9.5" ry="5.5" fill="#ffb056"/>
+    </g>
+
+    <!-- near wing -->
+    <g>
+      <animateTransform attributeName="transform" type="rotate" values="0 452 398;11 452 398;0 452 398" dur="1.1s" repeatCount="indefinite"/>
+      <path d="M452,400 q-36,-24 -66,-10 q-8,30 16,38 q40,12 52,-6 z" fill="#fdfbf5" stroke="#e2dcc9" stroke-width="2"/>
+      <path d="M382,398 q-6,24 14,32 q20,8 32,0 q-18,-4 -26,-18 q-10,-14 -20,-14 z" fill="#3d3d3d" opacity="0.9"/>
+    </g>
+
+    <!-- near arm -->
+    <path d="M498,412 q20,14 26,36" fill="none" stroke="#fdfbf5" stroke-width="11" stroke-linecap="round"/>
+    <circle cx="525" cy="449" r="6" fill="#fdfbf5" stroke="#e2dcc9" stroke-width="2"/>
+  </g>
+</svg>

--- a/outputs/deepseek-v4-flash-0731/claude-code-max/skeleton-watch.html
+++ b/outputs/deepseek-v4-flash-0731/claude-code-max/skeleton-watch.html
@@ -1,0 +1,1299 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Skeleton · 镂空机械机芯 · 三维鉴赏</title>
+<style>
+  :root{
+    --gold:#d8b56a;
+    --gold-dim:rgba(216,181,106,.35);
+    --ink:#cfd6e4;
+    --ink-dim:#8b93a5;
+  }
+  *{ box-sizing:border-box; }
+  html,body{ width:100%; height:100%; margin:0; overflow:hidden; }
+  body{
+    background:radial-gradient(120% 120% at 50% 20%, #0c0f16 0%, #07080c 55%, #04050a 100%);
+    color:var(--ink);
+    font-family:"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei",system-ui,sans-serif;
+    -webkit-font-smoothing:antialiased;
+  }
+  #view{ position:fixed; inset:0; }
+  #view canvas{ display:block; }
+  #css2d-layer{ position:fixed; top:0; left:0; width:100%; height:100%; overflow:hidden; pointer-events:none; }
+  .lbl{
+    pointer-events:auto; cursor:pointer; user-select:none; white-space:nowrap;
+    font:500 11px/1.4 "Segoe UI","PingFang SC","Microsoft YaHei",sans-serif;
+    letter-spacing:.06em; color:#e8d9ae;
+    background:rgba(9,11,17,.72); border:1px solid var(--gold-dim);
+    border-radius:11px; padding:2px 9px;
+    box-shadow:0 2px 10px rgba(0,0,0,.5);
+    transition:background .2s, color .2s, border-color .2s;
+    opacity:.78;
+  }
+  .lbl:hover{ background:rgba(216,181,106,.18); border-color:var(--gold); color:#ffe9b0; }
+  .lbl.sel{ background:rgba(216,181,106,.24); border-color:var(--gold); color:#ffe9b0; box-shadow:0 0 14px rgba(216,181,106,.35); }
+
+  .glass{
+    background:linear-gradient(160deg, rgba(17,21,30,.84), rgba(8,10,16,.9));
+    border:1px solid rgba(160,180,220,.14);
+    border-radius:14px;
+    backdrop-filter:blur(14px) saturate(1.2);
+    -webkit-backdrop-filter:blur(14px) saturate(1.2);
+    box-shadow:0 18px 50px rgba(0,0,0,.55);
+  }
+  #header{ position:fixed; top:18px; left:22px; z-index:20; padding:14px 20px 12px; pointer-events:none; }
+  #header h1{
+    margin:0; font-size:21px; font-weight:600; letter-spacing:.34em;
+    font-family:Georgia,"Times New Roman",serif;
+    background:linear-gradient(100deg,#f4e3b2 0%,#cfa45c 55%,#f2e0ae 100%);
+    -webkit-background-clip:text; background-clip:text; color:transparent;
+  }
+  #header .sub{ margin-top:6px; font-size:11.5px; letter-spacing:.22em; color:var(--ink-dim); }
+  #header .sub b{ color:#b9a06a; font-weight:600; }
+
+  #specs{
+    position:fixed; left:22px; bottom:18px; z-index:20;
+    font-size:11.5px; letter-spacing:.14em; color:var(--ink-dim);
+    padding:9px 14px; pointer-events:none;
+  }
+  #specs span{ color:var(--gold); }
+
+  #hint{
+    position:fixed; left:50%; bottom:18px; transform:translateX(-50%);
+    font-size:11px; letter-spacing:.18em; color:rgba(207,214,228,.38); pointer-events:none; z-index:10;
+  }
+
+  #tooltip{
+    position:fixed; z-index:60; display:none; pointer-events:none;
+    font-size:12px; letter-spacing:.05em; color:#f0e2b8;
+    background:rgba(10,12,18,.92); border:1px solid var(--gold-dim);
+    border-radius:8px; padding:5px 10px; box-shadow:0 6px 18px rgba(0,0,0,.5);
+    max-width:220px;
+  }
+  #tooltip small{ display:block; margin-top:2px; color:var(--ink-dim); font-size:10.5px; line-height:1.5; }
+
+  #panel{
+    position:fixed; top:18px; right:18px; z-index:30;
+    width:306px; max-height:calc(100vh - 36px);
+    display:flex; flex-direction:column; overflow:hidden;
+  }
+  #panel .p-head{
+    padding:14px 16px 12px; border-bottom:1px solid rgba(160,180,220,.12);
+  }
+  #panel .p-head h2{ margin:0 0 8px; font-size:14px; font-weight:600; letter-spacing:.24em; color:var(--gold); }
+  #panel .info-row{ display:flex; justify-content:space-between; font-size:11.5px; padding:2.5px 0; color:var(--ink-dim); letter-spacing:.08em; }
+  #panel .info-row b{ color:var(--ink); font-weight:500; }
+  #detail{
+    padding:14px 16px; min-height:96px; border-bottom:1px solid rgba(160,180,220,.12);
+  }
+  #detail .d-name{ font-size:14px; color:#ffe9b0; letter-spacing:.1em; margin:0 0 6px; font-weight:600; }
+  #detail .d-desc{ font-size:12px; line-height:1.75; color:var(--ink-dim); margin:0; }
+  #detail.dim .d-name, #detail.dim .d-desc{ color:var(--ink-dim); }
+  #parts{
+    overflow-y:auto; padding:10px 12px 14px; flex:1;
+    scrollbar-width:thin; scrollbar-color:rgba(216,181,106,.3) transparent;
+  }
+  #parts::-webkit-scrollbar{ width:5px; }
+  #parts::-webkit-scrollbar-thumb{ background:rgba(216,181,106,.3); border-radius:3px; }
+  .part-btn{
+    display:flex; align-items:center; gap:9px; width:100%;
+    background:rgba(255,255,255,.03); border:1px solid rgba(160,180,220,.1);
+    border-radius:9px; color:var(--ink); cursor:pointer;
+    font:inherit; font-size:12px; letter-spacing:.08em;
+    padding:7.5px 10px; margin-bottom:6px; text-align:left;
+    transition:background .18s, border-color .18s, color .18s;
+  }
+  .part-btn:hover{ background:rgba(216,181,106,.1); border-color:var(--gold-dim); }
+  .part-btn.sel{ background:rgba(216,181,106,.16); border-color:var(--gold); color:#ffe9b0; }
+  .part-btn .dot{ width:7px; height:7px; border-radius:50%; background:#4a5266; flex:none; transition:background .2s; }
+  .part-btn.sel .dot{ background:var(--gold); box-shadow:0 0 8px rgba(216,181,106,.8); }
+
+  #bar{
+    position:fixed; bottom:20px; right:50%; transform:translateX(50%);
+    display:flex; gap:8px; z-index:30; padding:9px 12px; align-items:center;
+  }
+  .ctl{
+    border:1px solid rgba(160,180,220,.16); background:rgba(255,255,255,.04);
+    color:var(--ink); border-radius:22px; cursor:pointer;
+    font:inherit; font-size:12px; letter-spacing:.1em; padding:7px 14px;
+    transition:all .18s; white-space:nowrap;
+  }
+  .ctl:hover{ border-color:var(--gold-dim); background:rgba(216,181,106,.1); color:#ffe9b0; }
+  .ctl.on{ background:rgba(216,181,106,.18); border-color:var(--gold); color:#ffe9b0; }
+
+  #vignette{
+    position:fixed; inset:0; pointer-events:none; z-index:5;
+    background:radial-gradient(75% 75% at 50% 42%, transparent 58%, rgba(0,0,0,.5) 100%);
+  }
+  #boot{
+    position:fixed; inset:0; z-index:100; display:flex; flex-direction:column; gap:16px;
+    align-items:center; justify-content:center; background:#05060a; transition:opacity .7s;
+  }
+  #boot .ring{
+    width:46px; height:46px; border-radius:50%;
+    border:2px solid rgba(216,181,106,.15); border-top-color:var(--gold);
+    animation:spin 1s linear infinite;
+  }
+  @keyframes spin{ to{ transform:rotate(360deg);} }
+  #boot .bt{ font-size:11px; letter-spacing:.4em; color:#8b93a5; }
+
+  @media (max-width:920px){
+    #panel{ width:248px; }
+    #header h1{ font-size:16px; letter-spacing:.22em; }
+    #bar{ right:auto; left:50%; transform:translateX(-50%); bottom:16px; max-width:96vw; overflow-x:auto; }
+    .ctl{ padding:6px 10px; font-size:11px; }
+  }
+</style>
+</head>
+<body>
+
+<div id="boot"><div class="ring"></div><div class="bt">装载机芯中…</div></div>
+<div id="view"></div>
+<div id="css2d-layer"></div>
+<div id="vignette"></div>
+
+<div id="header" class="glass">
+  <h1>SKELETON</h1>
+  <div class="sub">镂空机械腕表 · <b>三维机芯鉴赏</b></div>
+</div>
+
+<div id="panel" class="glass">
+  <div class="p-head">
+    <h2>机芯信息</h2>
+    <div class="info-row"><span>机芯类型</span><b>手动上链 · 镂空</b></div>
+    <div class="info-row"><span>振频</span><b>2.5 Hz · 18,000 A/h</b></div>
+    <div class="info-row"><span>红宝石</span><b>17 颗</b></div>
+    <div class="info-row"><span>动力储存</span><b>约 45 小时</b></div>
+    <div class="info-row"><span>擒纵系统</span><b>瑞士杠杆式</b></div>
+  </div>
+  <div id="detail" class="dim">
+    <p class="d-name">点击任意零件</p>
+    <p class="d-desc">在 3D 视图中点击零件，或从下方列表选择，即可查看该零件的高亮展示与详细说明。</p>
+  </div>
+  <div id="parts"></div>
+</div>
+
+<div id="bar" class="glass">
+  <button class="ctl" id="btn-explode">爆炸视图</button>
+  <button class="ctl on" id="btn-labels">零件标签</button>
+  <button class="ctl on" id="btn-rotate">自动旋转</button>
+  <button class="ctl" id="btn-pause">暂停</button>
+  <button class="ctl" id="btn-reset">复位视角</button>
+</div>
+
+<div id="specs" class="glass">17 钻 · 18,000 A/h · 45h 动力储存 &nbsp;|&nbsp; <span>点击零件查看详情</span></div>
+<div id="hint">拖动旋转 · 滚轮缩放 · 点击零件查看详情 · 快捷键 E / L / R / Space</div>
+<div id="tooltip"></div>
+
+<script src="https://unpkg.com/three@0.128.0/build/three.min.js"></script>
+<script src="https://unpkg.com/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+<script src="https://unpkg.com/three@0.128.0/examples/js/renderers/CSS2DRenderer.js"></script>
+<script>
+'use strict';
+/* ============ 基础场景 ============ */
+const view = document.getElementById('view');
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x07080c);
+
+const renderer = new THREE.WebGLRenderer({ antialias:true, alpha:false });
+renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+renderer.setSize(window.innerWidth, window.innerHeight);
+renderer.shadowMap.enabled = true;
+renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+renderer.outputEncoding = THREE.sRGBEncoding;
+renderer.toneMapping = THREE.ACESFilmicToneMapping;
+renderer.toneMappingExposure = 1.08;
+renderer.domElement.style.cursor = 'grab';
+view.appendChild(renderer.domElement);
+
+const camera = new THREE.PerspectiveCamera(34, window.innerWidth/window.innerHeight, 0.1, 500);
+const INIT_CAM = new THREE.Vector3(17, 12, 46);
+camera.position.copy(INIT_CAM);
+const TARGET = new THREE.Vector3(0, 0.6, 0);
+
+const controls = new THREE.OrbitControls(camera, renderer.domElement);
+controls.target.copy(TARGET);
+controls.enableDamping = true;
+controls.dampingFactor = 0.08;
+controls.minDistance = 16;
+controls.maxDistance = 140;
+controls.maxPolarAngle = Math.PI * 0.62;
+controls.update();
+
+const labelRenderer = new THREE.CSS2DRenderer();
+labelRenderer.setSize(window.innerWidth, window.innerHeight);
+document.getElementById('css2d-layer').appendChild(labelRenderer.domElement);
+
+/* ============ 环境反射（PMREM 程序化摄影棚） ============ */
+(function(){
+  const es = new THREE.Scene();
+  es.background = new THREE.Color(0x05060a);
+  const envMat = (c, i) => new THREE.MeshBasicMaterial({
+    color: new THREE.Color(c).multiplyScalar(i), side: THREE.DoubleSide
+  });
+  const panel = (w, h, pos, mat) => {
+    const m = new THREE.Mesh(new THREE.PlaneGeometry(w, h), mat);
+    m.position.copy(pos); m.lookAt(0, 0, 0); es.add(m);
+  };
+  panel(30, 30, new THREE.Vector3(0, 20, 0),  envMat(0xffffff, 1.7));  // 顶部柔光箱
+  panel(16, 10, new THREE.Vector3(18, 3, 12), envMat(0xffd9a8, 1.2)); // 暖色侧光
+  panel(12, 8,  new THREE.Vector3(-16, 6, -9), envMat(0x9fc0ff, 0.9));// 冷色补光
+  panel(30, 30, new THREE.Vector3(0, -16, 0), envMat(0xffffff, 0.55));
+  panel(16, 12, new THREE.Vector3(0, 7, 17),  envMat(0xffe9c8, 1.0)); // 正面主光
+  const pm = new THREE.PMREMGenerator(renderer);
+  scene.environment = pm.fromScene(es, 0.04).texture;
+  pm.dispose();
+})();
+
+/* ============ 灯光 ============ */
+const keyLight = new THREE.SpotLight(0xfff1df, 2.6, 0, 0.55, 0.65, 1.4);
+keyLight.position.set(16, 32, 30);
+keyLight.castShadow = true;
+keyLight.shadow.mapSize.set(2048, 2048);
+keyLight.shadow.camera.near = 5;
+keyLight.shadow.camera.far = 90;
+keyLight.shadow.bias = -0.0006;
+scene.add(keyLight);
+
+const fillLight = new THREE.DirectionalLight(0x9fc4ff, 0.55);
+fillLight.position.set(-22, 12, -16);
+scene.add(fillLight);
+
+const rimLight = new THREE.SpotLight(0xffd9a0, 1.6, 0, 0.42, 0.5, 1.4);
+rimLight.position.set(0, -10, -32);
+scene.add(rimLight);
+
+scene.add(new THREE.AmbientLight(0x33405c, 0.5));
+
+/* ============ 反射地面 ============ */
+const floorMat = new THREE.MeshStandardMaterial({
+  color: 0x0b0d12, metalness: 0.92, roughness: 0.34, envMapIntensity: 0.9
+});
+const floor = new THREE.Mesh(new THREE.CircleGeometry(70, 64), floorMat);
+floor.rotation.x = -Math.PI / 2;
+floor.position.y = -24;
+floor.receiveShadow = true;
+scene.add(floor);
+
+/* ============ 材质与几何工具 ============ */
+const TAU = Math.PI * 2;
+function metal(c, rough, envI){
+  return new THREE.MeshStandardMaterial({ color:c, metalness:1, roughness:rough, envMapIntensity:envI||1.15 });
+}
+function goldMat(){ return metal(0xd0a355, 0.2, 1.25); }
+function steelMat(){ return metal(0xd7dde2, 0.16, 1.3); }
+function blueMat(){ return metal(0x2f4a8f, 0.17, 1.25); }
+function rubyMat(){
+  return new THREE.MeshStandardMaterial({
+    color:0x9c1c33, metalness:0.25, roughness:0.12, envMapIntensity:1.1,
+    emissive:0x2a0510, emissiveIntensity:0.5
+  });
+}
+function glassMat(){
+  return new THREE.MeshPhysicalMaterial({
+    color:0xd8e8ff, metalness:0.25, roughness:0.03, transparent:true, opacity:0.13,
+    side:THREE.DoubleSide, envMapIntensity:1.4, depthWrite:false
+  });
+}
+function lumeMat(){
+  const m = new THREE.MeshStandardMaterial({
+    color:0xbfe6d2, metalness:0, roughness:0.5,
+    emissive:0x8fe0c2, emissiveIntensity:1.0
+  });
+  return m;
+}
+function darkMat(){ return metal(0x1a1d24, 0.42, 0.7); }
+
+function annulusShape(ro, ri){
+  const s = new THREE.Shape();
+  s.absarc(0, 0, ro, 0, TAU, false);
+  const h = new THREE.Path();
+  h.absarc(0, 0, ri, 0, TAU, true);
+  s.holes.push(h);
+  return s;
+}
+function extrude(shape, depth, bevel, bevelSize){
+  const geo = new THREE.ExtrudeGeometry(shape, {
+    depth: depth, bevelEnabled: !!bevel,
+    bevelThickness: bevelSize * 0.55, bevelSize: bevelSize, bevelSegments: 2, steps: 1
+  });
+  return geo;
+}
+function rrShape(x, y, w, h, r){ /* 圆角矩形 */
+  const s = new THREE.Shape();
+  s.moveTo(x + r, y);
+  s.lineTo(x + w - r, y);
+  s.quadraticCurveTo(x + w, y, x + w, y + r);
+  s.lineTo(x + w, y + h - r);
+  s.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+  s.lineTo(x + r, y + h);
+  s.quadraticCurveTo(x, y + h, x, y + h - r);
+  s.lineTo(x, y + r);
+  s.quadraticCurveTo(x, y, x + r, y);
+  return s;
+}
+function place(mesh, x, y, z, rx, ry, rz, parent){
+  mesh.position.set(x, y, z);
+  if (rx) mesh.rotation.x = rx;
+  if (ry) mesh.rotation.y = ry;
+  if (rz) mesh.rotation.z = rz;
+  if (parent) parent.add(mesh);
+  return mesh;
+}
+function meshOf(geo, mat, parent){
+  const m = new THREE.Mesh(geo, mat);
+  if (parent) parent.add(m);
+  return m;
+}
+
+/* 夹板螺丝：圆头 + 一字槽 */
+function makeScrew(mat, r){
+  const g = new THREE.Group();
+  const head = meshOf(new THREE.CylinderGeometry(r, r, 0.42, 24), mat, g);
+  head.rotation.x = Math.PI / 2; head.position.z = 0.2;
+  const slot = meshOf(new THREE.BoxGeometry(0.62, 0.06, 0.16), darkMat(), g);
+  slot.position.z = 0.42; slot.rotation.z = Math.random() * Math.PI;
+  const body = meshOf(new THREE.CylinderGeometry(r * 0.6, r * 0.6, 1.1, 16), mat, g);
+  body.rotation.x = Math.PI / 2; body.position.z = -0.38;
+  return g;
+}
+
+/* 红宝石轴承：金色托 + 红宝石轴眼 */
+function makeJewel(matGold, parent, z){
+  const g = new THREE.Group();
+  const cup = meshOf(new THREE.CylinderGeometry(0.55, 0.62, 0.34, 20), matGold, g);
+  cup.rotation.x = Math.PI / 2; cup.position.z = z;
+  const stone = meshOf(new THREE.CylinderGeometry(0.34, 0.3, 0.22, 20), rubyMat(), g);
+  stone.rotation.x = Math.PI / 2; stone.position.z = z;
+  if (parent) parent.add(g);
+  return g;
+}
+/* ============ 机芯装配 ============ */
+const watchRoot = new THREE.Group();
+watchRoot.rotation.set(-0.1, 0.42, 0.03);
+scene.add(watchRoot);
+
+const PARTS = [];          /* 零件注册表 */
+const partById = {};
+const pickMeshes = [];     /* 拾取列表 */
+function register(part){ PARTS.push(part); partById[part.id] = part; }
+
+/* ---------- 主夹板：底座环 + 四根立柱 ---------- */
+function buildMainplate(){
+  const g = new THREE.Group();
+  const mat = new THREE.MeshStandardMaterial({ color:0xb9bec7, metalness:0.9, roughness:0.3, envMapIntensity:1.0 });
+  const plate = meshOf(extrude(annulusShape(18.4, 7.6), 0.9, true, 0.18), mat, g);
+  plate.rotation.x = Math.PI / 2; plate.position.y = -3.9;
+  plate.castShadow = true; plate.receiveShadow = true;
+  for (let i = 0; i < 4; i++){
+    const a = i * Math.PI / 2 + Math.PI / 4;
+    const pillar = meshOf(new THREE.CylinderGeometry(0.9, 1.05, 7.6, 20), mat, g);
+    pillar.rotation.x = Math.PI / 2;
+    pillar.position.set(Math.cos(a) * 14.2, -0.7, Math.sin(a) * 14.2);
+    const scr = makeScrew(goldMat(), 0.85);
+    scr.rotation.x = -Math.PI / 2;
+    scr.position.set(Math.cos(a) * 14.2, -3.3, Math.sin(a) * 14.2);
+    g.add(scr);
+  }
+  watchRoot.add(g);
+  return g;
+}
+
+/* ---------- 发条盒 + 主发条螺旋 + 棘轮 ---------- */
+function buildBarrel(){
+  const g = new THREE.Group();
+  g.position.set(-8.5, -1.7, 3.5);
+  const gm = goldMat();
+  const sm = steelMat();
+
+  /* 底盖 */
+  const bottom = meshOf(extrude(annulusShape(8, 1.6), 0.5, true, 0.14), gm, g);
+  bottom.rotation.x = Math.PI / 2; bottom.position.y = -1.15;
+  bottom.castShadow = true;
+  /* 鼓身侧壁（半高，露出主发条） */
+  const wall = meshOf(new THREE.CylinderGeometry(8, 8, 1.9, 48, 1, true), gm, g);
+  wall.rotation.x = Math.PI / 2; wall.position.y = 0.3;
+
+  /* 主发条：阿基米德螺旋金属带 */
+  const spiralPts = [];
+  const turns = 8.5, r0 = 1.5, r1 = 7.3;
+  for (let i = 0; i <= 520; i++){
+    const k = i / 520;
+    const r = r0 + (r1 - r0) * k;
+    const a = k * turns * TAU;
+    spiralPts.push(new THREE.Vector3(Math.cos(a) * r, 0.15 + k * 0.14, Math.sin(a) * r));
+  }
+  const spiralCurve = new THREE.CatmullRomCurve3(spiralPts);
+  const springMat = new THREE.MeshStandardMaterial({ color:0xc8a24c, metalness:1, roughness:0.28, envMapIntensity:1.1 });
+  meshOf(new THREE.TubeGeometry(spiralCurve, 900, 0.115, 8, false), springMat, g);
+
+  /* 发条轴 */
+  const arbor = meshOf(new THREE.CylinderGeometry(1.05, 1.3, 3.2, 24), sm, g);
+  arbor.rotation.x = Math.PI / 2; arbor.position.y = 0.2;
+  const arborSquare = meshOf(new THREE.CylinderGeometry(1.35, 1.35, 0.8, 4, 1), sm, g);
+  arborSquare.rotation.x = Math.PI / 2; arborSquare.rotation.z = Math.PI / 4;
+  arborSquare.position.y = 1.8;
+
+  /* 棘轮：金色齿环 */
+  const ratchet = new THREE.Group();
+  const rteeth = 34, rpitch = 7.6;
+  const ringM = meshOf(extrude(annulusShape(7.8, 1.9), 0.55, true, 0.12), gm, ratchet);
+  ringM.rotation.x = Math.PI / 2;
+  for (let i = 0; i < rteeth; i++){
+    const a = i / rteeth * TAU;
+    const t = meshOf(new THREE.BoxGeometry(1.35, 0.62, 0.34), gm, ratchet);
+    t.position.set(Math.cos(a) * rpitch, 0.25, Math.sin(a) * rpitch);
+    t.rotation.y = a;
+  }
+  ratchet.position.y = 2.25;
+  ratchet.castShadow = true;
+  g.add(ratchet);
+
+  /* 轴承 */
+  makeJewel(gm, g, 2.75);
+  g.userData.ratchet = ratchet;
+  watchRoot.add(g);
+  return g;
+}
+
+/* ---------- 齿轮构建器（内层旋转组，让轮系平面 = XZ） ---------- */
+function makeWheel(o){
+  const g = new THREE.Group();
+  const s = new THREE.Group();
+  s.rotation.x = Math.PI / 2;
+  g.add(s);
+  const m = o.mat;
+  const ring = meshOf(extrude(annulusShape(o.ringO, o.ringI), o.thick, true, 0.1), m, s);
+  ring.castShadow = true;
+  for (let i = 0; i < o.teeth; i++){
+    const a = i / o.teeth * TAU + (o.phase || 0);
+    const t = meshOf(new THREE.BoxGeometry(o.toothH, o.toothW, o.thick * 1.14), m, s);
+    t.position.set(Math.cos(a) * o.pitchR, Math.sin(a) * o.pitchR, 0);
+    t.rotation.z = a;
+  }
+  const spokes = o.spokes === undefined ? 3 : o.spokes;
+  const armLen = o.ringI - o.hub - 0.5;
+  for (let j = 0; j < spokes; j++){
+    const a = j / spokes * TAU + Math.PI / spokes;
+    const arm = meshOf(new THREE.BoxGeometry(armLen, 1.35, o.thick * 0.82), m, s);
+    arm.position.set(Math.cos(a) * (o.hub + armLen / 2), Math.sin(a) * (o.hub + armLen / 2), 0);
+    arm.rotation.z = a;
+  }
+  const hub = meshOf(new THREE.CylinderGeometry(o.hub, o.hub * 0.92, o.thick * 1.35, 20), m, s);
+  if (o.pinion){
+    const pin = new THREE.Group();
+    const pc = meshOf(new THREE.CylinderGeometry(o.pinionR, o.pinionR * 0.85, 1.5, 12), m, pin);
+    for (let i = 0; i < o.pinion; i++){
+      const a = i / o.pinion * TAU;
+      const pt = meshOf(new THREE.BoxGeometry(0.5, 0.2, 1.6), m, pin);
+      pt.position.set(Math.cos(a) * o.pinionR, Math.sin(a) * o.pinionR, 0);
+      pt.rotation.z = a;
+    }
+    pin.position.z = 1.25; /* 内层 +Z → 世界 -Y（轮下） */
+    s.add(pin);
+  }
+  return g;
+}
+
+/* ---------- 齿轮系 ---------- */
+const wheels = {};
+function buildTrain(){
+  const center = makeWheel({
+    teeth: 26, pitchR: 5.1, toothH: 1.5, toothW: 1.05,
+    ringO: 5.1, ringI: 1.6, hub: 0.95, thick: 0.62,
+    mat: steelMat(), spokes: 4
+  });
+  center.position.set(0, -1.1, 0);
+  wheels.center = center;
+  watchRoot.add(center);
+
+  const third = makeWheel({
+    teeth: 22, pitchR: 4.55, toothH: 1.45, toothW: 1.0,
+    ringO: 4.55, ringI: 1.5, hub: 0.9, thick: 0.56,
+    mat: goldMat(), spokes: 3, phase: 0.14
+  });
+  third.position.set(6.8, -0.3, -2.2);
+  wheels.third = third;
+  watchRoot.add(third);
+
+  const fourth = makeWheel({
+    teeth: 18, pitchR: 3.9, toothH: 1.5, toothW: 0.95,
+    ringO: 3.9, ringI: 1.4, hub: 0.85, thick: 0.5,
+    mat: steelMat(), spokes: 3, phase: 0.2,
+    pinion: 8, pinionR: 0.75
+  });
+  fourth.position.set(4.6, 0.6, -7.4);
+  wheels.fourth = fourth;
+  watchRoot.add(fourth);
+
+  /* 擒纵轮：细齿燕尾形 */
+  const esc = new THREE.Group();
+  const s2 = new THREE.Group();
+  s2.rotation.x = Math.PI / 2;
+  esc.add(s2);
+  const em = steelMat();
+  const disc = meshOf(extrude(annulusShape(3.6, 1.2), 0.42, true, 0.1), em, s2);
+  const et = 15;
+  for (let i = 0; i < et; i++){
+    const a = i / et * TAU;
+    const tooth = meshOf(new THREE.CylinderGeometry(0.07, 0.2, 1.35, 5), em, s2);
+    tooth.position.set(Math.cos(a) * 3.85, Math.sin(a) * 3.85, 0);
+    tooth.rotation.z = a;
+  }
+  meshOf(new THREE.CylinderGeometry(1.0, 1.0, 0.6, 18), em, s2);
+  const epin = new THREE.Group();
+  const epc = meshOf(new THREE.CylinderGeometry(0.62, 0.55, 1.3, 12), em, epin);
+  for (let i = 0; i < 7; i++){
+    const a = i / 7 * TAU;
+    const pt = meshOf(new THREE.BoxGeometry(0.4, 0.16, 1.4), em, epin);
+    pt.position.set(Math.cos(a) * 0.62, Math.sin(a) * 0.62, 0);
+    pt.rotation.z = a;
+  }
+  epin.position.z = 1.1;
+  s2.add(epin);
+  esc.position.set(-2.6, 1.4, -8.5);
+  wheels.escape = esc;
+  watchRoot.add(esc);
+
+  /* 齿轮轴眼红宝石 */
+  const gm = goldMat();
+  const j = (x, y, z) => {
+    const jw = makeJewel(gm, null, z);
+    jw.position.set(x, 0, y);
+    watchRoot.add(jw);
+  };
+  j(0, 0, -0.5);
+  j(6.8, -2.2, 0.3);
+  j(4.6, -7.4, 1.2);
+  j(-2.6, -8.5, 2.0);
+  j(-8.5, 3.5, 2.7);
+}
+/* ---------- 摆轮组件 ---------- */
+const balance = { group: null, osc: null, angle: 0 };
+function buildBalance(){
+  const g = new THREE.Group();
+  g.position.set(-9.3, 2.3, -4.9);
+  const osc = new THREE.Group();
+  g.add(osc);
+  const bm = new THREE.MeshStandardMaterial({ color:0xd8dde2, metalness:1, roughness:0.14, envMapIntensity:1.35 });
+  const gm = goldMat();
+
+  /* 摆轮外圈 + 十字辐条 */
+  const ring = meshOf(new THREE.TorusGeometry(4.55, 0.42, 18, 56), bm, osc);
+  ring.rotation.x = Math.PI / 2;
+  ring.castShadow = true;
+  meshOf(new THREE.BoxGeometry(8.4, 0.36, 0.72), bm, osc);
+  meshOf(new THREE.BoxGeometry(0.72, 0.36, 8.4), bm, osc);
+  /* 摆钉（8 颗微调螺丝） */
+  for (let i = 0; i < 8; i++){
+    const a = i / 8 * TAU;
+    const s = makeScrew(gm, 0.32);
+    s.rotation.x = -Math.PI / 2; s.rotation.y = a;
+    s.position.set(Math.cos(a) * 4.9, 0, Math.sin(a) * 4.9);
+    osc.add(s);
+  }
+  /* 中心摆轴 */
+  const staff = meshOf(new THREE.CylinderGeometry(0.28, 0.28, 3.6, 14), bm, osc);
+  staff.rotation.x = Math.PI / 2;
+  /* 双圆盘：上盘 + 冲击圆盘 */
+  const table = meshOf(new THREE.CylinderGeometry(0.95, 0.95, 0.3, 18), bm, osc);
+  table.rotation.x = Math.PI / 2; table.position.y = 0.15;
+  const roller = meshOf(new THREE.CylinderGeometry(0.62, 0.62, 0.4, 16), gm, osc);
+  roller.rotation.x = Math.PI / 2; roller.position.y = 0.02;
+  /* 冲击红宝石（椭圆） */
+  const impulse = meshOf(new THREE.SphereGeometry(0.26, 12, 10), rubyMat(), osc);
+  impulse.scale.set(1, 0.62, 1);
+  impulse.position.set(0.42, 0.05, 0);
+  balance.osc = osc;
+  balance.group = g;
+  watchRoot.add(g);
+  return g;
+}
+
+/* ---------- 游丝 ---------- */
+function buildHairspring(){
+  const g = new THREE.Group();
+  g.position.set(-9.3, 2.3, -4.9);
+  const pts = [];
+  const turns = 7.5, r0 = 0.5, r1 = 3.1;
+  for (let i = 0; i <= 420; i++){
+    const k = i / 420;
+    const r = r0 + (r1 - r0) * k;
+    const a = -k * turns * TAU + 0.6;
+    pts.push(new THREE.Vector3(Math.cos(a) * r, 1.05 + k * 0.16, Math.sin(a) * r));
+  }
+  const curve = new THREE.CatmullRomCurve3(pts);
+  const hsMat = new THREE.MeshStandardMaterial({ color:0xd9c08a, metalness:0.95, roughness:0.25, envMapIntensity:1.2 });
+  meshOf(new THREE.TubeGeometry(curve, 700, 0.055, 7, false), hsMat, g);
+  /* 内桩 */
+  const collet = meshOf(new THREE.CylinderGeometry(0.3, 0.3, 0.6, 14), goldMat(), g);
+  collet.rotation.x = Math.PI / 2; collet.position.y = 1.05;
+  /* 外端固定销 */
+  const studPin = meshOf(new THREE.CylinderGeometry(0.1, 0.1, 0.7, 8), goldMat(), g);
+  studPin.rotation.x = Math.PI / 2;
+  studPin.position.set(3.1, 1.35, 0.55);
+  watchRoot.add(g);
+  return g;
+}
+
+/* ---------- 擒纵叉（瑞士杠杆式） ---------- */
+function buildFork(){
+  const g = new THREE.Group();
+  g.position.set(-6.5, 2.1, -7.3);
+  g.rotation.y = 0.3; /* 叉瓦朝向擒纵轮 */
+  g.userData.baseRy = 0.3;
+  const fm = new THREE.MeshStandardMaterial({ color:0xcdd3da, metalness:1, roughness:0.18, envMapIntensity:1.3 });
+  /* 叉身 */
+  const body = meshOf(new THREE.CylinderGeometry(0.42, 0.48, 3.6, 14), fm, g);
+  body.rotation.x = Math.PI / 2;
+  /* 两条叉臂 */
+  const armL = meshOf(new THREE.BoxGeometry(3.1, 0.42, 0.42), fm, g);
+  armL.position.set(-1.55, 0, 0.75); armL.rotation.y = 0.28;
+  const armR = meshOf(new THREE.BoxGeometry(3.1, 0.42, 0.42), fm, g);
+  armR.position.set(-1.55, 0, -0.75); armR.rotation.y = -0.28;
+  /* 叉头 */
+  const horn = meshOf(new THREE.BoxGeometry(1.5, 0.85, 0.3), fm, g);
+  horn.position.set(-3.35, 0, 0);
+  /* 叉瓦：两块红宝石 */
+  const stoneL = meshOf(new THREE.BoxGeometry(0.28, 0.6, 0.85), rubyMat(), g);
+  stoneL.position.set(1.35, 0, 0.5);
+  const stoneR = meshOf(new THREE.BoxGeometry(0.28, 0.6, 0.85), rubyMat(), g);
+  stoneR.position.set(1.35, 0, -0.5);
+  /* 保险销 */
+  const guard = meshOf(new THREE.CylinderGeometry(0.16, 0.16, 1.0, 10), goldMat(), g);
+  guard.rotation.x = Math.PI / 2; guard.position.set(-1.9, 0.4, 0);
+  /* 轴眼宝石 */
+  makeJewel(goldMat(), g, 0.6);
+  watchRoot.add(g);
+  return g;
+}
+
+/* ---------- 传动桥板（带镂空开窗） ---------- */
+function buildTrainBridge(){
+  const g = new THREE.Group();
+  g.position.y = 3.4;
+  const mat = new THREE.MeshStandardMaterial({ color:0xc2c8d1, metalness:0.92, roughness:0.26, envMapIntensity:1.05 });
+  const s = rrShape(-9.6, -9.4, 19.6, 18.8, 2.6);
+  const hole = (x, y, r) => {
+    const p = new THREE.Path();
+    p.absarc(x, y, r, 0, TAU, true);
+    s.holes.push(p);
+  };
+  hole(-8.5, 3.5, 4.75);   /* 发条盒 */
+  hole(0, 0, 5.6);         /* 中心轮 */
+  hole(6.8, -2.2, 4.35);   /* 三轮 */
+  hole(4.6, -7.4, 4.05);   /* 四轮 */
+  hole(-9.4, -4.9, 5.5);   /* 摆轮 */
+  hole(-6.5, -7.3, 3.1);   /* 擒纵叉 */
+  hole(-2.6, -8.5, 4.35);  /* 擒纵轮 */
+  const plate = meshOf(extrude(s, 1.1, true, 0.16), mat, g);
+  plate.rotation.x = Math.PI / 2; plate.position.y = -0.2;
+  plate.castShadow = true; plate.receiveShadow = true;
+  /* 桥板螺丝 */
+  const scrPos = [[-6.2, 8.9], [6.6, 7.6], [8.8, -6.8], [-7.8, -8.9], [2.2, 8.6], [-0.4, 8.6]];
+  for (const p of scrPos){
+    const sc = makeScrew(goldMat(), 0.78);
+    sc.rotation.x = -Math.PI / 2;
+    sc.position.set(p[0], 0.52, p[1]);
+    g.add(sc);
+  }
+  watchRoot.add(g);
+  return g;
+}
+
+/* ---------- 摆轮夹板（桥形托架） ---------- */
+function buildCock(){
+  const g = new THREE.Group();
+  g.position.set(-9.3, 3.7, -4.9);
+  const mat = new THREE.MeshStandardMaterial({ color:0xcfd5dc, metalness:0.95, roughness:0.22, envMapIntensity:1.2 });
+  /* 环形托架 */
+  const ring = meshOf(extrude(annulusShape(4.35, 3.15), 0.85, true, 0.14), mat, g);
+  ring.rotation.x = Math.PI / 2;
+  /* 尾臂（朝向桥板方向） */
+  const tail = meshOf(extrude(rrShape(0, -0.75, 3.2, 1.5, 0.7), 0.85, true, 0.14), mat, g);
+  tail.rotation.x = Math.PI / 2; tail.rotation.y = 0.55;
+  tail.position.set(1.1, 0.05, 2.35);
+  /* 夹板螺丝 */
+  const s1 = makeScrew(goldMat(), 0.7);
+  s1.rotation.x = -Math.PI / 2; s1.position.set(1.6, 0.52, 3.35);
+  g.add(s1);
+  const s2 = makeScrew(goldMat(), 0.7);
+  s2.rotation.x = -Math.PI / 2; s2.position.set(0.4, 0.52, 2.85);
+  g.add(s2);
+  /* 摆轮轴眼 + 游丝外桩 */
+  makeJewel(goldMat(), g, 0.72);
+  const stud = meshOf(new THREE.BoxGeometry(0.5, 0.42, 0.5), goldMat(), g);
+  stud.position.set(1.05, 0.5, -2.7);
+  watchRoot.add(g);
+  return g;
+}
+/* ---------- 镂空表盘 + 荧光时标 ---------- */
+function buildDial(){
+  const g = new THREE.Group();
+  g.position.y = 4.5;
+  const dm = darkMat();
+  const rim = meshOf(extrude(annulusShape(17.2, 12.1), 0.7, true, 0.1), dm, g);
+  rim.rotation.x = Math.PI / 2;
+  rim.castShadow = true;
+  const inner = meshOf(extrude(annulusShape(12.1, 11.3), 0.7, true, 0.1),
+    new THREE.MeshStandardMaterial({ color:0x232833, metalness:0.85, roughness:0.4 }), g);
+  inner.rotation.x = Math.PI / 2;
+  const lm = lumeMat();
+
+  /* 12 枚立体时标 + 荧光条 */
+  const markM = new THREE.MeshStandardMaterial({ color:0xe2e6ec, metalness:0.95, roughness:0.2, envMapIntensity:1.2 });
+  for (let i = 0; i < 12; i++){
+    const a = i / 12 * TAU + Math.PI / 2;
+    const mk = meshOf(new THREE.BoxGeometry(1.7, 0.85, 0.34), markM, g);
+    mk.position.set(Math.cos(a) * 15.1, 0.1, Math.sin(a) * 15.1);
+    mk.rotation.y = a;
+    const lum = meshOf(new THREE.BoxGeometry(1.2, 0.35, 0.16), lm, g);
+    lum.position.set(Math.cos(a) * 15.1, 0.52, Math.sin(a) * 15.1);
+    lum.rotation.y = a;
+    /* 12 点双刻度 */
+    if (i === 0){
+      const mk2 = mk.clone();
+      mk2.position.z = 12.8;
+      g.add(mk2);
+    }
+  }
+  /* 秒刻度环（荧光小点） */
+  for (let i = 0; i < 60; i++){
+    const a = i / 60 * TAU + Math.PI / 2;
+    const dot = meshOf(new THREE.BoxGeometry(0.16, 0.4, 0.16), lm, g);
+    dot.position.set(Math.cos(a) * 16.4, 0.28, Math.sin(a) * 16.4);
+  }
+  /* 盘面螺丝 */
+  for (let i = 0; i < 4; i++){
+    const a = i * Math.PI / 2 + Math.PI / 4;
+    const sc = makeScrew(goldMat(), 0.72);
+    sc.rotation.x = -Math.PI / 2;
+    sc.position.set(Math.cos(a) * 14.8, 0.55, Math.sin(a) * 14.8);
+    g.add(sc);
+  }
+  watchRoot.add(g);
+  return g;
+}
+
+/* ---------- 指针（荧光剑形针） ---------- */
+function handShape(len, width){
+  const s = new THREE.Shape();
+  s.moveTo(0, 0);
+  s.lineTo(len * 0.92, width * 0.55);
+  s.lineTo(len, 0);
+  s.lineTo(len * 0.92, -width * 0.55);
+  s.lineTo(0, 0);
+  const h = new THREE.Path();
+  h.absarc(0, 0, 0.62, 0, TAU, true);
+  s.holes.push(h);
+  return s;
+}
+function makeHand(len, width, mat, lumeLen, y, parent){
+  const g = new THREE.Group();
+  const body = meshOf(extrude(handShape(len, width), 0.16, true, 0.05), mat, g);
+  body.rotation.x = Math.PI / 2;
+  const lum = meshOf(new THREE.BoxGeometry(lumeLen, 0.13, width * 0.42), lumeMat(), g);
+  lum.position.set(len * 0.5, 0.14, 0);
+  g.position.y = y;
+  if (parent) parent.add(g);
+  return g;
+}
+function buildHands(){
+  const hour = makeHand(8.6, 1.05, blueMat(), 6.6, 5.0);
+  const minute = makeHand(12.6, 0.85, blueMat(), 9.8, 5.35);
+  const second = new THREE.Group();
+  second.position.y = 5.7;
+  const sm = new THREE.MeshStandardMaterial({ color:0xdfe3e8, metalness:1, roughness:0.15, envMapIntensity:1.35 });
+  const blade = meshOf(extrude(handShape(15.2, 0.42), 0.14, true, 0.04), sm, second);
+  blade.rotation.x = Math.PI / 2;
+  const tip = meshOf(new THREE.BoxGeometry(1.1, 0.3, 0.36),
+    new THREE.MeshStandardMaterial({ color:0xd23c22, metalness:0.4, roughness:0.35, emissive:0x7a1408, emissiveIntensity:0.9 }), second);
+  tip.position.set(14.6, 0.12, 0);
+  const tail = meshOf(new THREE.CylinderGeometry(0.9, 0.9, 0.3, 18), sm, second);
+  tail.rotation.x = Math.PI / 2; tail.position.set(-2.4, 0.02, 0);
+  /* 指针轴芯 */
+  const pinion = meshOf(new THREE.CylinderGeometry(0.5, 0.5, 2.2, 16), goldMat(), watchRoot);
+  pinion.rotation.x = Math.PI / 2; pinion.position.y = 5.85;
+  const cap = meshOf(new THREE.CylinderGeometry(0.34, 0.34, 0.7, 14), steelMat(), watchRoot);
+  cap.rotation.x = Math.PI / 2; cap.position.y = 6.5;
+  watchRoot.add(hour); watchRoot.add(minute); watchRoot.add(second);
+  return { hour, minute, second };
+}
+
+/* ---------- 表壳：表圈 + 表耳 + 表背 ---------- */
+function buildCase(){
+  const g = new THREE.Group();
+  const cm = new THREE.MeshStandardMaterial({ color:0xe4e9ef, metalness:1, roughness:0.12, envMapIntensity:1.5 });
+  /* 表圈 */
+  const bezel = meshOf(extrude(annulusShape(18.6, 16.6), 1.5, true, 0.22), cm, g);
+  bezel.rotation.x = Math.PI / 2; bezel.position.y = 4.6;
+  bezel.castShadow = true;
+  const bezelRim = meshOf(new THREE.TorusGeometry(18.6, 0.55, 16, 72), cm, g);
+  bezelRim.rotation.x = Math.PI / 2; bezelRim.position.y = 5.4;
+  /* 表耳（上下各 2 个） */
+  for (let i = 0; i < 2; i++){
+    const a = i === 0 ? 1 : -1;
+    const lug = meshOf(new THREE.BoxGeometry(4.6, 2.6, 7.6), cm, g);
+    lug.position.set(0, 3.4, a * 20.4);
+    lug.rotation.x = a * 0.2;
+    const lug2 = meshOf(new THREE.BoxGeometry(4.6, 2.6, 7.6), cm, g);
+    lug2.position.set(0, 3.4, a * 20.4);
+    lug2.rotation.x = -a * 0.2;
+    const drill = meshOf(new THREE.CylinderGeometry(0.62, 0.62, 5, 12), cm, g);
+    drill.rotation.y = Math.PI / 2;
+    drill.position.set(0, 3.4, a * 17.9);
+    g.add(drill);
+    g.add(lug);
+    g.add(lug2);
+  }
+  /* 表背（展览窗） */
+  const back = meshOf(extrude(annulusShape(17.6, 11.6), 1.0, true, 0.14), cm, g);
+  back.rotation.x = Math.PI / 2; back.position.y = -4.2;
+  for (let i = 0; i < 6; i++){
+    const a = i / 6 * TAU + 0.35;
+    const sc = makeScrew(goldMat(), 0.66);
+    sc.rotation.x = -Math.PI / 2; sc.rotation.y = a;
+    sc.position.set(Math.cos(a) * 14.9, -3.85, Math.sin(a) * 14.9);
+    g.add(sc);
+  }
+  watchRoot.add(g);
+  return g;
+}
+
+function buildCrown(){
+  const g = new THREE.Group();
+  const cm = new THREE.MeshStandardMaterial({ color:0xe4e9ef, metalness:1, roughness:0.12, envMapIntensity:1.5 });
+  const stem = meshOf(new THREE.CylinderGeometry(0.75, 0.75, 5.2, 16), cm, g);
+  stem.rotation.y = Math.PI / 2; stem.position.set(17.2, 4.9, 0);
+  const body = meshOf(new THREE.CylinderGeometry(1.55, 1.55, 2.6, 20), cm, g);
+  body.rotation.y = Math.PI / 2; body.position.set(20.6, 4.9, 0);
+  for (let i = 0; i < 10; i++){
+    const a = i / 10 * TAU;
+    const knurl = meshOf(new THREE.BoxGeometry(1.3, 0.55, 0.2), cm, g);
+    knurl.position.set(20.6, 4.9 + Math.cos(a) * 1.62, Math.sin(a) * 1.62);
+    knurl.rotation.x = a;
+  }
+  const cap = meshOf(new THREE.CylinderGeometry(1.32, 1.32, 0.5, 18), cm, g);
+  cap.rotation.y = Math.PI / 2; cap.position.set(22.15, 4.9, 0);
+  const crownWheel = makeWheel({
+    teeth: 12, pitchR: 1.55, toothH: 0.62, toothW: 0.5,
+    ringO: 1.55, ringI: 0.6, hub: 0.5, thick: 0.4,
+    mat: cm, spokes: 0
+  });
+  crownWheel.position.set(19.4, 4.9, 0);
+  g.add(crownWheel);
+  watchRoot.add(g);
+  return g;
+}
+
+function buildCrystal(){
+  const g = new THREE.Group();
+  const dome = meshOf(new THREE.SphereGeometry(18.6, 64, 28, 0, TAU, 0, 0.26), glassMat(), g);
+  dome.position.y = 5.6;
+  watchRoot.add(g);
+  return g;
+}
+/* ============ 装配 + 零件注册 ============ */
+function desc(name, text, label){
+  return { name: name, desc: text, label: label };
+}
+function mkPart(id, group, explode, labelPos, meta){
+  const p = Object.assign({ id: id, group: group, explode: explode, labelPos: labelPos, motionRy: 0 }, meta);
+  p.basePos = group.position.clone();
+  p.matSet = new Set();
+  group.traverse(n => {
+    if (n.isMesh){
+      n.userData.partId = id;
+      pickMeshes.push(n);
+      const m = n.material;
+      if (Array.isArray(m)) m.forEach(x => p.matSet.add(x)); else p.matSet.add(m);
+    }
+  });
+  register(p);
+  return p;
+}
+const V3 = THREE.Vector3;
+function ed(x, y, z, dist, rotY){
+  return { dir: new V3(x, y, z).normalize(), dist: dist, rotY: rotY || 0 };
+}
+
+let hands = {};
+function buildWatch(){
+  mkPart('base', buildMainplate(), ed(0, -1, 0, 2.6, 0), null, desc(
+    '主夹板',
+    '主夹板是机芯的基座，承载全部轮系与桥板。边缘设有四根立柱与金色螺丝，将夹板层与表壳牢牢固定，同时为镂空结构提供支撑。',
+    null));
+
+  mkPart('barrel', buildBarrel(), ed(-0.3, 0.84, 0.4, 9, 0.4), new V3(0, 1.0, 9.6), desc(
+    '发条盒 · 主发条',
+    '发条盒内盘绕约 8.5 圈主发条，提供约 45 小时动力储存。盒顶的棘轮与发条轴联动，是手动上链的动力入口；发条缓慢释放的能量经齿轮系逐级放大转速。',
+    '发条盒'));
+
+  buildTrain();
+
+  mkPart('center', wheels.center, ed(0, 1, 0, 4.8, 0.6), new V3(0, 0.6, 5.9), desc(
+    '中心轮',
+    '二轮（中心轮）承载分针运转，通过齿轮比将发条盒的缓慢转动逐级加速，传递给三轮与秒轮。',
+    '中心轮'));
+
+  mkPart('third', wheels.third, ed(0.4, 0.8, 0.35, 9.5, 0.5), new V3(0, 0.5, 5.2), desc(
+    '三轮',
+    '三轮是传动系中的中间轮，位于中心轮与秒轮之间，负责动力传递与转速调节。',
+    '三轮'));
+
+  mkPart('fourth', wheels.fourth, ed(-0.4, 0.8, -0.35, 9.5, 0.5), new V3(0, 0.5, 4.6), desc(
+    '秒轮',
+    '四轮（秒轮）以接近每秒一圈的速度旋转并驱动中央秒针，同时通过小齿轮（齿轴）将动力传递给擒纵轮。',
+    '秒轮'));
+
+  mkPart('escape', wheels.escape, ed(0, 1, 0, 5.6, 0.8), new V3(0, 0.5, 5.0), desc(
+    '擒纵轮',
+    '15 齿瑞士杠杆式擒纵轮，轮齿与叉瓦交替啮合，以“滴答”声步进释放动力。每步释放的动能维持摆轮持续振荡，并控制齿轮系的走时速率。',
+    '擒纵轮'));
+
+  mkPart('fork', buildFork(), ed(-0.45, 0.72, 0.4, 12, 0.6), new V3(0.4, 0.5, 4.0), desc(
+    '擒纵叉',
+    '杠杆式擒纵叉通过两枚红宝石叉瓦与擒纵轮啮合，叉头驱动摆轮上的冲击圆盘。它将擒纵轮的能量精准地传递给摆轮，是擒纵系统的重要环节。',
+    '擒纵叉'));
+
+  mkPart('balance', buildBalance(), ed(-0.55, 0.68, 0.48, 13, 1.0), new V3(-4.6, 0.4, 5.6), desc(
+    '摆轮组件',
+    '双辐条摆轮，外缘镶嵌 8 颗微调摆钉，配合无卡度游丝实现精密调速。摆轮以约 2.5 赫兹往复振荡，是机芯的“心脏”，其振荡周期直接决定走时精度。',
+    '摆轮'));
+
+  mkPart('hairspring', buildHairspring(), ed(0, 1, 0, 6.8, 0.3), new V3(0, 0.5, 4.4), desc(
+    '游丝',
+    '阿基米德螺旋形合金游丝，内端固定于内桩、外端由外桩销定位。游丝随摆轮同步伸缩，提供稳定的弹性恢复力矩，与摆轮共同构成振荡系统。',
+    '游丝'));
+
+  mkPart('bridge', buildTrainBridge(), ed(0, 1, 0, 6.4, 0), new V3(6.2, 0.9, 8.6), desc(
+    '传动桥板',
+    '经过大范围镂空开窗的传动桥板，将齿轮系与摆轮精确夹持在正确高度，同时以雕刻般的造型最大限度展示机芯机械结构。',
+    '桥板'));
+
+  mkPart('cock', buildCock(), ed(0, 1, 0, 7.6, 0), new V3(0, 1.1, 5.4), desc(
+    '摆轮夹板',
+    '摆轮夹板承载摆轮轴眼与游丝外桩，末端由两颗金色螺丝固定。它是镂空机芯中最富雕刻感的零件之一，环形托架恰好衬托出摆轮的运转。',
+    '摆轮夹板'));
+
+  mkPart('dial', buildDial(), ed(0, 1, 0, 11, 0.25), new V3(16.0, 1.2, 0), desc(
+    '镂空表盘',
+    '环形镂空表盘仅保留外缘时标环，中央完全开放以呈现机芯运作。时标与刻度涂覆荧光涂层，在暗处散发出幽绿色光芒。',
+    '表盘'));
+
+  hands = buildHands();
+  mkPart('hour', hands.hour, ed(0, 1, 0, 8.6, 0), null, desc(
+    '时针',
+    '蓝钢剑形时针，表面带荧光涂层，镂空设计与整体机芯风格呼应。',
+    null));
+  mkPart('minute', hands.minute, ed(0, 1, 0, 9.2, 0), null, desc(
+    '分针',
+    '蓝钢剑形分针，长度介于时针与秒针之间，边缘经过镜面倒角抛光。',
+    null));
+  mkPart('second', hands.second, ed(0, 1, 0, 9.9, 0), null, desc(
+    '秒针',
+    '纤细的中央秒针以红色尖端标识，尾部带有平衡重锤，确保运转平稳顺畅。',
+    null));
+
+  mkPart('case', buildCase(), ed(0, 1, 0, 15, 0.15), new V3(0, 3.4, 21.8), desc(
+    '表壳',
+    '抛光精钢表圈与表耳采用侧边开式结构，使机芯从任意角度一览无余；表背设有展览窗，从背面亦可欣赏摆轮起舞。',
+    '表壳'));
+
+  mkPart('crown', buildCrown(), ed(1, 0.25, 0, 11, 0), new V3(0, 0, 2.6), desc(
+    '表冠',
+    '滚花表冠用于手动上链与校时，内部通过立轮、棘轮与发条轴联动，旋动时能清晰感受上链阻尼。',
+    '表冠'));
+
+  mkPart('crystal', buildCrystal(), ed(0, 1, 0, 20, 0), new V3(0, 8.6, 0), desc(
+    '蓝宝石水晶',
+    '拱形蓝宝石水晶镜面，硬度仅次于钻石，兼具优异的抗刮性与通透性，让机芯的每一次跳动都清晰可见。',
+    '水晶'));
+}
+
+/* ============ 标签（CSS2D） ============ */
+function buildLabels(){
+  for (const p of PARTS){
+    if (!p.labelPos) continue;
+    const el = document.createElement('div');
+    el.className = 'lbl';
+    el.textContent = p.label || p.name;
+    el.addEventListener('click', ev => {
+      ev.stopPropagation();
+      selectPart(p.id);
+    });
+    const obj = new THREE.CSS2DObject(el);
+    obj.position.copy(p.labelPos);
+    p.group.add(obj);
+    p.labelEl = el;
+  }
+}
+
+/* ============ 选中 / 悬停高亮 ============ */
+let selectedPart = null;
+let hoverPart = null;
+
+function applyGlow(p, hex, intensity){
+  if (!p) return;
+  p.matSet.forEach(m => {
+    if (!m.emissive) return;
+    if (m.emissive.getHex() === 0x000000){
+      m.emissive.setHex(hex);
+      m.emissiveIntensity = intensity;
+    }
+  });
+}
+function refreshGlow(){
+  for (const p of PARTS){
+    if (p === selectedPart) applyGlow(p, 0xd8a34f, 0.95);
+    else if (p === hoverPart) applyGlow(p, 0x8a6b3a, 0.55);
+    else applyGlow(p, 0x000000, 0);
+  }
+  for (const p of PARTS){
+    if (p.labelEl) p.labelEl.classList.toggle('sel', p === selectedPart);
+  }
+  const btns = document.querySelectorAll('.part-btn');
+  PARTS.forEach((p, i) => btns[i] && btns[i].classList.toggle('sel', p === selectedPart));
+}
+
+const detailEl = document.getElementById('detail');
+function selectPart(id){
+  selectedPart = id ? partById[id] : null;
+  refreshGlow();
+  if (selectedPart){
+    detailEl.classList.remove('dim');
+    detailEl.innerHTML =
+      '<p class="d-name">' + selectedPart.name + '</p>' +
+      '<p class="d-desc">' + selectedPart.desc + '</p>';
+  } else {
+    detailEl.classList.add('dim');
+    detailEl.innerHTML =
+      '<p class="d-name">点击任意零件</p>' +
+      '<p class="d-desc">在 3D 视图中点击零件，或从下方列表选择，即可查看该零件的高亮展示与详细说明。</p>';
+  }
+}
+
+/* 零件列表 */
+function buildList(){
+  const wrap = document.getElementById('parts');
+  for (const p of PARTS){
+    const b = document.createElement('button');
+    b.className = 'part-btn';
+    b.innerHTML = '<span class="dot"></span>' + p.name;
+    b.addEventListener('click', () => selectPart(p.id));
+    wrap.appendChild(b);
+  }
+}
+
+/* ============ 拾取 ============ */
+const raycaster = new THREE.Raycaster();
+const pointerNdc = new THREE.Vector2();
+let mouse = { x: -100, y: -100 };
+const tooltip = document.getElementById('tooltip');
+
+function pickPart(ndc){
+  raycaster.setFromCamera(ndc, camera);
+  const hits = raycaster.intersectObjects(pickMeshes, false);
+  if (hits.length && hits[0].object.userData.partId){
+    return partById[hits[0].object.userData.partId];
+  }
+  return null;
+}
+function hoverPick(){
+  const p = pickPart(pointerNdc);
+  if (p !== hoverPart){
+    hoverPart = p;
+    refreshGlow();
+  }
+  if (p){
+    renderer.domElement.style.cursor = 'pointer';
+    tooltip.style.display = 'block';
+    tooltip.innerHTML = '<span style="color:#f0e2b8">' + p.name + '</span><small>' + p.desc.slice(0, 42) + '…</small>';
+    tooltip.style.left = (mouse.x + 16) + 'px';
+    tooltip.style.top = (mouse.y + 18) + 'px';
+  } else {
+    renderer.domElement.style.cursor = 'grab';
+    tooltip.style.display = 'none';
+  }
+}
+renderer.domElement.addEventListener('pointermove', e => {
+  pointerNdc.x = (e.clientX / window.innerWidth) * 2 - 1;
+  pointerNdc.y = -(e.clientY / window.innerHeight) * 2 + 1;
+  mouse.x = e.clientX; mouse.y = e.clientY;
+});
+let downPos = null;
+renderer.domElement.addEventListener('pointerdown', e => { downPos = { x: e.clientX, y: e.clientY }; });
+renderer.domElement.addEventListener('pointerup', e => {
+  if (!downPos) return;
+  const d = Math.hypot(e.clientX - downPos.x, e.clientY - downPos.y);
+  downPos = null;
+  if (d > 6) return;
+  const ndc = new THREE.Vector2((e.clientX / window.innerWidth) * 2 - 1, -(e.clientY / window.innerHeight) * 2 + 1);
+  const p = pickPart(ndc);
+  selectPart(p ? p.id : null);
+});
+/* ============ 爆炸视图 ============ */
+let explodeK = 0, explodeTarget = 0;
+let camDir = INIT_CAM.clone().sub(TARGET).normalize();
+function setExplode(on){
+  explodeTarget = on ? 1 : 0;
+  camDir = camera.position.clone().sub(TARGET).normalize();
+  document.getElementById('btn-explode').classList.toggle('on', on);
+}
+function applyExplode(dt){
+  const s = 1 - Math.exp(-dt * 9);
+  for (const p of PARTS){
+    const e = p.explode;
+    if (!e) continue;
+    const k = explodeK;
+    const tx = p.basePos.x + e.dir.x * e.dist * k;
+    const ty = p.basePos.y + e.dir.y * e.dist * k;
+    const tz = p.basePos.z + e.dir.z * e.dist * k;
+    p.group.position.x += (tx - p.group.position.x) * s;
+    p.group.position.y += (ty - p.group.position.y) * s;
+    p.group.position.z += (tz - p.group.position.z) * s;
+    if (e.rotY){
+      const tr = (p.motionRy || 0) + e.rotY * k;
+      p.group.rotation.y += (tr - p.group.rotation.y) * s;
+    }
+  }
+}
+
+/* ============ 荧光呼吸（发光材质收集） ============ */
+const lumeMats = [];
+function collectLumeMats(){
+  for (const p of PARTS){
+    p.matSet.forEach(m => {
+      if (m.emissive && m.emissive.getHex() !== 0x000000){
+        if (!m.userData.baseEm) m.userData.baseEm = m.emissiveIntensity;
+        lumeMats.push(m);
+      }
+    });
+  }
+}
+
+/* ============ 主循环 ============ */
+let paused = false;
+let autoRotate = true;
+let t = 0;
+let last = performance.now();
+const boot = document.getElementById('boot');
+let booted = false;
+
+function animate(){
+  requestAnimationFrame(animate);
+  const now = performance.now();
+  const dt = Math.min(0.05, (now - last) / 1000);
+  last = now;
+  if (!paused) t += dt;
+
+  /* 爆炸过渡 + 相机拉远 */
+  if (explodeK !== explodeTarget){
+    explodeK += (explodeTarget - explodeK) * Math.min(1, dt * 5);
+    if (Math.abs(explodeK - explodeTarget) < 0.002) explodeK = explodeTarget;
+    camera.position.copy(TARGET).addScaledVector(camDir, 48 + 32 * explodeK);
+  }
+
+  /* 机芯运动 */
+  if (!paused){
+    const bA = 0.62 * Math.sin(t * 10.05);
+    balance.osc.rotation.y = bA;
+
+    const forkP = partById['fork'];
+    forkP.motionRy = forkP.group.userData.baseRy - bA * 0.42;
+
+    const escP = partById['escape'];
+    const beats = Math.floor(t * 3.2);
+    const escTarget = beats * (TAU / 15);
+    escP.group.rotation.y += (escTarget - escP.group.rotation.y) * Math.min(1, dt * 22);
+    escP.motionRy = escP.group.rotation.y;
+
+    wheels.fourth.rotation.y = t * 0.18;   partById['fourth'].motionRy = wheels.fourth.rotation.y;
+    wheels.third.rotation.y  = t * 0.026;  partById['third'].motionRy  = wheels.third.rotation.y;
+    wheels.center.rotation.y = t * 0.005;  partById['center'].motionRy = wheels.center.rotation.y;
+    partById['barrel'].group.userData.ratchet.rotation.y = t * 0.0018;
+
+    hands.second.rotation.y = -Math.PI / 2 + t * TAU / 6;
+    hands.minute.rotation.y = -Math.PI / 2 + t * TAU / 360;
+    hands.hour.rotation.y   = -Math.PI / 2 + t * TAU / 4320;
+
+    const pulse = 1 + 0.28 * Math.sin(t * 1.7);
+    for (const m of lumeMats) m.emissiveIntensity = m.userData.baseEm * pulse;
+
+    if (autoRotate) watchRoot.rotation.y += dt * 0.12;
+  }
+
+  applyExplode(dt);
+  hoverPick();
+
+  controls.update();
+  labelRenderer.render(scene, camera);
+  renderer.render(scene, camera);
+
+  if (!booted){
+    booted = true;
+    boot.style.opacity = 0;
+    setTimeout(() => boot.remove(), 800);
+  }
+}
+
+/* ============ UI 控制 ============ */
+document.getElementById('btn-explode').addEventListener('click', () => setExplode(explodeTarget ? false : true));
+document.getElementById('btn-rotate').addEventListener('click', function(){
+  autoRotate = !autoRotate;
+  this.classList.toggle('on', autoRotate);
+});
+document.getElementById('btn-pause').addEventListener('click', function(){
+  paused = !paused;
+  this.textContent = paused ? '播放' : '暂停';
+  this.classList.toggle('on', paused);
+});
+document.getElementById('btn-reset').addEventListener('click', resetView);
+
+let labelsOn = true;
+document.getElementById('btn-labels').addEventListener('click', function(){
+  labelsOn = !labelsOn;
+  for (const p of PARTS){
+    if (p.labelEl) p.labelEl.style.display = labelsOn ? '' : 'none';
+  }
+  this.classList.toggle('on', labelsOn);
+});
+
+function resetView(){
+  setExplode(false);
+  explodeK = 0;
+  watchRoot.rotation.set(-0.1, 0.42, 0.03);
+  camera.position.copy(INIT_CAM);
+  controls.target.copy(TARGET);
+  controls.update();
+  selectPart(null);
+}
+
+window.addEventListener('keydown', e => {
+  const k = e.key.toLowerCase();
+  if (k === 'e') setExplode(explodeTarget ? false : true);
+  else if (k === 'l') document.getElementById('btn-labels').click();
+  else if (k === 'r') resetView();
+  else if (k === ' ') { e.preventDefault(); document.getElementById('btn-pause').click(); }
+});
+
+window.addEventListener('resize', () => {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  labelRenderer.setSize(window.innerWidth, window.innerHeight);
+});
+
+/* ============ 启动 ============ */
+buildWatch();
+collectLumeMats();
+buildLabels();
+buildList();
+refreshGlow();
+animate();
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 产出说明 / Run info

- 模型 / Model: DeepSeek-V4-Flash-0731
- 厂商 / Vendor: DeepSeek
- 运行环境 / Harness: Claude Code（Claude Code 作为工具/harness）
- 思考配额 / Thinking effort: Max
- 是否一次生成 / One-shot? 是；源码未经人工修改

新增 4 个 run（`models/deepseek-v4-flash-0731-cc.json`）：

| case | 产物 |
|---|---|
| mythos-craft（我的世界克隆）| `outputs/deepseek-v4-flash-0731/claude-code-max/mythos-craft.html`（47KB，柏林噪声无限地形 + 第一人称 + 16 种方块 + 七大神话遗迹）|
| skeleton-watch（镂空机械表）| `outputs/deepseek-v4-flash-0731/claude-code-max/skeleton-watch.html`（49KB，Three.js 18 个机芯零件 + 爆炸视图）|
| pelican-cycling（鹈鹕海边骑行）| `outputs/deepseek-v4-flash-0731/claude-code-max/pelican-cycling.svg`（15KB，SMIL 动画）|
| cs-dust2（CS Dust2 5v5）| `outputs/deepseek-v4-flash-0731/claude-code-max/cs-dust2/`（完整 Vite + React 18 + TS + Three.js 项目，tsc/vite build 通过）|

## 生成凭证截图 / Proof screenshot **(required)**

![proof](https://github.com/wuguohan0816-glitch/nagi-bench/raw/proof-assets/deepseek-v4-flash-0731-cc-proof.png)

截图于本地 Claude Code 会话（deepseek-v4-flash[1M]，Max effort）中截取。

## 自查 / Checklist

- [x] 只改了两类文件：`outputs/<artifactDir>/<case-id>.<ext>` + `models/<model-id>.json`
- [x] **没有**手改 `README.md` / `README.en.md`
- [x] 模型 id 用短横线、以**模型**命名：`deepseek-v4-flash-0731-cc`
- [x] `harness` 与 `effort` 如实填写：Claude Code / Max
- [x] 用 harness **默认形态**生成，未额外加载 skill / 插件 / MCP / 自定义系统提示（产物匿名，无模型身份泄露）
- [x] 每条 run 的 `note` 双语（zh + en，zh 先，无 emoji）
- [x] 同一模型换 Harness 或思考配额是**新建 JSON 条目**（旧版 DeepSeek V4 Flash 的条目 `deepseek-v4-flash-cc.json` / `deepseek-v4-flash-reasonix.json` 未动）
- [x] `contributor` 是 `wuguohan0816-glitch`
- [x] 已贴生成凭证截图（待补）
- [x] 本地 `node scripts/validate-data.ts` 通过：`Data OK: 80 models, 5 cases validated`

