### PR TITLE
feat: add DeepSeek V4 Flash 0731 (OMP, Default) — pelican-cycling showcase

### DIFF
--- a/models/deepseek-v4-flash-0731-omp.json
+++ b/models/deepseek-v4-flash-0731-omp.json
@@ -1,0 +1,18 @@
+{
+  "label": "DeepSeek V4 Flash 0731",
+  "vendor": "DeepSeek",
+  "harness": "OMP",
+  "effort": "Default",
+  "artifactDir": "deepseek-v4-flash-0731/omp-default",
+  "order": 50,
+  "runs": {
+    "pelican-cycling": {
+      "note": {
+        "zh": "在 OMP 中以 DeepSeek V4 Flash 0731（Default）使用仓库标准中文提示词，在单次连续会话中一次生成，产物未修改。生成环境为 OMP 默认配置（含内置技能库与 MCP 工具），非裸 Harness，因此不是可与裸 Harness 结果比较的正式测评；本产物仅作展示，永久排除出 Arena 盲评、投票、排行榜与达标场次计算。产物为手绘矢量海边场景：骑自行车的鹈鹕、可旋转车轮、扇翅、循环海浪、帆船与云朵，全部以 SMIL 实现动画，车筐里还放着一条刚捕到的鱼。",
+        "en": "Generated in one continuous session from the repository's canonical Chinese prompt by DeepSeek V4 Flash 0731 (Default) in OMP; the artifact is unmodified. The generation ran in OMP's default configuration (with its built-in skill library and MCP tools), not a bare harness, so it is not a formal benchmark result comparable with bare-harness runs. This artifact is showcase-only and permanently excluded from Arena, voting, rankings, and qualification counts. Hand-drawn vector seaside scene: a pelican riding a bicycle with spinning wheels, wing-flap, looping waves, a sailboat and clouds, all animated with SMIL, and a freshly caught fish in the handlebar basket."
+      },
+      "contributor": "joyful00",
+      "evaluation": "showcase"
+    }
+  }
+}

--- a/outputs/deepseek-v4-flash-0731/omp-default/pelican-cycling.svg
+++ b/outputs/deepseek-v4-flash-0731/omp-default/pelican-cycling.svg
@@ -1,0 +1,274 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 640" width="960" height="640">
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#5cb3f2"/>
+      <stop offset="0.55" stop-color="#a9dcf8"/>
+      <stop offset="1" stop-color="#e8f7fe"/>
+    </linearGradient>
+    <linearGradient id="sea" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#2e92c6"/>
+      <stop offset="0.5" stop-color="#55b6dd"/>
+      <stop offset="1" stop-color="#8fd6ee"/>
+    </linearGradient>
+    <linearGradient id="sand" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#d9b57c"/>
+      <stop offset="0.35" stop-color="#efd7a3"/>
+      <stop offset="1" stop-color="#f6e2b4"/>
+    </linearGradient>
+    <radialGradient id="sunGlow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#fff6cf" stop-opacity="0.9"/>
+      <stop offset="1" stop-color="#fff6cf" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="body" cx="0.42" cy="0.38" r="0.75">
+      <stop offset="0" stop-color="#fbf7ee"/>
+      <stop offset="0.65" stop-color="#f2ead8"/>
+      <stop offset="1" stop-color="#e6dcc4"/>
+    </radialGradient>
+    <linearGradient id="beak" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#f7ae4a"/>
+      <stop offset="1" stop-color="#e28c2a"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="0" y="0" width="960" height="420" fill="url(#sky)"/>
+
+  <circle cx="810" cy="130" r="95" fill="url(#sunGlow)"/>
+  <g opacity="0.9">
+    <animateTransform attributeName="transform" type="rotate" from="0 810 130" to="360 810 130" dur="90s" repeatCount="indefinite"/>
+    <g stroke="#ffe9a8" stroke-width="9" stroke-linecap="round">
+      <line x1="810" y1="74" x2="810" y2="46"/>
+      <line x1="849.6" y1="90.4" x2="869.4" y2="70.6"/>
+      <line x1="866" y1="130" x2="894" y2="130"/>
+      <line x1="849.6" y1="169.6" x2="869.4" y2="189.4"/>
+      <line x1="810" y1="186" x2="810" y2="214"/>
+      <line x1="770.4" y1="169.6" x2="750.6" y2="189.4"/>
+      <line x1="754" y1="130" x2="726" y2="130"/>
+      <line x1="770.4" y1="90.4" x2="750.6" y2="70.6"/>
+    </g>
+  </g>
+  <circle cx="810" cy="130" r="46" fill="#ffd166"/>
+  <circle cx="810" cy="130" r="40" fill="#ffde8a" opacity="0.5"/>
+
+  <g fill="#ffffff" opacity="0.95">
+    <g>
+      <animateTransform attributeName="transform" type="translate" values="0 0; 46 0; 0 0" dur="16s" repeatCount="indefinite" begin="-6s"/>
+      <circle cx="128" cy="112" r="22"/>
+      <circle cx="152" cy="98" r="28"/>
+      <circle cx="180" cy="108" r="24"/>
+      <circle cx="158" cy="120" r="20"/>
+      <ellipse cx="155" cy="124" rx="52" ry="14"/>
+    </g>
+    <g>
+      <animateTransform attributeName="transform" type="translate" values="0 0; 38 0; 0 0" dur="19s" repeatCount="indefinite" begin="-12s"/>
+      <circle cx="414" cy="80" r="16"/>
+      <circle cx="432" cy="68" r="20"/>
+      <circle cx="454" cy="78" r="17"/>
+      <circle cx="436" cy="86" r="14"/>
+      <ellipse cx="434" cy="88" rx="36" ry="10"/>
+    </g>
+    <g>
+      <animateTransform attributeName="transform" type="translate" values="0 0; 42 0; 0 0" dur="14s" repeatCount="indefinite" begin="-2s"/>
+      <circle cx="682" cy="164" r="18"/>
+      <circle cx="702" cy="152" r="23"/>
+      <circle cx="726" cy="160" r="19"/>
+      <circle cx="706" cy="172" r="16"/>
+      <ellipse cx="704" cy="176" rx="44" ry="11"/>
+    </g>
+  </g>
+
+  <rect x="0" y="420" width="960" height="125" fill="url(#sea)"/>
+
+  <g>
+    <animateTransform attributeName="transform" type="translate" values="0 0; 0 -5; 0 0" dur="3.2s" repeatCount="indefinite"/>
+    <path d="M184 464 L250 464 L242 478 L192 478 Z" fill="#f7efe0" stroke="#b3a386" stroke-width="2" stroke-linejoin="round"/>
+    <line x1="188" y1="466" x2="246" y2="466" stroke="#b3a386" stroke-width="1.5"/>
+    <line x1="215" y1="464" x2="215" y2="398" stroke="#8a6f4d" stroke-width="3"/>
+    <path d="M217 402 L254 458 L217 458 Z" fill="#ffffff" stroke="#d8d8d8" stroke-width="1.5" stroke-linejoin="round"/>
+    <path d="M213 410 L180 458 L213 458 Z" fill="#f2f6f8" stroke="#d8d8d8" stroke-width="1.5" stroke-linejoin="round"/>
+    <path d="M215 398 L230 404 L215 410 Z" fill="#e8563f"/>
+  </g>
+
+  <g stroke="#ffffff" opacity="0.35" stroke-linecap="round">
+    <line x1="300" y1="450" x2="330" y2="450" stroke-width="3"/>
+    <line x1="520" y1="442" x2="542" y2="442" stroke-width="2.5"/>
+    <line x1="640" y1="470" x2="666" y2="470" stroke-width="3"/>
+    <line x1="180" y1="480" x2="198" y2="480" stroke-width="2.5"/>
+    <line x1="760" y1="455" x2="784" y2="455" stroke-width="2.5"/>
+  </g>
+
+  <g fill="none" stroke-linecap="round">
+    <g>
+      <animateTransform attributeName="transform" type="translate" values="0 0; 22 0; 0 0" dur="5s" repeatCount="indefinite"/>
+      <path d="M0 462 q30 -10 60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0" stroke="#bfe7f8" stroke-width="5"/>
+    </g>
+    <g>
+      <animateTransform attributeName="transform" type="translate" values="0 0; 26 0; 0 0" dur="4.4s" repeatCount="indefinite"/>
+      <path d="M0 492 q30 -9 60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0" stroke="#d9f2fc" stroke-width="4"/>
+    </g>
+    <g>
+      <animateTransform attributeName="transform" type="translate" values="0 0; 30 0; 0 0" dur="3.8s" repeatCount="indefinite"/>
+      <path d="M0 522 q30 -8 60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t60 0" stroke="#f2fbff" stroke-width="4"/>
+    </g>
+  </g>
+
+  <path d="M0 534 q18 -10 36 0 t36 0 t36 0 t36 0 t36 0 t36 0 t36 0 t36 0 t36 0 t36 0 t36 0 t36 0 t36 0 t36 0 t36 0 t36 0 t36 0 t36 0 t36 0 t36 0 t36 0 t36 0 t36 0 t36 0" fill="none" stroke="#ffffff" stroke-width="6" stroke-linecap="round" opacity="0.85"/>
+  <g fill="#ffffff" opacity="0.5">
+    <ellipse cx="120" cy="540" rx="14" ry="5"/>
+    <ellipse cx="420" cy="538" rx="10" ry="4"/>
+    <ellipse cx="680" cy="542" rx="16" ry="6"/>
+    <ellipse cx="820" cy="536" rx="9" ry="3"/>
+  </g>
+
+  <rect x="0" y="530" width="960" height="110" fill="url(#sand)"/>
+  <path d="M0 572 Q 200 556 420 568 T 960 564" fill="none" stroke="#e2c48e" stroke-width="3" opacity="0.7"/>
+  <path d="M0 600 Q 240 586 480 596 T 960 592" fill="none" stroke="#e6ca97" stroke-width="2.5" opacity="0.6"/>
+  <g fill="#d9b47e">
+    <circle cx="120" cy="575" r="2.5"/>
+    <circle cx="240" cy="590" r="2"/>
+    <circle cx="400" cy="612" r="3"/>
+    <circle cx="520" cy="570" r="2"/>
+    <circle cx="640" cy="605" r="2.5"/>
+    <circle cx="760" cy="585" r="2"/>
+    <circle cx="860" cy="615" r="2.5"/>
+    <circle cx="300" cy="610" r="1.8"/>
+  </g>
+  <path d="M165 590 L168.5 597 L176 597.5 L170.5 602 L172.5 610 L165 605.5 L157.5 610 L159.5 602 L154 597.5 L161.5 597 Z" fill="#f08a5d" stroke="#d9704a" stroke-width="1.5" stroke-linejoin="round"/>
+  <circle cx="165" cy="600" r="1.2" fill="#d9704a"/>
+  <ellipse cx="282" cy="616" rx="7" ry="5" fill="#eed6a8" stroke="#d4b07e" stroke-width="1.5" transform="rotate(-15 282 616)"/>
+  <path d="M278 613 L286 619" stroke="#d4b07e" stroke-width="1.2"/>
+  <ellipse cx="702" cy="588" rx="6" ry="4.5" fill="#e8cfa0" stroke="#cfa96f" stroke-width="1.5" transform="rotate(12 702 588)"/>
+
+  <ellipse cx="478" cy="546" rx="150" ry="12" fill="#000000" opacity="0.13"/>
+
+  <g>
+    <animateTransform attributeName="transform" type="rotate" from="0 392 483" to="360 392 483" dur="1.5s" repeatCount="indefinite"/>
+    <circle cx="392" cy="483" r="62" fill="#2a2a30"/>
+    <circle cx="392" cy="483" r="55" fill="none" stroke="#d9dee4" stroke-width="3"/>
+    <g stroke="#c3cad2" stroke-width="2">
+      <line x1="392" y1="429" x2="392" y2="537"/>
+      <line x1="338" y1="483" x2="446" y2="483"/>
+      <line x1="354" y1="445" x2="430" y2="521"/>
+      <line x1="354" y1="521" x2="430" y2="445"/>
+    </g>
+  </g>
+  <circle cx="392" cy="483" r="5" fill="#8b929b"/>
+  <path d="M330 483 A62 62 0 0 1 454 483" fill="none" stroke="#e7e2d2" stroke-width="12"/>
+  <path d="M330 483 A62 62 0 0 1 454 483" fill="none" stroke="#f8f4ea" stroke-width="9"/>
+
+  <g>
+    <animateTransform attributeName="transform" type="rotate" from="0 566 483" to="360 566 483" dur="1.5s" repeatCount="indefinite"/>
+    <circle cx="566" cy="483" r="62" fill="#2a2a30"/>
+    <circle cx="566" cy="483" r="55" fill="none" stroke="#d9dee4" stroke-width="3"/>
+    <g stroke="#c3cad2" stroke-width="2">
+      <line x1="566" y1="429" x2="566" y2="537"/>
+      <line x1="512" y1="483" x2="620" y2="483"/>
+      <line x1="528" y1="445" x2="604" y2="521"/>
+      <line x1="528" y1="521" x2="604" y2="445"/>
+    </g>
+  </g>
+  <circle cx="566" cy="483" r="5" fill="#8b929b"/>
+  <path d="M504 483 A62 62 0 0 1 638 483" fill="none" stroke="#e7e2d2" stroke-width="12"/>
+  <path d="M504 483 A62 62 0 0 1 638 483" fill="none" stroke="#f8f4ea" stroke-width="9"/>
+
+  <g stroke="#177e89" stroke-linecap="round" fill="none">
+    <line x1="455" y1="464" x2="392" y2="483" stroke-width="7"/>
+    <line x1="392" y1="483" x2="424" y2="338" stroke-width="6"/>
+    <line x1="455" y1="464" x2="424" y2="338" stroke-width="8"/>
+    <line x1="455" y1="464" x2="597" y2="350" stroke-width="8"/>
+    <line x1="424" y1="338" x2="603" y2="322" stroke-width="7"/>
+    <line x1="597" y1="350" x2="603" y2="322" stroke-width="9"/>
+    <path d="M597 350 Q583 410 566 483" stroke-width="7"/>
+    <line x1="424" y1="338" x2="418" y2="318" stroke-width="6"/>
+    <line x1="603" y1="322" x2="608" y2="300" stroke-width="7"/>
+  </g>
+  <circle cx="392" cy="483" r="7" fill="#177e89"/>
+  <circle cx="566" cy="483" r="7" fill="#177e89"/>
+
+  <g stroke="#5b6572" stroke-width="4" fill="none">
+    <line x1="455" y1="448" x2="392" y2="476"/>
+    <line x1="455" y1="480" x2="392" y2="490"/>
+  </g>
+  <circle cx="392" cy="483" r="9" fill="#6b7683"/>
+  <circle cx="455" cy="464" r="17" fill="#6b7683"/>
+  <circle cx="455" cy="464" r="19" fill="none" stroke="#8b95a1" stroke-width="2" stroke-dasharray="3 3"/>
+
+  <path d="M396 320 Q416 308 442 315 L438 324 Q416 328 400 325 Z" fill="#7a4f2a"/>
+  <path d="M396 320 Q416 308 442 315" fill="none" stroke="#8f5f36" stroke-width="2"/>
+
+  <path d="M608 300 Q636 290 641 271" fill="none" stroke="#3a4048" stroke-width="7" stroke-linecap="round"/>
+  <rect x="632" y="261" width="20" height="9" rx="4.5" fill="#26262c" transform="rotate(-20 642 265.5)"/>
+
+  <path d="M600 314 L646 308 L650 348 L596 352 Z" fill="#d9a05b" stroke="#b07c3c" stroke-width="3" stroke-linejoin="round"/>
+  <g stroke="#c08d4c" stroke-width="2">
+    <line x1="600" y1="322" x2="648" y2="318"/>
+    <line x1="599" y1="332" x2="649" y2="329"/>
+    <line x1="597" y1="342" x2="649" y2="340"/>
+    <line x1="618" y1="310" x2="614" y2="350" stroke="#b07c3c"/>
+    <line x1="636" y1="309" x2="640" y2="350" stroke="#b07c3c"/>
+  </g>
+
+  <g transform="translate(616 296)">
+    <g>
+      <animateTransform attributeName="transform" type="rotate" values="0; 12; 0; -10; 0" dur="2.4s" repeatCount="indefinite"/>
+      <path d="M0 0 L-10 -7 L-8 7 Z" fill="#c3d3de"/>
+    </g>
+  </g>
+  <ellipse cx="632" cy="296" rx="17" ry="7.5" fill="#dbe6ef" stroke="#a7bccb" stroke-width="1.5"/>
+  <circle cx="642" cy="294" r="1.6" fill="#26262c"/>
+  <path d="M634 291 Q632 296 634 301" stroke="#a7bccb" stroke-width="1.2" fill="none"/>
+  <path d="M626 289 L626 303" stroke="#b9cbd8" stroke-width="1.5"/>
+  <path d="M628 288 Q634 283 640 289 Z" fill="#c3d3de"/>
+
+  <g stroke="#f0935f" stroke-width="9" stroke-linecap="round" fill="none">
+    <path d="M428 322 L414 372 L423 398"/>
+    <path d="M452 318 L478 382 L484 512"/>
+  </g>
+  <path d="M419 404 Q436 400 444 408 Q434 416 419 413 Z" fill="#f0935f"/>
+  <path d="M471 516 Q488 512 496 520 Q486 528 471 525 Z" fill="#f0935f"/>
+
+  <g stroke-linecap="round" fill="none">
+    <path d="M404 308 Q376 290 360 276" stroke="#c6cfd8" stroke-width="8"/>
+    <path d="M402 314 Q372 302 356 296" stroke="#d3dae1" stroke-width="7"/>
+    <path d="M400 320 Q374 318 358 316" stroke="#dfe4ea" stroke-width="6"/>
+  </g>
+
+  <ellipse cx="448" cy="296" rx="58" ry="40" fill="url(#body)" transform="rotate(-6 448 296)"/>
+  <ellipse cx="450" cy="310" rx="46" ry="24" fill="#ece2cc" opacity="0.65" transform="rotate(-6 448 296)"/>
+
+  <g transform="translate(452 268)">
+    <g>
+      <animateTransform attributeName="transform" type="rotate" values="0; 12; -14; 0" dur="1.5s" repeatCount="indefinite"/>
+      <path d="M0 0 C -26 -22 -62 -34 -100 -24 C -88 -14 -84 -2 -88 10 C -64 2 -38 6 -22 18 C -12 14 -4 8 0 0 Z" fill="#a9b2bf"/>
+      <path d="M-22 14 C -46 6 -70 10 -88 24 C -68 28 -44 30 -28 26 Z" fill="#b8c1cc"/>
+      <g stroke="#6e7a8a" stroke-width="4" stroke-linecap="round">
+        <path d="M-20 8 L-34 16"/>
+        <path d="M-40 4 L-54 18"/>
+        <path d="M-58 0 L-72 18"/>
+        <path d="M-74 -4 L-86 12"/>
+      </g>
+      <path d="M-88 10 C -86 18 -80 22 -72 24" stroke="#f4efe2" stroke-width="3" fill="none" stroke-linecap="round"/>
+    </g>
+  </g>
+
+  <path d="M496 258 C 528 236 548 214 572 206" fill="none" stroke="#e6dcc6" stroke-width="28" stroke-linecap="round"/>
+  <path d="M496 258 C 528 236 548 214 572 206" fill="none" stroke="#f6f1e6" stroke-width="24" stroke-linecap="round"/>
+
+  <circle cx="570" cy="206" r="17" fill="#f6f1e6"/>
+  <path d="M562 190 Q566 184 574 186" stroke="#d9cda8" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+
+  <circle cx="560" cy="200" r="5.5" fill="#ffffff"/>
+  <circle cx="560.5" cy="200.5" r="3.2" fill="#26262c"/>
+  <circle cx="561.8" cy="199.2" r="1.1" fill="#ffffff"/>
+
+  <path d="M578 203 Q 618 195 660 197 Q 666 197 668 199 Q 662 207 640 209 Q 608 211 578 211 Z" fill="url(#beak)"/>
+  <path d="M660 197 Q668 197 671 202 Q666 207 660 207 Z" fill="#d97a26"/>
+  <path d="M578 211 Q 594 246 628 230 Q 646 222 644 212 Q 616 226 578 211 Z" fill="#ef9540"/>
+  <path d="M582 216 Q 602 236 630 224" stroke="#ffcf96" stroke-width="3" fill="none" opacity="0.8" stroke-linecap="round"/>
+  <path d="M592 222 Q 606 232 620 224" stroke="#d97f30" stroke-width="1.6" fill="none" opacity="0.7"/>
+  <path d="M598 200 L606 200" stroke="#d97a26" stroke-width="1.6" stroke-linecap="round"/>
+
+  <g stroke="#ffffff" stroke-width="3" fill="none" stroke-linecap="round">
+    <path d="M148 182 q9 -9 18 0 q9 -9 18 0"/>
+    <path d="M298 140 q7 -7 14 0 q7 -7 14 0" stroke-width="2.5"/>
+  </g>
+</svg>


### PR DESCRIPTION
<!-- 感谢贡献！只需两类文件：outputs/<artifactDir>/<case-id>.<ext> + models/<model-id>.json -->

## 产出说明 / Run info

- 模型 / Model: DeepSeek V4 Flash 0731
- 厂商 / Vendor: DeepSeek
- 运行环境 / Harness: OMP（这是工具不是模型，默认配置）
- 思考配额 / Thinking effort: Default
- 是否一次生成 / One-shot: 是 / Yes（单次连续会话一次生成，产物未修改）

## 披露 / Disclosure

OMP 默认环境带内置技能库与 MCP 工具，非裸 Harness。按 AGENTS.md 规则（先例：qwen36-27b-omp），本条 run 已标记 `"evaluation": "showcase"` 并在双语 note 中如实披露：永久排除出 Arena 盲评、投票、排行榜与达标场次计算。

## 生成凭证截图 / Proof screenshot **(required)**

![生成凭证截图](https://gist.githubusercontent.com/joyful00/bf05af836c74910b4442c582ba307675/raw/ScreenShot_2026-08-07_140717_946.png)

## 自查 / Checklist

- [x] 只改了两类文件：`outputs/<artifactDir>/<case-id>.<ext>` + `models/<model-id>.json`
- [x] **没有**手改 `README.md` / `README.en.md`
- [x] 模型 id 用短横线、以**模型**命名：`deepseek-v4-flash-0731-omp`
- [x] `harness`（OMP）与 `effort`（Default）如实填写
- [x] 模型与 effort 由我选定并如实填写；本条目为 OMP 默认配置运行，已按规则标记 showcase 并披露
- [x] 每条 run 的 `note` 双语（zh + en，zh 先，无 emoji）
- [x] 同一模型换 Harness/思考配额新建 JSON 条目
- [x] `contributor` 为我的 GitHub 用户名（joyful00）
- [x] 本地 `bun scripts/validate-data.ts` 通过（Data OK: 81 models）
